### PR TITLE
feat(fm): basic fa leg support

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -34,6 +34,7 @@
 1. [APU] APU can now consume fuel - @tracernz (Mike)
 1. [EFB] Added UI message on fuel/payload page when GSX is activated - @frankkopp (Frank Kopp)
 1. [FWC] WING TANK LO LVL message now considers centre tank mode selector - @tracernz (Mike)
+1. [FMS] Add basic support for FA legs - @tracernz (Mike)
 
 ## 0.10.0
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -254,7 +254,7 @@ class CDUFlightPlanPage {
                             fixAnnotation = `C${magCourse}\u00b0`;
                             break;
                         case 8: // FA
-                            fixAnnotation = `${wp.ident.substring(0, 3)}${magCourse}`;
+                            fixAnnotation = `${WayPoint.formatIdentFromIcao(wp.additionalData.fixIcao ? wp.additionalData.fixIcao : '').substring(0, 3)}${magCourse}`;
                             break;
                         case 11: // FM
                             if (wpPrev) {

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/GeoMath.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/GeoMath.ts
@@ -36,7 +36,7 @@ export class GeoMath {
    * @param referenceCoordinates The reference coordinates to calculate from.
    * @returns The calculated coordinates.
    */
-  public static relativeBearingDistanceToCoords(course: number, distanceInNM: number, referenceCoordinates: LatLongAlt): LatLongAlt {
+  public static relativeBearingDistanceToCoords(course: number, distanceInNM: number, referenceCoordinates: Coordinates): LatLongAlt {
       const courseRadians = course * Avionics.Utils.DEG2RAD;
       const distanceRadians = (Math.PI / (180 * 60)) * distanceInNM;
 

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/LegsProcedure.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/LegsProcedure.ts
@@ -520,6 +520,7 @@ export class LegsProcedure {
     const waypoint = this.buildWaypoint(FixNamingScheme.headingUntilAltitude(altitudeFeet), coordinates, magVar);
 
     waypoint.additionalData.vectorsAltitude = altitudeFeet;
+    waypoint.additionalData.fixIcao = leg.fixIcao;
 
     return waypoint;
   }

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/LegsProcedure.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/LegsProcedure.ts
@@ -202,6 +202,9 @@ export class LegsProcedure {
                   case LegType.VA:
                       mappedLeg = this.mapHeadingUntilAltitude(currentLeg, this._previousFix);
                       break;
+                  case LegType.FA:
+                      mappedLeg = this.mapFixUntilAltitude(currentLeg);
+                      break;
                   case LegType.HA:
                   case LegType.HF:
                   case LegType.HM:
@@ -503,6 +506,22 @@ export class LegsProcedure {
       waypoint.additionalData.vectorsAltitude = altitudeFeet;
 
       return waypoint;
+  }
+
+  public mapFixUntilAltitude(leg: RawProcedureLeg) {
+    const magVar = this.getMagCorrection(leg);
+    const course = leg.trueDegrees ? leg.course : A32NX_Util.magneticToTrue(leg.course, magVar);
+    const altitudeFeet = (leg.altitude1 * 3.2808399);
+    const distanceInNM = altitudeFeet / 500.0;
+
+    const facility = this.getLoadedFacility(leg.fixIcao);
+
+    const coordinates = GeoMath.relativeBearingDistanceToCoords(course, distanceInNM, { lat: facility.lat, long: facility.lon });
+    const waypoint = this.buildWaypoint(FixNamingScheme.headingUntilAltitude(altitudeFeet), coordinates, magVar);
+
+    waypoint.additionalData.vectorsAltitude = altitudeFeet;
+
+    return waypoint;
   }
 
   /**


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Introduces basic support for FA legs in  the same fashion as we currently support CA and VA legs. Not sure why we never did this before as a basic measure to improve a lot of SIDs.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
In the past (old screenshot from another old PR):
![178011190-16a46597-b98a-4826-a40b-a9811e335b85](https://github.com/flybywiresim/aircraft/assets/9995998/d32caa56-c452-405d-840f-9aa5f9e9d714)
Now, the 2000 foot FA leg is there:
![image](https://github.com/flybywiresim/aircraft/assets/9995998/15281af7-5abd-4f7a-861b-e7b15e0b2cca)
![image](https://github.com/flybywiresim/aircraft/assets/9995998/98383fbf-0d1d-4367-a854-068ff79239eb)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Fly some departures with FA legs. A random selection:

Airport | SID| Runway (B is for both)
-- | -- | --
YBCS | SWIFT8 | RW15
LOWK | KFT1L | RW10L
OIAW | GODM1B | RW12
LEHC | HUE1B | RW30L
OIMM | RAMI1K | RW13B
EDDF | TAU2Q | RW25L
OLBA | LATE1D | RW21
LGSK | SIGF1B | RW01
KGSB | GSB4 | RW26
MMZH | VILT2A | RW09
OIMM | EMES1A | RW31B
OIHR | DEKB1C | RW26
KSDL | MRRIC1 | RW21
OIZH | PIRA1E | RW17B
LELN | ZMR2G | RW05
LFML | MTG6C | RW31L
LFBO | LACO6A | RW14B
UTFA | RIND1F | RW22
LTCR | ARTA1U | RW21
ZMUB | TORO3H | RW32
OIBS | KIS1C | RW30
WAHS | KIDE2A | RW13
KSRR | CAP2 | RW30
LSGG | MEDA5P | RW04
AGGH | KIRA1B | RW24
AGGH | NODO1B | RW24
FWCL | UVDA1A | RW10
FZKA | EKVI1B | RW28
LTAN | OBRU1D | RW01B
OITL | ITUP1L | RW15

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
