### PR TITLE
feat(CDU): return to previous FPlan position

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1137,3 +1137,4 @@
 1. [DCDU] Fixed MSG- and MSG+ button labels - @tyler58546 (tyler58546)
 1. [ISIS] Fixed issue where ISIS was allowing a bug to be set while in the OFF state - Patrick Macken (@Pat M on
    Discord)
+1. [CDU] Return to previous F-Plan page/scroll - @vkrizan (Viliam)

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_ATSU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_ATSU.js
@@ -147,6 +147,8 @@ const insertUplink = (mcdu) => {
             if (mcdu.page.Current === mcdu.page.InitPageA) {
                 CDUInitPage.ShowPage1(mcdu);
             }
+
+            mcdu.fpOffset = 0; // reset F-Plan offset
         }
     }).catch((e) => {
         if (e instanceof McduMessage) {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
@@ -24,7 +24,7 @@ class A320_Neo_CDU_AirwaysFromWaypointPage {
         }
         mcdu.onLeftInput[5] = async () => {
             mcdu.eraseTemporaryFlightPlan(() => {
-                CDUFlightPlanPage.ShowPage(mcdu, 0);
+                CDUFlightPlanPage.ShowPage(mcdu);
             });
         };
         let showInput = false;

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
@@ -18,7 +18,10 @@ class A320_Neo_CDU_AirwaysFromWaypointPage {
                 mcdu.insertTemporaryFlightPlan(() => {
                     mcdu.copyAirwaySelections();
                     mcdu.updateConstraints();
-                    CDUFlightPlanPage.ShowPage(mcdu, 0);
+
+                    const tmpWaypoints = mcdu.flightPlanManager.getWaypointsCount(1);
+                    const activeWaypoints = mcdu.flightPlanManager.getWaypointsCount(0);
+                    CDUFlightPlanPage.ShowPage(mcdu, mcdu.fpOffset + (tmpWaypoints - activeWaypoints));
                 });
             };
         }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
@@ -225,7 +225,7 @@ class CDUAvailableArrivalsPage {
                         mcdu.updateTowerHeadwind();
                         mcdu.updateConstraints();
                         CDUPerformancePage.UpdateThrRedAccFromDestination(mcdu);
-                        CDUFlightPlanPage.ShowPage(mcdu);
+                        CDUFlightPlanPage.ShowPage(mcdu, -5);
                     });
                 };
             } else {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_HoldAtPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_HoldAtPage.js
@@ -172,7 +172,7 @@ class CDUHoldAtPage {
         mcdu.onRightInput[5] = () => {
             if (tmpy) {
                 mcdu.insertTemporaryFlightPlan(() => {
-                    CDUFlightPlanPage.ShowPage(mcdu, waypointIndexFP);
+                    CDUFlightPlanPage.ShowPage(mcdu);
                 });
             }
         };

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -194,6 +194,7 @@ class CDUInitPage {
                         CDUPerformancePage.UpdateThrRedAccFromOrigin(mcdu);
                         CDUPerformancePage.UpdateEngOutAccFromOrigin(mcdu);
                         CDUPerformancePage.UpdateThrRedAccFromDestination(mcdu);
+                        mcdu.fpOffset = 0; // reset F-Plan offset
                         CDUAvailableFlightPlanPage.ShowPage(mcdu);
                     } else {
                         scratchpadCallback();

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_Keypad.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_Keypad.js
@@ -9,7 +9,10 @@ class Keypad {
                 mcdu.eraseTemporaryFlightPlan();
                 CDUDirectToPage.ShowPage(mcdu);
             },
-            "FPLN": () => CDUFlightPlanPage.ShowPage(mcdu),
+            "FPLN": () => {
+                // reset to top if the FPLAN is pressed twice
+                CDUFlightPlanPage.ShowPage(mcdu, mcdu.page.Current === mcdu.page.FlightPlanPage ? 0 : undefined);
+            },
             "FUEL": () => mcdu.goToFuelPredPage(),
             "INIT": () => {
                 if (mcdu.flightPhaseManager.phase === FmgcFlightPhases.DONE) {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -26,6 +26,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this.clrStop = false;
         this.allSelected = false;
         this.updateRequest = false;
+        this.fpOffset = 0;
         this.initB = false;
         this.lastPowerState = 0;
         this.PageTimeout = {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
@@ -354,7 +354,7 @@ class CDUVerticalRevisionPage {
     }
 
     // constraints can be set directly by LSK on f-pln page
-    static setConstraints(mcdu, waypoint, value, scratchpadCallback, offset = 0) {
+    static setConstraints(mcdu, waypoint, value, scratchpadCallback) {
         const matchResult = value.match(/^(([0-9]{1,3})\/?)?(\/([+-])?(((FL)?([0-9]{1,3}))|([0-9]{4,5})))?$/);
         if (matchResult === null) {
             mcdu.setScratchpadMessage(NXSystemMessages.formatError);
@@ -393,14 +393,14 @@ class CDUVerticalRevisionPage {
 
         if (speed !== undefined) {
             mcdu.flightPlanManager.setWaypointSpeed(speed, mcdu.flightPlanManager.indexOfWaypoint(waypoint), () => {
-                CDUFlightPlanPage.ShowPage(mcdu, offset);
+                CDUFlightPlanPage.ShowPage(mcdu);
             }, type === WaypointConstraintType.DES);
         }
 
         if (alt !== undefined) {
             mcdu.flightPlanManager.setLegAltitudeDescription(waypoint, code);
             mcdu.flightPlanManager.setWaypointAltitude(alt, mcdu.flightPlanManager.indexOfWaypoint(waypoint), () => {
-                CDUFlightPlanPage.ShowPage(mcdu, offset);
+                CDUFlightPlanPage.ShowPage(mcdu);
             }, type === WaypointConstraintType.DES);
         }
     }

--- a/src/fmgc/src/flightplanning/FixInfo.ts
+++ b/src/fmgc/src/flightplanning/FixInfo.ts
@@ -35,12 +35,12 @@ export class FixInfo {
         this.flightPlanManager = flightPlanManager;
     }
 
-    setRefFix(fix?: WayPoint): void {
+    async setRefFix(fix?: WayPoint): Promise<void> {
         this.radials.length = 0;
         this.radius = undefined;
         this.abeam = false;
         this.refFix = fix;
-        this.flightPlanManager.updateFlightPlanVersion();
+        await this.flightPlanManager.updateFlightPlanVersion();
     }
 
     getRefFix(): WayPoint | undefined {
@@ -51,7 +51,7 @@ export class FixInfo {
         return this.refFix?.ident;
     }
 
-    setRadial(index: 0 | 1, magneticBearing?: number): void {
+    async setRadial(index: 0 | 1, magneticBearing?: number): Promise<void> {
         if (magneticBearing !== undefined) {
             const trueBearing = Avionics.Utils.clampAngle(magneticBearing + Facilities.getMagVar(this.refFix.infos.coordinates.lat, this.refFix.infos.coordinates.long));
             this.radials[index] = { magneticBearing, trueBearing };
@@ -59,7 +59,7 @@ export class FixInfo {
             this.radials.splice(index, 1);
         }
         // TODO calculate flight plan intercepts
-        this.flightPlanManager.updateFlightPlanVersion();
+        await this.flightPlanManager.updateFlightPlanVersion();
     }
 
     getRadial(index: 0 | 1): FixInfoRadial | undefined {
@@ -70,14 +70,14 @@ export class FixInfo {
         return this.radials.map((r) => r.trueBearing);
     }
 
-    setRadius(radius?: number): void {
+    async setRadius(radius?: number): Promise<void> {
         if (radius !== undefined) {
             this.radius = { radius };
         } else {
             this.radius = undefined;
         }
         // TODO calculate flight plan intercepts
-        this.flightPlanManager.updateFlightPlanVersion();
+        await this.flightPlanManager.updateFlightPlanVersion();
     }
 
     getRadius(): FixInfoRadius | undefined {

--- a/src/fmgc/src/flightplanning/FixInfo.ts
+++ b/src/fmgc/src/flightplanning/FixInfo.ts
@@ -35,12 +35,14 @@ export class FixInfo {
         this.flightPlanManager = flightPlanManager;
     }
 
-    async setRefFix(fix?: WayPoint): Promise<void> {
+    async setRefFix(fix?: WayPoint, updateVersion = true): Promise<void> {
         this.radials.length = 0;
         this.radius = undefined;
         this.abeam = false;
         this.refFix = fix;
-        await this.flightPlanManager.updateFlightPlanVersion();
+        if (updateVersion) {
+            await this.flightPlanManager.updateFlightPlanVersion();
+        }
     }
 
     getRefFix(): WayPoint | undefined {

--- a/src/fmgc/src/flightplanning/FlightPlanManager.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanManager.ts
@@ -381,7 +381,7 @@ export class FlightPlanManager {
         // we allow the last leg to be sequenced therefore the index can be 1 past the end of the plan length
         if (index >= 0 && index <= currentFlightPlan.length) {
             currentFlightPlan.activeWaypointIndex = index;
-            Coherent.call('SET_ACTIVE_WAYPOINT_INDEX', index + 1).catch(console.error);
+            await Coherent.call('SET_ACTIVE_WAYPOINT_INDEX', index + 1).catch(console.error);
 
             if (currentFlightPlan.directTo.isActive && currentFlightPlan.directTo.waypointIsInFlightPlan
                 && currentFlightPlan.activeWaypointIndex > currentFlightPlan.directTo.planWaypointIndex) {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #7422

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

The primary aim of the PR is to F-PLAN offset stateful to be able to return back to same scroll.
Offset changes on these situations:
* New Departure insertion -- resets to top
* New Arrival -- resets to bottom
* Airway insertion -- moves by number of inserted waypoints
* New INIT (incl. AOC) -- resests to top
* Second press of FPLAN button -- resets to top

The PR also refactors FlightPlanManager to await flight plan version updates. This is to ensure that a new offset set on waypoint insertions is correct, as it is computed and limited to actual waypoint numbers.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
https://youtu.be/syr4G3pokgU?t=191
https://youtu.be/_skUOMfv-AQ
https://youtu.be/E8IjkgQjw2M
https://youtu.be/D7HjVlvKd8o
https://youtu.be/dDny7J9Bc1Y
https://youtu.be/tXnbLtRpcqM


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): coolll.sk#0022

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

For FPLAN:
* validate returns from sub pages returning to FPLAN -- scroll should be the same
  * Departure, Arrival ... (with no changes)
  * Vertical and Lateral revision pages
  * Holds
* validate return after insertions from Departure, Arrival, Airways
  * New Departure insertion -- resets to top
  * New Arrival -- resets to bottom
  * Airway insertion -- moves by number of inserted waypoints
* validate second press of FPLAN button -- resets to top
* regression test AIRPORT button 

For the FPM refactoring:
* regression testing with a full flight
* observe INIT from AOC
* observe DIR to behavior
* try waypoint changes during curise

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
