### PR TITLE
fix(adirs): correct local gravity vector calc for IR body accelerations

### DIFF
--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -1129,7 +1129,7 @@ impl InertialReference {
         // based on Theta and Phi.
         let g = Acceleration::new::<meter_per_second_squared>(9.81);
         self.body_longitudinal_acc
-            .set_value(context.long_accel() / g - pitch.cos(), ssm);
+            .set_value(context.long_accel() / g - pitch.sin(), ssm);
         self.body_lateral_acc
             .set_value(context.lat_accel() / g + pitch.cos() * roll.sin(), ssm);
         self.body_normal_acc

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -2862,7 +2862,7 @@ mod tests {
                     .normal_value()
                     .unwrap()
                     .get::<percent>(),
-                (acc / g - test_bed.pitch(adiru_number).normal_value().unwrap().cos())
+                (acc / g - test_bed.pitch(adiru_number).normal_value().unwrap().sin())
                     .get::<ratio>()
             );
         }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
As the title says, it changes a `cos` to a `sin` in the IR local gravity calculation, so it correctly works as the euler angle transformation.


The affected value is not (yet) used in master and exp, so should have no effect at the moment

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
https://de.wikipedia.org/wiki/Eulersche_Winkel#Anwendungsbeispiel

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
