### PR TITLE
fix(fm): altitude formatting

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -41,6 +41,7 @@
 1. [EFB/FWC] Auto Call Outs selectable - @tracernz (Mike)
 1. [FWC] Added "twenty five hundred" and "two thousand" callouts - @tracernz (Mike)
 1. [FMS] Load procedures that reference a runway correctly - @tracernz (Mike)
+1. [MCDU/ND] Corrected altitude formatting with respect to transition altitude and transition level - @tracernz (Mike)
 
 ## 0.10.0
 

--- a/fbw-a32nx/src/systems/fmgc/src/efis/EfisSymbols.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/efis/EfisSymbols.ts
@@ -396,7 +396,7 @@ export class EfisSymbols {
                     }
 
                     if (efisOption === EfisOption.Constraints && !isFromWp) {
-                        const descent = wp.constraintType === WaypointConstraintType.DES;
+                        const descent = wp.additionalData.constraintType === WaypointConstraintType.DES;
                         switch (wp.legAltitudeDescription) {
                         case 1:
                             constraints.push(formatConstraintAlt(wp.legAltitude1, descent));

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/lnav/legs/TF.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/lnav/legs/TF.ts
@@ -37,7 +37,7 @@ export class TFLeg extends XFLeg {
         this.from = from;
         this.to = to;
         this.segment = segment;
-        this.constraintType = to.constraintType;
+        this.constraintType = to.additionalData.constraintType;
         this.course = Avionics.Utils.computeGreatCircleHeading(
             this.from.infos.coordinates,
             this.to.infos.coordinates,

--- a/fbw-a32nx/src/systems/shared/src/NavigationDisplay.ts
+++ b/fbw-a32nx/src/systems/shared/src/NavigationDisplay.ts
@@ -26,6 +26,7 @@ export enum EfisOption {
 }
 
 export enum NdSymbolTypeFlags {
+    None = 0,
     Vor = 1 << 0,
     VorDme = 1 << 1,
     Ndb = 1 << 2,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8174

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Corrects altitude/flight level formatting with respect to transition altitude and transition level. For constraints we explicitly know their type so we can pick the correct one, but for other altitudes on the MCDU F-PLN page we need to try to guess because VNAV does not provide us this information.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Test some procedures with the transition altitude (PERF TO) and transition level (PERF APPR, labelled as TRANS ALT) set to different altitudes. Make sure the trans alt only affects climb altitudes and the transition level only affects cruise and descent altitudes. See the fixed issue for more context if needed.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
