### PR TITLE
feat(elec-a380): ALTN ESS FEED P/B FAULT illuminates when AC EMER is not powered

### DIFF
--- a/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/alternating_current.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/alternating_current.rs
@@ -210,10 +210,6 @@ impl A380AlternatingCurrentElectrical {
         self.emergency_gen_contactor.is_closed()
     }
 
-    pub fn ac_ess_bus_is_powered(&self, electricity: &Electricity) -> bool {
-        electricity.is_powered(&self.ac_ess_bus)
-    }
-
     pub fn ac_emer_bus_is_powered(&self, electricity: &Electricity) -> bool {
         electricity.is_powered(&self.ac_emer_bus)
     }

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/alternating_current.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/alternating_current.rs
@@ -213,6 +213,10 @@ impl A380AlternatingCurrentElectrical {
     pub fn ac_ess_bus_is_powered(&self, electricity: &Electricity) -> bool {
         electricity.is_powered(&self.ac_ess_bus)
     }
+
+    pub fn ac_emer_bus_is_powered(&self, electricity: &Electricity) -> bool {
+        electricity.is_powered(&self.ac_emer_bus)
+    }
 }
 impl A380AlternatingCurrentElectricalSystem for A380AlternatingCurrentElectrical {
     fn ac_bus_powered(&self, electricity: &Electricity, number: usize) -> bool {

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/mod.rs
@@ -200,10 +200,6 @@ impl A380Electrical {
             .emergency_generator_contactor_is_closed()
     }
 
-    fn ac_ess_bus_is_powered(&self, electricity: &Electricity) -> bool {
-        self.alternating_current.ac_ess_bus_is_powered(electricity)
-    }
-
     fn ac_emer_bus_is_powered(&self, electricity: &Electricity) -> bool {
         self.alternating_current.ac_emer_bus_is_powered(electricity)
     }
@@ -2483,8 +2479,11 @@ mod a380_electrical_circuit_tests {
     }
 
     #[test]
-    fn when_ac_ess_bus_is_unpowered_ac_ess_feed_has_fault() {
-        let mut test_bed = test_bed_with().airspeed(Velocity::default()).run();
+    fn when_ac_emer_bus_is_unpowered_ac_ess_feed_has_fault() {
+        let mut test_bed = test_bed_with()
+            .airspeed(Velocity::default())
+            .all_bats_off()
+            .run();
 
         assert!(test_bed.ac_ess_feed_has_fault());
     }

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/mod.rs
@@ -204,6 +204,10 @@ impl A380Electrical {
         self.alternating_current.ac_ess_bus_is_powered(electricity)
     }
 
+    fn ac_emer_bus_is_powered(&self, electricity: &Electricity) -> bool {
+        self.alternating_current.ac_emer_bus_is_powered(electricity)
+    }
+
     fn galley_is_shed(&self) -> bool {
         self.main_galley.is_shed() || self.secondary_galley.is_shed()
     }
@@ -348,7 +352,7 @@ impl A380ElectricalOverheadPanel {
         electricity: &Electricity,
     ) {
         self.ac_ess_feed
-            .set_fault(!electrical.ac_ess_bus_is_powered(electricity));
+            .set_fault(!electrical.ac_emer_bus_is_powered(electricity));
 
         self.generators
             .iter_mut()


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
As the name says. Changes the fault legend of the AC ESS FAULT light to illuminate when the AC EMER bus is not powered.
The power source for the button is DC ESS, so the light is on when AC EMER is not powered and DC ESS is powered.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
