### PR TITLE
fix: nose wheel steering for non-320 airbus

### DIFF
--- a/fbw-a380x/src/wasm/systems/a380_systems_wasm/src/nose_wheel_steering.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems_wasm/src/nose_wheel_steering.rs
@@ -153,10 +153,10 @@ fn recenter_when_close_to_center(value: f64, increment: f64) -> f64 {
     }
 }
 
-const MAX_CONTROLLABLE_STEERING_ANGLE_DEGREES: f64 = 75.;
+const MAX_CONTROLLABLE_STEERING_ANGLE_DEGREES: f64 = 70.;
 
 fn steering_animation_to_msfs_from_steering_angle(nose_wheel_position: f64) -> f64 {
-    const STEERING_ANIMATION_TOTAL_RANGE_DEGREES: f64 = 360.;
+    const STEERING_ANIMATION_TOTAL_RANGE_DEGREES: f64 = 140.;
 
     ((nose_wheel_position * MAX_CONTROLLABLE_STEERING_ANGLE_DEGREES
         / (STEERING_ANIMATION_TOTAL_RANGE_DEGREES / 2.))
@@ -168,7 +168,7 @@ fn steering_demand_to_msfs_from_steering_angle(
     nose_wheel_position: f64,
     rudder_position: f64,
 ) -> f64 {
-    const MAX_MSFS_STEERING_ANGLE_DEGREES: f64 = 90.;
+    const MAX_MSFS_STEERING_ANGLE_DEGREES: f64 = 75.;
 
     // Steering in msfs is the max we want rescaled to the max in msfs
     let steering_ratio_converted = nose_wheel_position * MAX_CONTROLLABLE_STEERING_ANGLE_DEGREES


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Correct steering angle of 70/75 vs 75/90 and Animation Degree 360 -> 140.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
A380 AC

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Testing N/A not needed

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
