### PR TITLE
feat(efcs): use correct buses for A380 F/CTL computers

### DIFF
--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
@@ -750,7 +750,7 @@ void FlyByWireInterface::setupLocalVariables() {
   idLowerRudderPosition = std::make_unique<LocalVariable>("A32NX_HYD_LOWER_RUDDER_DEFLECTION");
 
   idElecDcEssBusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_DC_ESS_BUS_IS_POWERED");
-  idElecDcEhaBusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_DC_247PP_BUS_IS_POWERED");
+  idElecDcEhaBusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_247PP_BUS_IS_POWERED");
   idElecDc1BusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_DC_1_BUS_IS_POWERED");
 
   idHydYellowSystemPressure = std::make_unique<LocalVariable>("A32NX_HYD_YELLOW_SYSTEM_1_SECTION_PRESSURE");

--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
@@ -749,9 +749,9 @@ void FlyByWireInterface::setupLocalVariables() {
   idUpperRudderPosition = std::make_unique<LocalVariable>("A32NX_HYD_UPPER_RUDDER_DEFLECTION");
   idLowerRudderPosition = std::make_unique<LocalVariable>("A32NX_HYD_LOWER_RUDDER_DEFLECTION");
 
-  idElecDcBus2Powered = std::make_unique<LocalVariable>("A32NX_ELEC_DC_2_BUS_IS_POWERED");
   idElecDcEssBusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_DC_ESS_BUS_IS_POWERED");
-  idElecBat1HotBusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_DC_HOT_1_BUS_IS_POWERED");
+  idElecDcEhaBusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_DC_247PP_BUS_IS_POWERED");
+  idElecDc1BusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_DC_1_BUS_IS_POWERED");
 
   idHydYellowSystemPressure = std::make_unique<LocalVariable>("A32NX_HYD_YELLOW_SYSTEM_1_SECTION_PRESSURE");
   idHydGreenSystemPressure = std::make_unique<LocalVariable>("A32NX_HYD_GREEN_SYSTEM_1_SECTION_PRESSURE");
@@ -1455,9 +1455,9 @@ bool FlyByWireInterface::updatePrim(double sampleTime, int primIndex) {
     if (primIndex == 0) {
       powerSupplyAvailable = idElecDcEssBusPowered->get();
     } else if (primIndex == 1) {
-      powerSupplyAvailable = idElecDcBus2Powered->get();
+      powerSupplyAvailable = idElecDcEhaBusPowered->get();
     } else {
-      powerSupplyAvailable = idElecDcBus2Powered->get();
+      powerSupplyAvailable = idElecDc1BusPowered->get();
     }
 
     prims[primIndex].update(sampleTime, simData.simulationTime,
@@ -1649,9 +1649,9 @@ bool FlyByWireInterface::updateSec(double sampleTime, int secIndex) {
     if (secIndex == 0) {
       powerSupplyAvailable = idElecDcEssBusPowered->get();
     } else if (secIndex == 1) {
-      powerSupplyAvailable = idElecDcBus2Powered->get();
+      powerSupplyAvailable = idElecDcEhaBusPowered->get();
     } else {
-      powerSupplyAvailable = idElecDcBus2Powered->get();
+      powerSupplyAvailable = idElecDc1BusPowered->get();
     }
 
     Failures failureIndex = secIndex == 0 ? Failures::Sec1 : (secIndex == 1 ? Failures::Sec2 : Failures::Sec3);

--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.h
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.h
@@ -563,9 +563,9 @@ class FlyByWireInterface {
   std::unique_ptr<LocalVariable> idUpperRudderPosition;
   std::unique_ptr<LocalVariable> idLowerRudderPosition;
 
-  std::unique_ptr<LocalVariable> idElecDcBus2Powered;
   std::unique_ptr<LocalVariable> idElecDcEssBusPowered;
-  std::unique_ptr<LocalVariable> idElecBat1HotBusPowered;
+  std::unique_ptr<LocalVariable> idElecDcEhaBusPowered;
+  std::unique_ptr<LocalVariable> idElecDc1BusPowered;
 
   std::unique_ptr<LocalVariable> idHydYellowSystemPressure;
   std::unique_ptr<LocalVariable> idHydGreenSystemPressure;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Small PR that updates the electrical busses used for the F/CTL computers:

PRIM/SEC Number | Bus
-----|------
1 | DC ESS
2 | DC EHA
3 | DC 1

FACs are no longer connected to any bus, since they only serve as placeholder for the FE functions.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
