### PR TITLE
fix(fwc): ctr tk mode sel memo line now works

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -33,6 +33,7 @@
 1. [MCDU] Split subsystem scratchpads - @tracernz (Mike)
 1. [APU] APU can now consume fuel - @tracernz (Mike)
 1. [EFB] Added UI message on fuel/payload page when GSX is activated - @frankkopp (Frank Kopp)
+1. [FWC] WING TANK LO LVL message now considers centre tank mode selector - @tracernz (Mike)
 
 ## 0.10.0
 

--- a/fbw-a32nx/src/systems/instruments/src/EWD/PseudoFWC.ts
+++ b/fbw-a32nx/src/systems/instruments/src/EWD/PseudoFWC.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-import { Subject, Subscribable, MappedSubject, DebounceTimer, ConsumerValue, EventBus } from '@microsoft/msfs-sdk';
+import { Subject, Subscribable, MappedSubject, DebounceTimer, ConsumerValue, EventBus, ConsumerSubject } from '@microsoft/msfs-sdk';
 
 import { Arinc429Register, Arinc429Word, NXDataStore, NXLogicClockNode, NXLogicConfirmNode, NXLogicMemoryNode, NXLogicPulseNode, NXLogicTriggeredMonostableNode } from '@flybywiresim/fbw-sdk';
 import { VerticalMode } from '@shared/autopilot';
@@ -321,37 +321,37 @@ export class PseudoFWC {
 
     /* FUEL */
 
-    private readonly centerFuelPump1Auto = Subject.create(false);
+    private readonly centerFuelPump1Auto = ConsumerValue.create(null, false);
 
-    private readonly centerFuelPump2Auto = Subject.create(false);
+    private readonly centerFuelPump2Auto = ConsumerValue.create(null, false);
 
     private readonly centerFuelQuantity = Subject.create(0);
 
     private readonly fuelXFeedPBOn = Subject.create(false);
 
-    private readonly leftOuterInnerValve = Subject.create(0);
+    private readonly leftOuterInnerValve = ConsumerSubject.create(null, 0);
 
     private readonly leftFuelLow = Subject.create(false);
 
     private readonly leftFuelLowConfirm = new NXLogicConfirmNode(30, true);
 
-    private readonly leftFuelPump1Auto = Subject.create(false);
+    private readonly leftFuelPump1Auto = ConsumerValue.create(null, false);
 
-    private readonly leftFuelPump2Auto = Subject.create(false);
+    private readonly leftFuelPump2Auto = ConsumerValue.create(null, false);
 
     private readonly lrTankLow = Subject.create(false);
 
     private readonly lrTankLowConfirm = new NXLogicConfirmNode(30, true);
 
-    private readonly rightOuterInnerValve = Subject.create(0);
+    private readonly rightOuterInnerValve = ConsumerSubject.create(null, 0);
 
     private readonly rightFuelLow = Subject.create(false);
 
     private readonly rightFuelLowConfirm = new NXLogicConfirmNode(30, true);
 
-    private readonly rightFuelPump1Auto = Subject.create(false);
+    private readonly rightFuelPump1Auto = ConsumerValue.create(null, false);
 
-    private readonly rightFuelPump2Auto = Subject.create(false);
+    private readonly rightFuelPump2Auto = ConsumerValue.create(null, false);
 
     private readonly fuelCtrTankModeSelMan = ConsumerValue.create(null, false);
 
@@ -560,9 +560,9 @@ export class PseudoFWC {
 
     private readonly throttle2Position = Subject.create(0);
 
-    private readonly engine1ValueSwitch = Subject.create(false);
+    private readonly engine1ValueSwitch = ConsumerValue.create(null, false);
 
-    private readonly engine2ValueSwitch = Subject.create(false);
+    private readonly engine2ValueSwitch = ConsumerValue.create(null, false);
 
     private readonly autoThrustStatus = Subject.create(0);
 
@@ -719,6 +719,16 @@ export class PseudoFWC {
         const sub = this.bus.getSubscriber<FuelSystemEvents>();
 
         this.fuelCtrTankModeSelMan.setConsumer(sub.on('fuel_ctr_tk_mode_sel_man'));
+        this.engine1ValueSwitch.setConsumer(sub.on('fuel_valve_switch_1'));
+        this.engine2ValueSwitch.setConsumer(sub.on('fuel_valve_switch_2'));
+        this.centerFuelPump1Auto.setConsumer(sub.on('fuel_pump_switch_1'));
+        this.centerFuelPump2Auto.setConsumer(sub.on('fuel_pump_switch_4'));
+        this.leftOuterInnerValve.setConsumer(sub.on('fuel_valve_open_4'));
+        this.leftFuelPump1Auto.setConsumer(sub.on('fuel_pump_switch_2'));
+        this.leftFuelPump2Auto.setConsumer(sub.on('fuel_pump_switch_5'));
+        this.rightOuterInnerValve.setConsumer(sub.on('fuel_valve_open_5'));
+        this.rightFuelPump1Auto.setConsumer(sub.on('fuel_pump_switch_3'));
+        this.rightFuelPump2Auto.setConsumer(sub.on('fuel_pump_switch_6'));
     }
 
     mapOrder(array, order): [] {
@@ -891,8 +901,6 @@ export class PseudoFWC {
         this.eng2AntiIce.set(SimVar.GetSimVarValue('ENG ANTI ICE:2', 'bool'));
         this.throttle1Position.set(SimVar.GetSimVarValue('L:A32NX_AUTOTHRUST_TLA:1', 'number'));
         this.throttle2Position.set(SimVar.GetSimVarValue('L:A32NX_AUTOTHRUST_TLA:2', 'number'));
-        this.engine1ValueSwitch.set(SimVar.GetSimVarValue('FUELSYSTEM VALVE SWITCH:1', 'bool'));
-        this.engine2ValueSwitch.set(SimVar.GetSimVarValue('FUELSYSTEM VALVE SWITCH:2', 'bool'));
         this.autoThrustStatus.set(SimVar.GetSimVarValue('L:A32NX_AUTOTHRUST_STATUS', 'enum'));
         this.autothrustLeverWarningFlex.set(SimVar.GetSimVarValue('L:A32NX_AUTOTHRUST_THRUST_LEVER_WARNING_FLEX', 'bool'));
         this.autothrustLeverWarningToga.set(SimVar.GetSimVarValue('L:A32NX_AUTOTHRUST_THRUST_LEVER_WARNING_TOGA', 'bool'));
@@ -1078,16 +1086,8 @@ export class PseudoFWC {
 
         /* FUEL */
         const fuelGallonsToKg = SimVar.GetSimVarValue('FUEL WEIGHT PER GALLON', 'kilogram');
-        this.centerFuelPump1Auto.set(SimVar.GetSimVarValue('FUELSYSTEM PUMP SWITCH:1', 'Enum'));
-        this.centerFuelPump2Auto.set(SimVar.GetSimVarValue('FUELSYSTEM PUMP SWITCH:4', 'Enum'));
         this.centerFuelQuantity.set(SimVar.GetSimVarValue('FUEL TANK CENTER QUANTITY', 'gallons') * fuelGallonsToKg);
         this.fuelXFeedPBOn.set(SimVar.GetSimVarValue('L:XMLVAR_Momentary_PUSH_OVHD_FUEL_XFEED_Pressed', 'bool'));
-        this.leftOuterInnerValve.set(SimVar.GetSimVarValue('FUELSYSTEM VALVE OPEN:4', 'Bool'));
-        this.leftFuelPump1Auto.set(SimVar.GetSimVarValue('FUELSYSTEM PUMP SWITCH:2', 'Enum'));
-        this.leftFuelPump2Auto.set(SimVar.GetSimVarValue('FUELSYSTEM PUMP SWITCH:5', 'Enum'));
-        this.rightOuterInnerValve.set(SimVar.GetSimVarValue('FUELSYSTEM VALVE OPEN:5', 'Bool'));
-        this.rightFuelPump1Auto.set(SimVar.GetSimVarValue('FUELSYSTEM PUMP SWITCH:3', 'Enum'));
-        this.rightFuelPump2Auto.set(SimVar.GetSimVarValue('FUELSYSTEM PUMP SWITCH:6', 'Enum'));
 
         const leftInnerFuelQuantity = SimVar.GetSimVarValue('FUEL TANK LEFT MAIN QUANTITY', 'gallons') * fuelGallonsToKg;
         const rightInnerFuelQuantity = SimVar.GetSimVarValue('FUEL TANK RIGHT MAIN QUANTITY', 'gallons') * fuelGallonsToKg;

--- a/fbw-a32nx/src/systems/instruments/src/EWD/instrument.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EWD/instrument.tsx
@@ -1,4 +1,5 @@
-import { Clock, EventBus, FSComponent } from '@microsoft/msfs-sdk';
+import { Clock, EventBus, FSComponent, InstrumentBackplane } from '@microsoft/msfs-sdk';
+import { FuelSystemPublisher } from 'instruments/src/MsfsAvionicsCommon/providers/FuelSystemPublisher';
 import { ArincValueProvider } from './shared/ArincValueProvider';
 import { EwdComponent } from './EWD';
 import { EwdSimvarPublisher } from './shared/EwdSimvarPublisher';
@@ -7,115 +8,38 @@ import { PseudoFWC } from './PseudoFWC';
 import './style.scss';
 
 class A32NX_EWD extends BaseInstrument {
-    private bus: EventBus;
+    private readonly bus = new EventBus();
 
-    private simVarPublisher: EwdSimvarPublisher;
+    private readonly backplane = new InstrumentBackplane();
 
-    private readonly arincProvider: ArincValueProvider;
+    private readonly simVarPublisher = new EwdSimvarPublisher(this.bus);
 
-    private readonly clock: Clock;
+    private readonly arincProvider = new ArincValueProvider(this.bus);
 
-    private pseudoFwc: PseudoFWC;
+    private readonly clock = new Clock(this.bus);
 
-    /**
-     * "mainmenu" = 0
-     * "loading" = 1
-     * "briefing" = 2
-     * "ingame" = 3
-     */
-    private gameState = 0;
+    private readonly fuelSystemPublisher = new FuelSystemPublisher(this.bus);
+
+    private readonly pseudoFwc = new PseudoFWC(this.bus, this);
 
     constructor() {
         super();
-        this.bus = new EventBus();
-        this.simVarPublisher = new EwdSimvarPublisher(this.bus);
-        this.arincProvider = new ArincValueProvider(this.bus);
-        this.clock = new Clock(this.bus);
-        this.pseudoFwc = new PseudoFWC();
+
+        this.backplane.addInstrument('Clock', this.clock);
+        this.backplane.addPublisher('SimVars', this.simVarPublisher);
+        this.backplane.addPublisher('FuelSystem', this.fuelSystemPublisher);
+        this.backplane.addInstrument('Fwc', this.pseudoFwc);
     }
 
     get templateID(): string {
         return 'A32NX_EWD';
     }
 
-    public getDeltaTime() {
-        return this.deltaTime;
-    }
-
     public connectedCallback(): void {
         super.connectedCallback();
 
         this.arincProvider.init();
-        this.clock.init();
-        this.pseudoFwc.init();
-
-        this.simVarPublisher.subscribe('acEssBus');
-        this.simVarPublisher.subscribe('ewdPotentiometer');
-
-        this.simVarPublisher.subscribe('autoThrustCommand1');
-        this.simVarPublisher.subscribe('autoThrustCommand2');
-        this.simVarPublisher.subscribe('autoThrustLimit');
-        this.simVarPublisher.subscribe('autoThrustLimitToga');
-        this.simVarPublisher.subscribe('thrustLimitType');
-        this.simVarPublisher.subscribe('autoThrustMode');
-        this.simVarPublisher.subscribe('autoThrustStatus');
-        this.simVarPublisher.subscribe('autoThrustTLA1');
-        this.simVarPublisher.subscribe('autoThrustTLA2');
-        this.simVarPublisher.subscribe('autoThrustWarningToga');
-        this.simVarPublisher.subscribe('throttle1Position');
-        this.simVarPublisher.subscribe('throttle2Position');
-
-        this.simVarPublisher.subscribe('apuBleedPressure');
-        this.simVarPublisher.subscribe('packs1Supplying');
-        this.simVarPublisher.subscribe('packs2Supplying');
-
-        this.simVarPublisher.subscribe('engine1AntiIce');
-        this.simVarPublisher.subscribe('engine1EGT');
-        this.simVarPublisher.subscribe('engine1Fadec');
-        this.simVarPublisher.subscribe('engine1FF');
-        this.simVarPublisher.subscribe('engine1N1');
-        this.simVarPublisher.subscribe('engine1N2');
-        this.simVarPublisher.subscribe('engine1ReverserTransit');
-        this.simVarPublisher.subscribe('engine1ReverserDeployed');
-        this.simVarPublisher.subscribe('engine1State');
-
-        this.simVarPublisher.subscribe('engine2AntiIce');
-        this.simVarPublisher.subscribe('engine2EGT');
-        this.simVarPublisher.subscribe('engine2Fadec');
-        this.simVarPublisher.subscribe('engine2FF');
-        this.simVarPublisher.subscribe('engine2N1');
-        this.simVarPublisher.subscribe('engine2N2');
-        this.simVarPublisher.subscribe('engine2ReverserTransit');
-        this.simVarPublisher.subscribe('engine2ReverserDeployed');
-        this.simVarPublisher.subscribe('engine2State');
-
-        this.simVarPublisher.subscribe('ewdLowerLeft1');
-        this.simVarPublisher.subscribe('ewdLowerLeft2');
-        this.simVarPublisher.subscribe('ewdLowerLeft3');
-        this.simVarPublisher.subscribe('ewdLowerLeft4');
-        this.simVarPublisher.subscribe('ewdLowerLeft5');
-        this.simVarPublisher.subscribe('ewdLowerLeft6');
-        this.simVarPublisher.subscribe('ewdLowerLeft7');
-        this.simVarPublisher.subscribe('ewdLowerRight1');
-        this.simVarPublisher.subscribe('ewdLowerRight2');
-        this.simVarPublisher.subscribe('ewdLowerRight3');
-        this.simVarPublisher.subscribe('ewdLowerRight4');
-        this.simVarPublisher.subscribe('ewdLowerRight5');
-        this.simVarPublisher.subscribe('ewdLowerRight6');
-        this.simVarPublisher.subscribe('ewdLowerRight7');
-
-        this.simVarPublisher.subscribe('flexTemp');
-        this.simVarPublisher.subscribe('fwcFlightPhase');
-        this.simVarPublisher.subscribe('idleN1');
-        this.simVarPublisher.subscribe('left1LandingGear');
-        this.simVarPublisher.subscribe('right1LandingGear');
-        this.simVarPublisher.subscribe('totalFuel');
-        this.simVarPublisher.subscribe('wingAntiIce');
-
-        this.simVarPublisher.subscribe('flapsPositionRaw');
-        this.simVarPublisher.subscribe('satRaw');
-        this.simVarPublisher.subscribe('slatsFlapsStatusRaw');
-        this.simVarPublisher.subscribe('slatsPositionRaw');
+        this.backplane.init();
 
         FSComponent.render(<EwdComponent bus={this.bus} instrument={this} />, document.getElementById('EWD_CONTENT'));
 
@@ -126,17 +50,7 @@ class A32NX_EWD extends BaseInstrument {
     public Update(): void {
         super.Update();
 
-        if (this.gameState !== 3) {
-            const gamestate = this.getGameState();
-            if (gamestate === 3) {
-                this.simVarPublisher.startPublish();
-            }
-            this.gameState = gamestate;
-        } else {
-            this.simVarPublisher.onUpdate();
-            this.clock.onUpdate();
-            this.pseudoFwc.onUpdate(this.deltaTime);
-        }
+        this.backplane.onUpdate();
     }
 }
 

--- a/fbw-a32nx/src/systems/instruments/src/MsfsAvionicsCommon/providers/FuelSystemPublisher.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MsfsAvionicsCommon/providers/FuelSystemPublisher.ts
@@ -1,7 +1,7 @@
-import { EventBus, PublishPacer, SimVarPublisher, SimVarPublisherEntry, SimVarValueType } from '@microsoft/msfs-sdk';
+import { EventBus, IndexedEventType, PublishPacer, SimVarPublisher, SimVarPublisherEntry, SimVarValueType } from '@microsoft/msfs-sdk';
 
 /* eslint-disable camelcase */
-export interface FuelSystemEvents {
+export interface BaseFuelSystemEvents {
     fuel_ctr_tk_mode_sel_man: boolean,
     /** The valve's switch: */
     fuel_valve_switch: boolean;
@@ -19,6 +19,19 @@ export interface FuelSystemEvents {
     fuel_line_flow: number;
     /** The quantity of fuel in the selected tank (by tank index), in gallons. */
     fuel_tank_quantity: number;
+}
+
+type IndexedTopics = 'fuel_valve_switch' | 'fuel_valve_open' | 'fuel_pump_switch' | 'fuel_pump_active'
+    | 'fuel_engine_pressure' | 'fuel_line_pressure' | 'fuel_line_flow' | 'fuel_tank_quantity';
+
+type FuelSystemIndexedEvents = {
+  [P in keyof Pick<BaseFuelSystemEvents, IndexedTopics> as IndexedEventType<P>]: BaseFuelSystemEvents[P];
+};
+
+/**
+ * Fuel System events.
+ */
+export interface FuelSystemEvents extends BaseFuelSystemEvents, FuelSystemIndexedEvents {
 }
 
 export class FuelSystemPublisher extends SimVarPublisher<FuelSystemEvents> {

--- a/fbw-a32nx/src/systems/instruments/src/MsfsAvionicsCommon/providers/FuelSystemPublisher.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MsfsAvionicsCommon/providers/FuelSystemPublisher.ts
@@ -1,0 +1,40 @@
+import { EventBus, PublishPacer, SimVarPublisher, SimVarPublisherEntry, SimVarValueType } from '@microsoft/msfs-sdk';
+
+/* eslint-disable camelcase */
+export interface FuelSystemEvents {
+    fuel_ctr_tk_mode_sel_man: boolean,
+    /** The valve's switch: */
+    fuel_valve_switch: boolean;
+    /** The valve's actual continous position, in percent, 0 ... 1 */
+    fuel_valve_open: number;
+    /** The pump's switch state */
+    fuel_pump_switch: boolean;
+    /** The pump's active state (ex. false when pump is on but no fuel in tank) */
+    fuel_pump_active: boolean;
+    /** The engines's fuel pressure in psi. */
+    fuel_engine_pressure: number;
+    /** The pressure of a fuel line in psi. */
+    fuel_line_pressure: number;
+    /** The fuel flow of a fuel line in gallons per hour. */
+    fuel_line_flow: number;
+    /** The quantity of fuel in the selected tank (by tank index), in gallons. */
+    fuel_tank_quantity: number;
+}
+
+export class FuelSystemPublisher extends SimVarPublisher<FuelSystemEvents> {
+    constructor(bus: EventBus, pacer?: PublishPacer<FuelSystemEvents>) {
+        const simvars: [keyof FuelSystemEvents, SimVarPublisherEntry<any>][] = [
+            ['fuel_ctr_tk_mode_sel_man', { name: 'L:A32NX_OVHD_FUEL_MODESEL_MANUAL', type: SimVarValueType.Number, map: (v) => !!v }],
+            ['fuel_valve_switch', { name: 'FUELSYSTEM VALVE SWITCH:#index#', type: SimVarValueType.Bool, indexed: true, map: (v) => !!v }],
+            ['fuel_valve_open', { name: 'FUELSYSTEM VALVE OPEN:#index#', type: SimVarValueType.Number, indexed: true }],
+            ['fuel_pump_switch', { name: 'FUELSYSTEM PUMP SWITCH:#index#', type: SimVarValueType.Bool, indexed: true, map: (v) => !!v }],
+            ['fuel_pump_active', { name: 'FUELSYSTEM PUMP ACTIVE:#index#', type: SimVarValueType.Bool, indexed: true, map: (v) => !!v }],
+            ['fuel_engine_pressure', { name: 'FUELSYSTEM ENGINE PRESSURE:#index#', type: SimVarValueType.PSI, indexed: true }],
+            ['fuel_line_pressure', { name: 'FUELSYSTEM LINE FUEL PRESSURE:#index#', type: SimVarValueType.PSI, indexed: true }],
+            ['fuel_line_flow', { name: 'FUELSYSTEM LINE FUEL FLOW:#index#', type: SimVarValueType.GPH, indexed: true }],
+            ['fuel_tank_quantity', { name: 'FUELSYSTEM TANK QUANTITY:#index#', type: SimVarValueType.GAL, indexed: true }],
+        ];
+
+        super(new Map(simvars), bus, pacer);
+    }
+}


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The WING TK LO LVL memo has a CTR TK MODE SEL...MAN line that should be away when the button is pressed. This PR hooks the line up to the button. It also tidies some legacy stuff in the EWD instrument and adds a fuel system publisher that can provide all the fuel data.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Run one wing tanks down to < 700 kg. Make sure the CTR TK MODE SEL line goes away when you press the MODE SEL to MAN.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
