### PR TITLE
fix: pitch prot indicators visibility

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/PFD/AttitudeIndicatorHorizon.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/AttitudeIndicatorHorizon.tsx
@@ -92,13 +92,9 @@ export class Horizon extends DisplayComponent<HorizonProps> {
 
     private rollGroupRef = FSComponent.createRef<SVGGElement>();
 
-    private pitchProtSymbolUpper = FSComponent.createRef<SVGGElement>();
+    private pritchProtActiveVisibility = Subject.create('visible');
 
-    private pitchProtSymbolLower = FSComponent.createRef<SVGGElement>();
-
-    private pitchProtLostSymbolUpper = FSComponent.createRef<SVGGElement>();
-
-    private pitchProtLostSymbolLower = FSComponent.createRef<SVGGElement>();
+    private pritchProtLostVisibility = Subject.create('hidden');
 
     private yOffset = Subject.create(0);
 
@@ -129,14 +125,11 @@ export class Horizon extends DisplayComponent<HorizonProps> {
             }
         });
 
-        apfd.on('fcdcDiscreteWord1').whenArinc429SsmChanged().handle((fcdcWord1) => {
+        apfd.on('fcdcDiscreteWord1').handle((fcdcWord1) => {
             const isNormalLawActive = fcdcWord1.getBitValue(11) && !fcdcWord1.isFailureWarning();
 
-            this.pitchProtSymbolLower.instance.style.display = isNormalLawActive ? 'block' : 'none';
-            this.pitchProtSymbolUpper.instance.style.display = isNormalLawActive ? 'block' : 'none';
-
-            this.pitchProtLostSymbolLower.instance.style.display = !isNormalLawActive ? 'block' : 'none';
-            this.pitchProtLostSymbolUpper.instance.style.display = !isNormalLawActive ? 'block' : 'none';
+            this.pritchProtActiveVisibility.set(isNormalLawActive ? 'visible' : 'hidden');
+            this.pritchProtLostVisibility.set(!isNormalLawActive ? 'visible' : 'hidden');
         });
     }
 
@@ -176,19 +169,19 @@ export class Horizon extends DisplayComponent<HorizonProps> {
                         <path d="m47.906-19.177h42h0" />
                     </g>
 
-                    <g id="PitchProtUpper" ref={this.pitchProtSymbolUpper} style="display: none" class="NormalStroke Green">
+                    <g id="PitchProtUpper" visibility={this.pritchProtActiveVisibility} class="NormalStroke Green">
                         <path d="m51.506 31.523h4m-4-1.4h4" />
                         <path d="m86.306 31.523h-4m4-1.4h-4" />
                     </g>
-                    <g id="PitchProtLostUpper" ref={this.pitchProtLostSymbolUpper} style="display: none" class="NormalStroke Amber">
+                    <g id="PitchProtLostUpper" visibility={this.pritchProtLostVisibility} class="NormalStroke Amber">
                         <path d="m52.699 30.116 1.4142 1.4142m-1.4142 0 1.4142-1.4142" />
                         <path d="m85.114 31.53-1.4142-1.4142m1.4142 0-1.4142 1.4142" />
                     </g>
-                    <g id="PitchProtLower" ref={this.pitchProtSymbolLower} style="display: none" class="NormalStroke Green">
+                    <g id="PitchProtLower" visibility={this.pritchProtActiveVisibility} class="NormalStroke Green">
                         <path d="m59.946 104.52h4m-4-1.4h4" />
                         <path d="m77.867 104.52h-4m4-1.4h-4" />
                     </g>
-                    <g id="PitchProtLostLower" ref={this.pitchProtLostSymbolLower} style="display: none" class="NormalStroke Amber">
+                    <g id="PitchProtLostLower" visibility={this.pritchProtLostVisibility} class="NormalStroke Amber">
                         <path d="m61.199 103.12 1.4142 1.4142m-1.4142 0 1.4142-1.4142" />
                         <path d="m76.614 104.53-1.4142-1.4142m1.4142 0-1.4142 1.4142" />
                     </g>

--- a/fbw-a32nx/src/systems/instruments/src/PFD/AttitudeIndicatorHorizon.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/AttitudeIndicatorHorizon.tsx
@@ -92,9 +92,9 @@ export class Horizon extends DisplayComponent<HorizonProps> {
 
     private rollGroupRef = FSComponent.createRef<SVGGElement>();
 
-    private pritchProtActiveVisibility = Subject.create('visible');
+    private pitchProtActiveVisibility = Subject.create('visible');
 
-    private pritchProtLostVisibility = Subject.create('hidden');
+    private pitchProtLostVisibility = Subject.create('hidden');
 
     private yOffset = Subject.create(0);
 
@@ -128,8 +128,8 @@ export class Horizon extends DisplayComponent<HorizonProps> {
         apfd.on('fcdcDiscreteWord1').handle((fcdcWord1) => {
             const isNormalLawActive = fcdcWord1.getBitValue(11) && !fcdcWord1.isFailureWarning();
 
-            this.pritchProtActiveVisibility.set(isNormalLawActive ? 'visible' : 'hidden');
-            this.pritchProtLostVisibility.set(!isNormalLawActive ? 'visible' : 'hidden');
+            this.pitchProtActiveVisibility.set(isNormalLawActive ? 'visible' : 'hidden');
+            this.pitchProtLostVisibility.set(!isNormalLawActive ? 'visible' : 'hidden');
         });
     }
 
@@ -169,19 +169,19 @@ export class Horizon extends DisplayComponent<HorizonProps> {
                         <path d="m47.906-19.177h42h0" />
                     </g>
 
-                    <g id="PitchProtUpper" visibility={this.pritchProtActiveVisibility} class="NormalStroke Green">
+                    <g id="PitchProtUpper" visibility={this.pitchProtActiveVisibility} class="NormalStroke Green">
                         <path d="m51.506 31.523h4m-4-1.4h4" />
                         <path d="m86.306 31.523h-4m4-1.4h-4" />
                     </g>
-                    <g id="PitchProtLostUpper" visibility={this.pritchProtLostVisibility} class="NormalStroke Amber">
+                    <g id="PitchProtLostUpper" visibility={this.pitchProtLostVisibility} class="NormalStroke Amber">
                         <path d="m52.699 30.116 1.4142 1.4142m-1.4142 0 1.4142-1.4142" />
                         <path d="m85.114 31.53-1.4142-1.4142m1.4142 0-1.4142 1.4142" />
                     </g>
-                    <g id="PitchProtLower" visibility={this.pritchProtActiveVisibility} class="NormalStroke Green">
+                    <g id="PitchProtLower" visibility={this.pitchProtActiveVisibility} class="NormalStroke Green">
                         <path d="m59.946 104.52h4m-4-1.4h4" />
                         <path d="m77.867 104.52h-4m4-1.4h-4" />
                     </g>
-                    <g id="PitchProtLostLower" visibility={this.pritchProtLostVisibility} class="NormalStroke Amber">
+                    <g id="PitchProtLostLower" visibility={this.pitchProtLostVisibility} class="NormalStroke Amber">
                         <path d="m61.199 103.12 1.4142 1.4142m-1.4142 0 1.4142-1.4142" />
                         <path d="m76.614 104.53-1.4142-1.4142m1.4142 0-1.4142 1.4142" />
                     </g>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
In my previous PR I erroneouslyadded a "whenArinc429SsmChanged" filter to fcdcDiscreteWord, which prevented the visibility of the pitch protection indicators to be display properly. This has been fixed.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://github.com/flybywiresim/aircraft/assets/19493808/747ba3c0-1c57-4dd9-abf3-18f972a47f9d)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Spawn and make sure the pitch protections are shown as active ("green lines"). Disable ELAC 1 and 2 (or go into alternate or direct law any other way) and make sure the pitch protections are shown as disabled on the pfd (amber crosses instead of green lines)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
