### PR TITLE
feat: apu fuel consumption

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -31,6 +31,7 @@
 1. [MCDU] Add basic annunciator support - @tracernz (Mike)
 1. [MCDU] Add basic MCDU MENU functionality - @tracernz (Mike)
 1. [MCDU] Split subsystem scratchpads - @tracernz (Mike)
+1. [APU] APU can now consume fuel - @tracernz (Mike)
 
 ## 0.10.0
 

--- a/fbw-a32nx/src/wasm/fadec_a320/src/EngineControl.h
+++ b/fbw-a32nx/src/wasm/fadec_a320/src/EngineControl.h
@@ -658,11 +658,10 @@ class EngineControl {
     }
   }
 
-  /// <summary>
-  /// FBW Fuel Consumption and Tankering
+  /// @brief FBW Fuel Consumption and Tankering
   /// Updates Fuel Consumption with realistic values
-  /// </summary>
-  void updateFuel(double deltaTime) {
+  /// @param deltaTimeSeconds Frame delta time in seconds
+  void updateFuel(double deltaTimeSeconds) {
     double m = 0;
     double b = 0;
     double fuelBurn1 = 0;
@@ -692,6 +691,7 @@ class EngineControl {
     double engine1FF = simVars->getEngine1FF();        // KG/H
     double engine2FF = simVars->getEngine2FF();        // KG/H
 
+    /// weight of one gallon of fuel in pounds
     double fuelWeightGallon = simVars->getFuelWeightGallon();
     double fuelUsedLeft = simVars->getFuelUsedLeft();    // Kg
     double fuelUsedRight = simVars->getFuelUsedRight();  // Kg
@@ -706,7 +706,9 @@ class EngineControl {
     double leftAuxQuantity = simVars->getFuelTankQuantity(4) * fuelWeightGallon;   // LBS
     double rightAuxQuantity = simVars->getFuelTankQuantity(5) * fuelWeightGallon;  // LBS
     double centerQuantity = simVars->getFuelTankQuantity(1) * fuelWeightGallon;    // LBS
-    double fuelLeft = 0;                                                           // LBS
+    /// Left inner tank fuel quantity in pounds
+    double fuelLeft = 0;
+    /// Right inner tank fuel quantity in pounds
     double fuelRight = 0;
     double fuelLeftAux = 0;
     double fuelRightAux = 0;
@@ -733,7 +735,8 @@ class EngineControl {
     isReady = simVars->getIsReady();
     devState = simVars->getDeveloperState();
 
-    deltaTime = deltaTime / 3600;
+    /// Delta time for this update in hours
+    double deltaTime = deltaTimeSeconds / 3600;
 
     // Pump State Logic for Left Wing
     if (pumpStateLeft == 0 && (timerLeft.elapsed() == 0 || timerLeft.elapsed() >= 1000)) {
@@ -902,10 +905,13 @@ class EngineControl {
       else if (xfrValveCenterRightOpen)
         xfrCenterToRight = fuelCenterPre - centerQuantity;
 
+      /// apu fuel consumption for this frame in pounds
+      double apuFuelConsumption = simVars->getLineFlow(18) * fuelWeightGallon * deltaTime;
+
       //--------------------------------------------
       // Final Fuel levels for left and right inner tanks
-      fuelLeft = (fuelLeftPre - (fuelBurn1 * KGS_TO_LBS)) + xfrAuxLeft + xfrCenterToLeft;      // LBS
-      fuelRight = (fuelRightPre - (fuelBurn2 * KGS_TO_LBS)) + xfrAuxRight + xfrCenterToRight;  // LBS
+      fuelLeft = (fuelLeftPre - (fuelBurn1 * KGS_TO_LBS)) + xfrAuxLeft + xfrCenterToLeft - apuFuelConsumption;  // LBS
+      fuelRight = (fuelRightPre - (fuelBurn2 * KGS_TO_LBS)) + xfrAuxRight + xfrCenterToRight;                   // LBS
 
       //--------------------------------------------
       // Setting new pre-cycle conditions

--- a/fbw-a32nx/src/wasm/fadec_a320/src/EngineControl.h
+++ b/fbw-a32nx/src/wasm/fadec_a320/src/EngineControl.h
@@ -552,7 +552,7 @@ class EngineControl {
       outFlow = 0;
     } else {
       outFlow = max(0, (correctedFuelFlow * LBS_TO_KGS * ratios->delta2(mach, ambientPressure) * sqrt(ratios->theta2(mach, ambientTemp))) -
-                paramImbalance);
+                           paramImbalance);
     }
 
     if (engine == 1) {
@@ -719,7 +719,7 @@ class EngineControl {
     double xfrAuxRight = 0;
     double fuelTotalActual = leftQuantity + rightQuantity + leftAuxQuantity + rightAuxQuantity + centerQuantity;  // LBS
     double fuelTotalPre = fuelLeftPre + fuelRightPre + fuelAuxLeftPre + fuelAuxRightPre + fuelCenterPre;          // LBS
-    double deltaFuelRate = abs(fuelTotalActual - fuelTotalPre) / (fuelWeightGallon * deltaTime);                  // LBS/ sec
+    double deltaFuelRate = abs(fuelTotalActual - fuelTotalPre) / (fuelWeightGallon * deltaTimeSeconds);           // LBS/ sec
 
     double engine1State = simVars->getEngine1State();
     double engine2State = simVars->getEngine2State();

--- a/fbw-a32nx/src/wasm/fadec_a320/src/SimVars.h
+++ b/fbw-a32nx/src/wasm/fadec_a320/src/SimVars.h
@@ -378,6 +378,9 @@ class SimVars {
   FLOAT64 getNAI(int index) { return aircraft_varget(NacelleAntiIce, m_Units->Bool, index); }
   FLOAT64 getPump(int index) { return aircraft_varget(FuelPump, m_Units->Number, index); }
   FLOAT64 getValve(int index) { return aircraft_varget(FuelValve, m_Units->Number, index); }
+  /// @brief Gets a fuel line flow rate in gallons/hour
+  /// @param index Index of the fuel line
+  /// @return Fuel line flow rate in gallons/hour
   FLOAT64 getLineFlow(int index) { return aircraft_varget(FuelLineFlow, m_Units->Gph, index); }
   FLOAT64 getJunctionSetting(int index) { return aircraft_varget(FuelJunctionSetting, m_Units->Number, index); }
 };

--- a/fbw-a32nx/src/wasm/fadec_a320/src/SimVars.h
+++ b/fbw-a32nx/src/wasm/fadec_a320/src/SimVars.h
@@ -178,7 +178,7 @@ class SimVars {
     Engine1VibN1 = register_named_variable("A32NX_ENGINE_VIB_N1:1");
     Engine2VibN1 = register_named_variable("A32NX_ENGINE_VIB_N1:2");
     Engine1VibN2 = register_named_variable("A32NX_ENGINE_VIB_N2:1");
-    Engine2VibN2 = register_named_variable("A32NX_ENGINE_VIB_N2:2");				
+    Engine2VibN2 = register_named_variable("A32NX_ENGINE_VIB_N2:2");
     Engine1FF = register_named_variable("A32NX_ENGINE_FF:1");
     Engine2FF = register_named_variable("A32NX_ENGINE_FF:2");
     Engine1PreFF = register_named_variable("A32NX_ENGINE_PRE_FF:1");
@@ -324,7 +324,7 @@ class SimVars {
   FLOAT64 getEngine1VibN1() { return get_named_variable_value(Engine1VibN1); }
   FLOAT64 getEngine2VibN1() { return get_named_variable_value(Engine2VibN1); }
   FLOAT64 getEngine1VibN2() { return get_named_variable_value(Engine1VibN2); }
-  FLOAT64 getEngine2VibN2() { return get_named_variable_value(Engine2VibN2); }  
+  FLOAT64 getEngine2VibN2() { return get_named_variable_value(Engine2VibN2); }
   FLOAT64 getEngine1PreFF() { return get_named_variable_value(Engine1PreFF); }
   FLOAT64 getEngine2PreFF() { return get_named_variable_value(Engine2PreFF); }
   FLOAT64 getEngineImbalance() { return get_named_variable_value(EngineImbalance); }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This patch allows the APU to consume fuel (from the left inner tank).

Known issues not fixed by this PR:
- The APU has no fuel flow when the left inner tank fuel pumps are off (https://github.com/flybywiresim/aircraft/issues/8146).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Check that the left inner tank fuel level reduces when the APU is running with the left inner tank pumps on.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
