### PR TITLE
fix(fmgc): FMGC flight phase transition with no V2 entered on airport near sea-level

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -33,6 +33,7 @@
 1. [AP] Improved SPD/MACH law model - @IbrahimK42 (IbrahimK42)
 1. [AP/FBW] Improved behavior in cruise when using high sim rate with roll performance - @aguther (Andreas Guther) and @IbrahimK42 (IbrahimK42)
 1. [LIGHTS] Add TO/TAXI LT logic, ambience to TAXI/TO/LDG LT + min. changes to strobe/beacon/nav - @bouveng (Johan Bouveng)
+1. [FMGC] Fixed issue with TO flight phase transition when no V2 is entered and airport is near sea level - @aguther (Andreas Guther)
 
 ## 0.7.0
 1. [HYD] First building block, more to come. Hydraulics do not impact the sim YET. - @crocket6 (crocket)

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/FMGC/A32NX_FlightPhaseManager.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/FMGC/A32NX_FlightPhaseManager.js
@@ -2,8 +2,7 @@
  * The following functions are used to determine whether a flight phase can be changed or not
  */
 function canInitiateTO(_fmc) {
-    const ra = Simplane.getAltitudeAboveGround();
-    return Math.round(ra / 100) !== Math.round(Simplane.getAltitude() / 100) && ra > 1.5 ||
+    return SimVar.GetSimVarValue("CAMERA STATE", "number") < 10 && Simplane.getAltitudeAboveGround() > 1.5 ||
     (
         Math.max(SimVar.GetSimVarValue("L:A32NX_AUTOTHRUST_TLA:1", "number"), SimVar.GetSimVarValue("L:A32NX_AUTOTHRUST_TLA:2", "number")) >= 35 &&
         !isNaN(_fmc.v2Speed) &&


### PR DESCRIPTION
Fixes #5587

## Summary of Changes
This PR targets to fix #5587.

## Testing instructions

### Take-Off with FMGC setup
Test several take-off on high altitude and low altitude (< 20 ft) with normal FMGC setup, especially enter a V2 speed.

### Take-Off *without* FMGC setup
Test several take-off on high altitude and low altitude (< 20 ft) without any FMGC setup.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
