### PR TITLE
fix(nd): a380 TERR ON ND

### DIFF
--- a/fbw-a380x/src/wasm/systems/a380_systems/src/lib.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/lib.rs
@@ -138,7 +138,7 @@ impl A380 {
                     Length::new::<nautical_mile>(320.0),
                     Length::new::<nautical_mile>(640.0),
                 ],
-                1,
+                3,
             ),
 
             icing_simulation: Icing::new(context),

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/lib.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/lib.rs
@@ -130,6 +130,7 @@ impl A380 {
                 context,
                 ElectricalBusType::DirectCurrent(1),
                 vec![
+                    Length::new::<nautical_mile>(0.0),
                     Length::new::<nautical_mile>(10.0),
                     Length::new::<nautical_mile>(20.0),
                     Length::new::<nautical_mile>(40.0),

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/lib.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/lib.rs
@@ -277,6 +277,8 @@ impl Aircraft for A380 {
         self.cds.update();
 
         self.icing_simulation.update(context);
+
+        self.egpwc.update(&self.adirs, self.lgcius.lgciu1());
     }
 }
 impl SimulationElement for A380 {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes some bugs in the EGPWC code to enable the TERR ON ND in the A380

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
No testing required.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
