### PR TITLE
feat: activate fmgc phase approach with LOC*/LOC engagement

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -40,6 +40,7 @@
 1. [MCDU] Fixed length limitation for system messages - @derl30n (Leon)
 1. [FMGC] Use correct variable to determine lateral AP mode for APPROACH phase switch - @aguther (Andreas Guther)
 1. [ENGINE] Correctly adapt fuel burn with sim rate - @aguther (Andreas Guther)
+1. [FMGC] Activate APPROACH phase when LOC*/LOC engages - @aguther (Andreas Guther)
 
 ## 0.7.0
 1. [HYD] First building block, more to come. Hydraulics do not impact the sim YET. - @crocket6 (crocket)

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/FMGC/A32NX_FlightPhaseManager.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/FMGC/A32NX_FlightPhaseManager.js
@@ -303,7 +303,7 @@ class A32NX_FlightPhase_Descent {
             const long = SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude");
             const planeLla = new LatLongAlt(lat, long);
             const dist = Avionics.Utils.computeGreatCircleDistance(_fmc.flightPlanManager.decelWaypoint.infos.coordinates, planeLla);
-            if (dist < 3) {
+            if (dist <= 1) {
                 _fmc.flightPlanManager._decelReached = true;
                 _fmc._waypointReachedAt = SimVar.GetGlobalVarValue("ZULU TIME", "seconds");
             }
@@ -311,14 +311,11 @@ class A32NX_FlightPhase_Descent {
 
         const autopilotLateralMode = SimVar.GetSimVarValue("L:A32NX_FMA_LATERAL_MODE", "Number");
 
-        return _fmc.flightPlanManager._decelReached &&
-            (
-                Simplane.getAltitudeAboveGround() < 9500 &&
-                (
-                    // NAV || LOC* || LOC
-                    autopilotLateralMode === 20 || autopilotLateralMode === 30 || autopilotLateralMode === 31
-                )
-            );
+        const conditionAltitude = Simplane.getAltitudeAboveGround() < 9500;
+        const conditionDecelOverflownInNav = _fmc.flightPlanManager._decelReached && autopilotLateralMode === 20;
+        const conditionLocalizer = autopilotLateralMode === 30 || autopilotLateralMode === 31;
+
+        return conditionAltitude && (conditionDecelOverflownInNav || conditionLocalizer);
     }
 }
 


### PR DESCRIPTION
## Summary of Changes
Based on A320 type rated pilot feedback, this PR introduces a switch to FMGC approach phase when:
- plane altitude is below 9500 ft, and DECEL waypoint is reached within 1 nm, and NAV is engaged
- plane altitude is below 9500 ft, and LOC* or LOC engages

## Testing instructions
- test both above conditions

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
