### PR TITLE
fix: ensure reverse does not activate in flight

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -105,6 +105,7 @@
 1. [AP/FMGC] Improved managed speed and V2 validity - @aguther (Andreas Guther)
 1. [FCU] Init FCU with SPD 100 kn, HDG = 0° and ALT 100 ft - @aguther (Andreas Guther)
 1. [FBW] Inhibit alpha floor and protection law for 10 s after flight start / plane reload - @aguther (Andreas Guther)
+1. [ATHR/FADEC] Fixed potential engagement of reverse thrust in flight - @aguther (Andreas Guther)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -1068,10 +1068,10 @@ bool FlyByWireInterface::updateAutothrust(double sampleTime) {
   SimData simData = simConnectInterface.getSimData();
 
   // set ground / flight for throttle handling
-  if (simData.gear_animation_pos_1 > 0.55 || simData.gear_animation_pos_1 > 0.55) {
+  if (flyByWireOutput.sim.data_computed.on_ground) {
     throttleAxis[0]->setOnGround();
     throttleAxis[1]->setOnGround();
-  } else if (simData.gear_animation_pos_1 <= 0.5 && simData.gear_animation_pos_1 <= 0.5) {
+  } else {
     throttleAxis[0]->setInFlight();
     throttleAxis[1]->setInFlight();
   }

--- a/src/fbw/src/ThrottleAxisMapping.cpp
+++ b/src/fbw/src/ThrottleAxisMapping.cpp
@@ -48,11 +48,17 @@ ThrottleAxisMapping::ThrottleAxisMapping(unsigned int id) {
 }
 
 void ThrottleAxisMapping::setInFlight() {
-  inFlight = true;
+  if (!inFlight) {
+    inFlight = true;
+    setCurrentValue(currentValue);
+  }
 }
 
 void ThrottleAxisMapping::setOnGround() {
-  inFlight = false;
+  if (inFlight) {
+    inFlight = false;
+    setCurrentValue(currentValue);
+  }
 }
 
 double ThrottleAxisMapping::getValue() {


### PR DESCRIPTION
Fixes #5050

## Summary of Changes
This PR fixes a potential engagement of reverse thrust in flight. This was mainly happening when mouse was used to drag the 3D thrust levers. This was also possible when landed, reverse idle engaged and then leaving ground again. All of this is fixed by this PR.

Some additional info:
In the real plane there is nothing that stops you to put the physical thrust levers into reverse position. This is only partially reflected. The thrust levers can be put into reverse using the mouse, but not using an assigned throttle axis or keyboard events.

## Testing instructions

### In Flight
- test if reverse can be engaged using dragging of the thrust levers : should move into reverse area but thrust is kept on idle
- test if reverse can be engaged using keyboard : should **not** move into reverse area
- test if reverse can be engaged using throttle axis / reverse toggle : should **not** move into reverse area

### On Ground / Landing
- test if reverse can be engaged using dragging of the thrust levers 
- test if reverse can be engaged using keyboard
- test if reverse can be engaged using throttle axis / reverse toggle

### On Ground -> Lift-Off
- land
- engage reverse idle
- lift-off again -> reverse must disengage and thrust goes to IDLE

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
