### PR TITLE
fix(sd): line thickness and fuel quantity position adjustments

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -25,6 +25,8 @@
 1. [PFD] Corrected the NO DH logic in the FMS and PFD - @tracernz (Mike)
 1. [FDR] Add secondary engine parameters to FDR - @Taz5150 (TazX [Z+2]#0405)
 1. [FLIGHTMODEL] Fix outer to inner tank transfer valve closure - @donstim (donbikes)
+1. [SD] Corrected thickness and position of lower ECAM fuel page lines - @robertxing2004 (robeet)
+1. [SD] Corrected position of outer tank fuel quantity values - @robertxing2004 (robeet)
 
 ## 0.10.0
 

--- a/fbw-a32nx/src/systems/instruments/src/SD/Pages/Fuel/Fuel.scss
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Pages/Fuel/Fuel.scss
@@ -43,7 +43,7 @@
 
   .EngineLine {
     stroke: $display-grey;
-    stroke-width: 2.5;
+    stroke-width: 3;
   }
 
   .UsedQuantity {
@@ -55,7 +55,7 @@
 
   .ThickShape {
     stroke: $display-grey;
-    stroke-width: 2.5;
+    stroke-width: 4;
     fill: none;
   }
 

--- a/fbw-a32nx/src/systems/instruments/src/SD/Pages/Fuel/Fuel.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Pages/Fuel/Fuel.tsx
@@ -81,7 +81,7 @@ export const FuelPage = () => {
                 <Pump x={180} y={215} onBus="DC_2" pumpNumber={5} />
 
                 {/* Quantities */}
-                <text className="TankQuantity" x={74} y={285}>{fuelInTanksForDisplay(tankLeftOuter, unit, fuelWeightPerGallon)}</text>
+                <text className="TankQuantity" x={80} y={285}>{fuelInTanksForDisplay(tankLeftOuter, unit, fuelWeightPerGallon)}</text>
                 <text className="TankQuantity" x={190} y={285}>{fuelInTanksForDisplay(tankLeftInner, unit, fuelWeightPerGallon)}</text>
 
                 { leftOuterInnerValve ? <Triangle x={77} y={319} colour="Green" fill={0} orientation={90} /> : null }
@@ -146,7 +146,7 @@ export const FuelPage = () => {
 
                 {/* Quantities */}
                 <text className="TankQuantity" x={472} y={285}>{fuelInTanksForDisplay(tankRightInner, unit, fuelWeightPerGallon)}</text>
-                <text className="TankQuantity" x={579} y={285}>{fuelInTanksForDisplay(tankRightOuter, unit, fuelWeightPerGallon)}</text>
+                <text className="TankQuantity" x={580} y={285}>{fuelInTanksForDisplay(tankRightOuter, unit, fuelWeightPerGallon)}</text>
                 {rightOuterInnerValve && <Triangle x={522} y={319} colour="Green" fill={0} orientation={-90} />}
 
                 <text className="UnitTemp" x="510" y="355">°C</text>
@@ -236,7 +236,7 @@ const FOB = ({ unit }:FOBProps) => {
 const Wings = () => (
     <>
         {/* Bottom line */}
-        <path className="ThickShape" d="M 15, 255 l 0, 80 l 570, 0 l 0,-80" strokeLinecap="round" />
+        <path className="ThickShape" d="M 15, 255 l 0, 75 l 570, 0 l 0,-75" strokeLinecap="round" />
 
         {/* Top line */}
         <path className="ThickShape" d="M 585, 255 l -124.2, -21.6" />
@@ -246,10 +246,10 @@ const Wings = () => (
         <path className="ThickShape" d="M 355, 215 l 29.9, 5.2" />
 
         {/* Tank lines */}
-        <path className="ThickShape" d="M 80,  244 L 80,  335" />
-        <path className="ThickShape" d="M 245, 215 L 230, 335" />
-        <path className="ThickShape" d="M 355, 215 L 370, 335" />
-        <path className="ThickShape" d="M 520, 244 L 520, 335" />
+        <path className="ThickShape" d="M 85,  243 L 85,  330" />
+        <path className="ThickShape" d="M 245, 215 L 230, 330" />
+        <path className="ThickShape" d="M 355, 215 L 370, 330" />
+        <path className="ThickShape" d="M 515, 243 L 515, 330" />
     </>
 );
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8106

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR carries some minor cosmetic changes to the fuel page on the lower ECAM. The thickness and position of the tank lines was adjusted to better match reference images of the display onboard the actual aircraft. Also adjusted the position of the text displaying both outer fuel tanks to better match reference images and to prevent clipping with the lines (I tested several different fuel quantities with both kg and lbs and found no clipping).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

| Before| After|
| --- | ----------- |
| ![kg_match_before](https://github.com/flybywiresim/aircraft/assets/73909958/1bf4f587-0393-4e80-aeeb-95118b6a3869)| ![kg_match_after](https://github.com/flybywiresim/aircraft/assets/73909958/b7581568-22c5-41c9-b81a-7de11d3d6b10)|
| ![lb_match_before](https://github.com/flybywiresim/aircraft/assets/73909958/ddc8aed8-cfa9-4100-b063-f8ea20279cdb)| ![lb_match_after](https://github.com/flybywiresim/aircraft/assets/73909958/fc774412-ad75-4ddf-8669-346cc51ba7bc)|

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
reference images from issue #8106 comparing FBW lower ECAM fuel display to IRL display , provided by OP
![image](https://github.com/flybywiresim/aircraft/assets/73909958/9836dab1-871b-4357-ac8d-02dd36620812)

separate image of IRL lower ECAM fuel display, also provided by OP
![image](https://github.com/flybywiresim/aircraft/assets/73909958/89d353e1-98ea-4fbf-8a3a-e8b7688c6b4c)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
robeet

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Navigate to fuel page on lower ECAM
- Observe fuel tank lines and outer tank fuel quantity values
- Adjust fuel levels and units via EFB to ensure that no fuel quantity will cause the text to clip with the tank lines

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
