### PR TITLE
feat: adding note to UI when GSX Payload Sync is enabled

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,6 +32,7 @@
 1. [MCDU] Add basic MCDU MENU functionality - @tracernz (Mike)
 1. [MCDU] Split subsystem scratchpads - @tracernz (Mike)
 1. [APU] APU can now consume fuel - @tracernz (Mike)
+1. [EFB] Added UI message on fuel/payload page when GSX is activated - @frankkopp (Frank Kopp)
 
 ## 0.10.0
 

--- a/fbw-a32nx/src/localization/flypad/en.json
+++ b/fbw-a32nx/src/localization/flypad/en.json
@@ -156,6 +156,7 @@
       "DeboardConfirmationConfirm": "Deboard",
       "DeboardConfirmationTitle": "Deboard all Passengers?",
       "EstimatedDurationUnit": "minutes",
+      "GSXPayloadSyncEnabled": "GSX Payload Sync Enabled",
       "GW": "GW",
       "GWCG": "GW CG",
       "LoadingTime": "Loading Time",

--- a/fbw-a32nx/src/localization/flypad/en.json
+++ b/fbw-a32nx/src/localization/flypad/en.json
@@ -131,6 +131,7 @@
       "Defueling": "Defueling",
       "EstimatedDuration": "Estimated duration (minutes)",
       "EstimatedTime": "Estimated Time",
+      "GSXFuelSyncEnabled": "GSX Fuel Sync Enabled",
       "LeftInnerTank": "Left Inner Tank",
       "LeftOuterTank": "Left Outer Tank",
       "ReadyToStart": "Ready to Start",

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/FuelPage.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/FuelPage.tsx
@@ -150,7 +150,7 @@ export const FuelPage = () => {
         if (refuelStartedByUser) {
             setRefuelStartedByUser(false);
         }
-        return `(${t('Ground.Fuel.Unavailable')})`;
+        return gsxFuelSyncEnabled === 1 ? `(${t('Ground.Fuel.GSXFuelSyncEnabled')})` : `(${t('Ground.Fuel.Unavailable')})`;
     };
 
     const formatRefuelStatusClass = () => {

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
@@ -346,6 +346,7 @@ export const Payload = () => {
                     }}
                 />,
             );
+            return;
         }
         setBoardingStarted(false);
     }, [totalPaxDesired, totalPax, totalCargo, boardingStarted, totalCargoDesired]);
@@ -882,6 +883,11 @@ export const Payload = () => {
                                 {/* <Card className="h-full w-fit" childrenContainerClassName="h-full w-fit rounded-r-none"> */}
                                 {/* */}
                                 {/* </Card> */}
+                            </div>
+                        )}
+                        {gsxPayloadSyncEnabled === 1 && (
+                            <div className="pt-6 pl-2">
+                                {t('Ground.Payload.GSXPayloadSyncEnabled')}
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
## Summary of Changes
Adds a textual note to the fuel and payload page when GSX Sync is enabled - see screenshots below.

This should help reduce support requests for people having activated the sync and wondering why the controls do not work/disappeared. 

## Screenshots (if necessary)
![2023-07-28_13h52_04](https://github.com/flybywiresim/aircraft/assets/16833201/8671c1ee-80ca-4055-8767-4da7ef2aee6c)
![2023-07-28_14h19_05](https://github.com/flybywiresim/aircraft/assets/16833201/8815821e-dfa6-4810-a30a-feb47e0c5a27)

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Test the appearance of the text note on the fuel page when GSX sync is enabled in settings. 
Also if available test fueling and loading with GSX as well (I do not have GSX and could not test this)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
