### PR TITLE
fix(ND): fix the color and orientation of course reversal arrow

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/NDv2/shared/map/PseudoWaypointLayer.ts
+++ b/fbw-a32nx/src/systems/instruments/src/NDv2/shared/map/PseudoWaypointLayer.ts
@@ -19,8 +19,6 @@ const LEVEL_OFF_CLIMB_PATH = new Path2D('M -42 16.2 l 19.8 -16.2 h 22.2 m -4.2 -
 const START_OF_DESCENT_PATH = new Path2D('M 0 0 h 22.2 l 19.8 16.2 m -6 0 h 6 v -6');
 const LEVEL_OFF_DESCENT_PATH = new Path2D('M -42 -16.2 l 19.8 16.2 h 22.2 m -4.2 -4.2 l 4.2 4.2 l -4.2 4.2');
 const INTERCEPT_PROFILE_PATH = new Path2D('M -38, 0 l 14, -17 v 34 l 14 -17 h10 m -5 -5 l 5 5 l -5 5');
-const COURSE_REVERSAL_ARC_PATH_LEFT = new Path2D('M 0, 0 a 21, 21 0 0 0 -42, 0');
-const COURSE_REVERSAL_ARC_PATH_RIGHT = new Path2D('M 0, 0 a 21, 21 0 0  1 42, 0');
 
 export class PseudoWaypointLayer implements MapLayer<NdSymbol> {
     data: NdSymbol[] = [];
@@ -52,13 +50,13 @@ export class PseudoWaypointLayer implements MapLayer<NdSymbol> {
                 context.translate(384, 620);
                 context.rotate(rotate * Math.PI / 180);
 
-                this.paintPseudoWaypoint(false, context, 0, -dy, symbol, mapParameters);
+                this.paintPseudoWaypoint(false, context, 0, -dy, symbol);
             } else {
                 const [x, y] = mapParameters.coordinatesToXYy(symbol.location);
                 const rx = x + mapWidth / 2;
                 const ry = y + mapHeight / 2;
 
-                this.paintPseudoWaypoint(false, context, rx, ry, symbol, mapParameters);
+                this.paintPseudoWaypoint(false, context, rx, ry, symbol);
             }
             this.lastUpdateTime = Date.now();
         }
@@ -73,19 +71,19 @@ export class PseudoWaypointLayer implements MapLayer<NdSymbol> {
                 context.translate(384, 620);
                 context.rotate(rotate * Math.PI / 180);
 
-                this.paintPseudoWaypoint(true, context, 0, -dy, symbol, mapParameters);
+                this.paintPseudoWaypoint(true, context, 0, -dy, symbol);
             } else {
                 const [x, y] = mapParameters.coordinatesToXYy(symbol.location);
                 const rx = x + mapWidth / 2;
                 const ry = y + mapHeight / 2;
 
-                this.paintPseudoWaypoint(true, context, rx, ry, symbol, mapParameters);
+                this.paintPseudoWaypoint(true, context, rx, ry, symbol);
             }
         }
         this.lastUpdateTime = Date.now();
     }
 
-    private paintPseudoWaypoint(isColorLayer: boolean, context: CanvasRenderingContext2D, x: number, y: number, symbol: NdSymbol, mapParameters: MapParameters) {
+    private paintPseudoWaypoint(isColorLayer: boolean, context: CanvasRenderingContext2D, x: number, y: number, symbol: NdSymbol) {
         const color = isColorLayer ? typeFlagToColor(symbol.type) : '#000';
         context.strokeStyle = color;
 
@@ -111,24 +109,7 @@ export class PseudoWaypointLayer implements MapLayer<NdSymbol> {
             context.fillStyle = color;
             context.strokeStyle = 'none';
             this.paintSpeedChange(context, x, y);
-        } else if (symbol.type & (NdSymbolTypeFlags.CourseReversalLeft | NdSymbolTypeFlags.CourseReversalRight)) {
-            this.paintCourseReversal(context, x, y, mapParameters, symbol);
         }
-    }
-
-    private paintCourseReversal(context: CanvasRenderingContext2D, x: number, y: number, mapParams: MapParameters, symbol: NdSymbol) {
-        const left = symbol.type & (NdSymbolTypeFlags.CourseReversalLeft);
-        const arcEnd = left ? -42 : 42;
-        context.translate(x, y);
-        context.beginPath();
-        context.moveTo(arcEnd, 0);
-        context.lineTo(arcEnd - 4, -4);
-        context.moveTo(arcEnd, 0);
-        context.lineTo(arcEnd + 4, -4);
-        context.stroke();
-        context.stroke(left ? COURSE_REVERSAL_ARC_PATH_LEFT : COURSE_REVERSAL_ARC_PATH_RIGHT);
-        context.closePath();
-        context.resetTransform();
     }
 
     private paintPath(context: CanvasRenderingContext2D, x: number, y: number, path: Path2D) {

--- a/fbw-a32nx/src/systems/instruments/src/NDv2/shared/map/WaypointLayer.ts
+++ b/fbw-a32nx/src/systems/instruments/src/NDv2/shared/map/WaypointLayer.ts
@@ -33,7 +33,7 @@ export class WaypointLayer implements MapLayer<NdSymbol> {
             } else if (BitFlags.isAny(symbol.type, NdSymbolTypeFlags.VorDme | NdSymbolTypeFlags.Vor | NdSymbolTypeFlags.Dme | NdSymbolTypeFlags.Ndb)) {
                 this.paintNavaid(false, context, rx, ry, symbol);
             } else if (BitFlags.isAny(symbol.type, NdSymbolTypeFlags.FixInfo | NdSymbolTypeFlags.FlightPlan)) {
-                this.paintFlightPlanWaypoint(false, context, rx, ry, symbol);
+                this.paintFlightPlanWaypoint(false, context, rx, ry, symbol, mapParameters);
             } else {
                 this.paintWaypoint(false, context, rx, ry, symbol);
             }
@@ -51,7 +51,7 @@ export class WaypointLayer implements MapLayer<NdSymbol> {
             } else if (BitFlags.isAny(symbol.type, NdSymbolTypeFlags.VorDme | NdSymbolTypeFlags.Vor | NdSymbolTypeFlags.Dme | NdSymbolTypeFlags.Ndb)) {
                 this.paintNavaid(true, context, rx, ry, symbol);
             } else if (BitFlags.isAny(symbol.type, NdSymbolTypeFlags.FixInfo | NdSymbolTypeFlags.FlightPlan)) {
-                this.paintFlightPlanWaypoint(true, context, rx, ry, symbol);
+                this.paintFlightPlanWaypoint(true, context, rx, ry, symbol, mapParameters);
             } else {
                 this.paintWaypoint(true, context, rx, ry, symbol);
             }
@@ -129,7 +129,7 @@ export class WaypointLayer implements MapLayer<NdSymbol> {
         PaintUtils.paintText(isColorLayer, context, x + 15, y + 17, symbol.ident, '#ff94ff');
     }
 
-    private paintFlightPlanWaypoint(isColorLayer: boolean, context: CanvasRenderingContext2D, x: number, y: number, symbol: NdSymbol) {
+    private paintFlightPlanWaypoint(isColorLayer: boolean, context: CanvasRenderingContext2D, x: number, y: number, symbol: NdSymbol, mapParameters: MapParameters) {
         const mainColor = symbol.type & NdSymbolTypeFlags.ActiveLegTermination ? '#fff' : '#0f0';
 
         this.paintWaypointShape(context, x, y, isColorLayer ? mainColor : '#000', isColorLayer ? 1.75 : 3.25);
@@ -139,16 +139,18 @@ export class WaypointLayer implements MapLayer<NdSymbol> {
         PaintUtils.paintText(isColorLayer, context, x + 15, y + 17, symbol.ident, mainColor);
 
         if (symbol.type & (NdSymbolTypeFlags.CourseReversalLeft | NdSymbolTypeFlags.CourseReversalRight)) {
-            this.paintCourseReversal(context, x, y, symbol);
+            this.paintCourseReversal(context, x, y, symbol, mapParameters);
         }
     }
 
-    private paintCourseReversal(context: CanvasRenderingContext2D, x: number, y: number, symbol: NdSymbol) {
+    private paintCourseReversal(context: CanvasRenderingContext2D, x: number, y: number, symbol: NdSymbol, mapParameters: MapParameters) {
         const left = symbol.type & (NdSymbolTypeFlags.CourseReversalLeft);
         const arcEnd = left ? -42 : 42;
+        const rotation = mapParameters.rotation(symbol.direction);
         context.strokeStyle = '#fff';
         context.lineWidth = 1.75;
         context.translate(x, y);
+        context.rotate(rotation * MathUtils.DEGREES_TO_RADIANS);
         context.beginPath();
         context.moveTo(arcEnd, 0);
         context.lineTo(arcEnd - 4, -4);

--- a/fbw-a32nx/src/systems/instruments/src/NDv2/shared/map/WaypointLayer.ts
+++ b/fbw-a32nx/src/systems/instruments/src/NDv2/shared/map/WaypointLayer.ts
@@ -13,6 +13,8 @@ import { CanvasMap } from './CanvasMap';
 const VOR_DME_PATH = new Path2D('M -7,0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0 M 0,-15 L 0,-7 M 0,15 L 0,7 M -15,0 L -7,0 M 15,0 L 7,0');
 const DME_PATH = new Path2D('M -7,0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0');
 const NDB_PATH = new Path2D('M -10,10 L 0,-10 L 10,10 L -10,10');
+const COURSE_REVERSAL_ARC_PATH_LEFT = new Path2D('M 0, 0 a 21, 21 0 0 0 -42, 0');
+const COURSE_REVERSAL_ARC_PATH_RIGHT = new Path2D('M 0, 0 a 21, 21 0 0  1 42, 0');
 
 export class WaypointLayer implements MapLayer<NdSymbol> {
     data: NdSymbol[] = [];
@@ -135,6 +137,27 @@ export class WaypointLayer implements MapLayer<NdSymbol> {
         context.font = '21px Ecam';
 
         PaintUtils.paintText(isColorLayer, context, x + 15, y + 17, symbol.ident, mainColor);
+
+        if (symbol.type & (NdSymbolTypeFlags.CourseReversalLeft | NdSymbolTypeFlags.CourseReversalRight)) {
+            this.paintCourseReversal(context, x, y, symbol);
+        }
+    }
+
+    private paintCourseReversal(context: CanvasRenderingContext2D, x: number, y: number, symbol: NdSymbol) {
+        const left = symbol.type & (NdSymbolTypeFlags.CourseReversalLeft);
+        const arcEnd = left ? -42 : 42;
+        context.strokeStyle = '#fff';
+        context.lineWidth = 1.75;
+        context.translate(x, y);
+        context.beginPath();
+        context.moveTo(arcEnd, 0);
+        context.lineTo(arcEnd - 4, -4);
+        context.moveTo(arcEnd, 0);
+        context.lineTo(arcEnd + 4, -4);
+        context.stroke();
+        context.stroke(left ? COURSE_REVERSAL_ARC_PATH_LEFT : COURSE_REVERSAL_ARC_PATH_RIGHT);
+        context.closePath();
+        context.resetTransform();
     }
 
     private paintAirportShape(context: CanvasRenderingContext2D, x: number, y: number, color: string, lineWidth: number) {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This fixes the color of the course reversal arrow so it no longer becomes magenta or amber depending on the vnav constraint prediction at the waypoint

It also fixes the orientation of the arrow since it used to follow the inbound course but no longer does in the current NDv2 implementation. 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before:
![image](https://github.com/flybywiresim/aircraft/assets/5833783/1d4d8c55-d00f-45e0-82b6-1dd00583190b)

After:
![image](https://github.com/flybywiresim/aircraft/assets/5833783/5088cb7e-f3fa-4ab6-b662-c5a2d4092a9b)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): \_chaoz_

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

You can force the course reversal arrow by inserting a hold at a waypoint. 
You need to choose a waypoint with a vnav constraint, or add one yourself.

The prediction will only show on waypoints that are a few waypoints ahead from your current waypoint.

For the orientation, just play with different courses for the hold and the arrow should change accordingly
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
