### PR TITLE
fix(sd): fix apu bleed pressure indication

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -47,6 +47,7 @@
 1. [BLEED] Improve bleed page visuals on the SD - @BlueberryKing (BlueberryKing)
 1. [BLEED] Use more accurate pneumatic valves and sensors - @BlueberryKing (BlueberryKing)
 1. [EFB] flyPad OS 3.2 - Cosmetic changes for throttle configuration settings and support for multiple airframes - @2hwk (2cas)
+1. [SD] Connect SD BLEED page APU bleed pressure indication to correct ADRs - @BlueberryKing (BlueberryKing)
 
 ## 0.10.0
 

--- a/fbw-a32nx/src/systems/instruments/src/SD/Pages/Apu/Apu.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Pages/Apu/Apu.tsx
@@ -144,8 +144,12 @@ const ApuBleed = ({ x, y } : ComponentPositionProps) => {
     const [apuBleedOpen] = useSimVar('L:A32NX_APU_BLEED_AIR_VALVE_OPEN', 'Bool', 1000);
     const [apuBleedPressure] = useSimVar('L:APU_BLEED_PRESSURE', 'PSI', 1000);
     const displayedBleedPressure = Math.round(apuBleedPressure / 2) * 2; // APU bleed pressure is shown in steps of two.
-    const correctedAverageStaticPressure = useArinc429Var('A32NX_ADIRS_ADR_1_CORRECTED_AVERAGE_STATIC_PRESSURE');
+    // This assumes that the SD is displayed by DMC 1, which is the case during normal operation.
+    const [attHdgPosition] = useSimVar('L:A32NX_ATT_HDG_SWITCHING_KNOB', 'Position', 100);
+    const adrSource = attHdgPosition === 0 ? 3 : 1;
+    const correctedAverageStaticPressure = useArinc429Var(`L:A32NX_ADIRS_ADR_${adrSource}_CORRECTED_AVERAGE_STATIC_PRESSURE`, 100);
     const apuN = useArinc429Var('L:A32NX_APU_N', 100);
+
     useEffect(() => {
         if (apuBleedPbOn) {
             const timeout = setTimeout(() => {
@@ -157,6 +161,7 @@ const ApuBleed = ({ x, y } : ComponentPositionProps) => {
 
         return () => {};
     }, [apuBleedPbOn]);
+
     // FIXME should be APU bleed absolute pressure label from SDAC
     const apuBleedPressAvailable = apuN.isNormalOperation() && correctedAverageStaticPressure.isNormalOperation();
     return (


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8198
Fixes #8001

## Summary of Changes
It seems an `L:` prefix before an LVar access was lost in #8118. This caused the APU bleed pressure reading to be shown as 'XX'. This also checks the correct ADR depending on the position of the ATT/HDG switching knob.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BlueberryKing

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
When the APU is running, ensure that the APU bleed pressure indication is only 'XX' when
- The ATT/HDG switching knob is in the NORM or F/O position and ADR 1 is off
OR
- The ATT/HDG switching knob is in the CAPT position and ADR 3 is off.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
