### PR TITLE
fix(ND): correct color of FROM/TO airport

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/efis/EfisSymbols.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/efis/EfisSymbols.ts
@@ -469,7 +469,7 @@ export class EfisSymbols {
                         databaseId: airport.icao,
                         ident: airport.ident,
                         location: airport.infos.coordinates,
-                        type: NdSymbolTypeFlags.Airport,
+                        type: NdSymbolTypeFlags.Airport | NdSymbolTypeFlags.FlightPlan,
                     });
                 }
             }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8183

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Correctly draws the Origin and Destination airport in white instead of magenta. 


## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![image](https://github.com/flybywiresim/aircraft/assets/5833783/15ad8430-0030-4c9b-9e5c-168eefc3c3f1)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):\_chaoz_

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
It is a one line change and should have no effect on anything but the drawing of the airport symbol on the ND
Test should make sure that when only from/to airports are entered they show up in white on the ND


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
