### PR TITLE
fix(payload): workaround broken gsx turnarounds and bus deboarding

### DIFF
--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/payload/test.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/payload/test.rs
@@ -215,7 +215,6 @@ impl BoardingTestBed {
             max_pax += test_bed().query(|a| a.max_pax(ps)) as i32;
         }
         self.write_by_name("FSDT_GSX_NUMPASSENGERS_BOARDING_TOTAL", max_pax / 2);
-        self.write_by_name("FSDT_GSX_NUMPASSENGERS_TOTAL", max_pax / 2);
         self
     }
 
@@ -225,13 +224,11 @@ impl BoardingTestBed {
             max_pax += test_bed().query(|a| a.max_pax(ps)) as i32;
         }
         self.write_by_name("FSDT_GSX_NUMPASSENGERS_BOARDING_TOTAL", max_pax);
-        self.write_by_name("FSDT_GSX_NUMPASSENGERS_TOTAL", max_pax);
         self
     }
 
-    fn deboard_gsx_pax_from(mut self, pax_deboard: i32, boarded: i32) -> Self {
+    fn deboard_gsx_pax(mut self, pax_deboard: i32) -> Self {
         self.write_by_name("FSDT_GSX_NUMPASSENGERS_DEBOARDING_TOTAL", pax_deboard);
-        self.write_by_name("FSDT_GSX_NUMPASSENGERS_TOTAL", boarded);
         self
     }
 
@@ -1467,7 +1464,7 @@ fn gsx_deboarding_initial_state() {
         .gsx_requested_deboard_state()
         .and_run()
         .gsx_performing_deboard_state()
-        .deboard_gsx_pax_from(10, 100)
+        .deboard_gsx_pax(10)
         .and_run();
 
     // Check that pax moves and cargo remain the same when GSX has started performing
@@ -1492,11 +1489,11 @@ fn gsx_deboarding_full_pax() {
         .gsx_requested_deboard_state()
         .and_run()
         .gsx_performing_deboard_state()
-        .deboard_gsx_pax_from(87, 174)
+        .deboard_gsx_pax(87)
         .deboard_gsx_cargo_half()
         .and_run()
         .and_stabilize()
-        .deboard_gsx_pax_from(174, 174)
+        .deboard_gsx_pax(174)
         .deboard_gsx_cargo_full()
         .and_run()
         .gsx_complete_deboard_state();
@@ -1521,11 +1518,11 @@ fn gsx_deboarding_half_pax() {
         .gsx_requested_deboard_state()
         .and_run()
         .gsx_performing_deboard_state()
-        .deboard_gsx_pax_from(0, 87)
+        .deboard_gsx_pax(0)
         .deboard_gsx_cargo_half()
         .and_run()
         .and_stabilize()
-        .deboard_gsx_pax_from(87, 87)
+        .deboard_gsx_pax(87)
         .deboard_gsx_cargo_full()
         .and_run()
         .gsx_complete_deboard_state();
@@ -1560,7 +1557,7 @@ fn gsx_deboarding_full_pax_partial() {
 
     // SET GSX values to half and run
     let mut test_bed = test_bed
-        .deboard_gsx_pax_from(87, 174)
+        .deboard_gsx_pax(87)
         .deboard_gsx_cargo_half()
         .and_run()
         .and_stabilize();
@@ -1569,7 +1566,7 @@ fn gsx_deboarding_full_pax_partial() {
     test_bed.has_half_cargo();
 
     let mut test_bed = test_bed
-        .deboard_gsx_pax_from(0, 174)
+        .deboard_gsx_pax(0)
         .deboard_gsx_cargo_full()
         .and_run()
         .and_stabilize()

--- a/fbw-a32nx/src/wasm/systems/a320_systems_wasm/src/lib.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems_wasm/src/lib.rs
@@ -333,7 +333,6 @@ async fn systems(mut gauge: msfs::Gauge) -> Result<(), Box<dyn Error>> {
     .provides_aircraft_variable("PAYLOAD STATION WEIGHT", "Pounds", 8)?
     .provides_named_variable("FSDT_GSX_BOARDING_STATE")?
     .provides_named_variable("FSDT_GSX_DEBOARDING_STATE")?
-    .provides_named_variable("FSDT_GSX_NUMPASSENGERS_TOTAL")?
     .provides_named_variable("FSDT_GSX_NUMPASSENGERS_BOARDING_TOTAL")?
     .provides_named_variable("FSDT_GSX_NUMPASSENGERS_DEBOARDING_TOTAL")?
     .provides_named_variable("FSDT_GSX_BOARDING_CARGO_PERCENT")?

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/payload/test.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/payload/test.rs
@@ -217,7 +217,6 @@ impl BoardingTestBed {
             max_pax += test_bed().query(|a| a.max_pax(ps)) as i32;
         }
         self.write_by_name("FSDT_GSX_NUMPASSENGERS_BOARDING_TOTAL", max_pax / 2);
-        self.write_by_name("FSDT_GSX_NUMPASSENGERS_TOTAL", max_pax / 2);
         self
     }
 
@@ -227,19 +226,11 @@ impl BoardingTestBed {
             max_pax += test_bed().query(|a| a.max_pax(ps)) as i32;
         }
         self.write_by_name("FSDT_GSX_NUMPASSENGERS_BOARDING_TOTAL", max_pax);
-        self.write_by_name("FSDT_GSX_NUMPASSENGERS_TOTAL", max_pax);
         self
     }
 
-    fn deboard_gsx_pax_from(mut self, pax_deboard: i32, boarded: i32) -> Self {
+    fn deboard_gsx_pax(mut self, pax_deboard: i32) -> Self {
         self.write_by_name("FSDT_GSX_NUMPASSENGERS_DEBOARDING_TOTAL", pax_deboard);
-        self.write_by_name("FSDT_GSX_NUMPASSENGERS_TOTAL", boarded);
-        self
-    }
-
-    #[allow(dead_code)]
-    fn deboard_gsx_pax_num(mut self, value: i32) -> Self {
-        self.write_by_name("FSDT_GSX_NUMPASSENGERS_DEBOARDING_TOTAL", value);
         self
     }
 
@@ -1627,7 +1618,7 @@ fn gsx_deboarding_initial_state() {
         .gsx_requested_deboard_state()
         .and_run()
         .gsx_performing_deboard_state()
-        .deboard_gsx_pax_from(10, 100)
+        .deboard_gsx_pax(10)
         .and_run();
 
     // Check that pax moves and cargo remain the same when GSX has started performing
@@ -1652,11 +1643,11 @@ fn gsx_deboarding_full_pax() {
         .gsx_requested_deboard_state()
         .and_run()
         .gsx_performing_deboard_state()
-        .deboard_gsx_pax_from(259, 519)
+        .deboard_gsx_pax(259)
         .deboard_gsx_cargo_half()
         .and_run()
         .and_stabilize()
-        .deboard_gsx_pax_from(519, 519)
+        .deboard_gsx_pax(519)
         .deboard_gsx_cargo_full()
         .and_run()
         .gsx_complete_deboard_state();
@@ -1681,11 +1672,11 @@ fn gsx_deboarding_half_pax() {
         .gsx_requested_deboard_state()
         .and_run()
         .gsx_performing_deboard_state()
-        .deboard_gsx_pax_from(0, 259)
+        .deboard_gsx_pax(0)
         .deboard_gsx_cargo_half()
         .and_run()
         .and_stabilize()
-        .deboard_gsx_pax_from(259, 259)
+        .deboard_gsx_pax(259)
         .deboard_gsx_cargo_full()
         .and_run()
         .gsx_complete_deboard_state();

--- a/fbw-a380x/src/wasm/systems/a380_systems_wasm/src/lib.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems_wasm/src/lib.rs
@@ -345,7 +345,6 @@ async fn systems(mut gauge: msfs::Gauge) -> Result<(), Box<dyn Error>> {
     .provides_aircraft_variable("PAYLOAD STATION WEIGHT", "Pounds", 18)?
     .provides_named_variable("FSDT_GSX_BOARDING_STATE")?
     .provides_named_variable("FSDT_GSX_DEBOARDING_STATE")?
-    .provides_named_variable("FSDT_GSX_NUMPASSENGERS_TOTAL")?
     .provides_named_variable("FSDT_GSX_NUMPASSENGERS_BOARDING_TOTAL")?
     .provides_named_variable("FSDT_GSX_NUMPASSENGERS_DEBOARDING_TOTAL")?
     .provides_named_variable("FSDT_GSX_BOARDING_CARGO_PERCENT")?

--- a/fbw-common/src/wasm/systems/systems/src/payload/mod.rs
+++ b/fbw-common/src/wasm/systems/systems/src/payload/mod.rs
@@ -1237,7 +1237,7 @@ impl GsxDriver {
                 self.performing_board = false;
             }
             GsxState::Completed => {
-                if (self.performing_board) {
+                if self.performing_board {
                     passenger_deck.spawn_all_pax();
                     cargo_deck.spawn_all_cargo();
                 }
@@ -1269,7 +1269,7 @@ impl GsxDriver {
                 self.performing_deboard = false;
             }
             GsxState::Completed => {
-                if (self.performing_deboard) {
+                if self.performing_deboard {
                     passenger_deck.spawn_all_pax();
                     cargo_deck.spawn_all_cargo();
                     cargo_deck.reset_cargo_loaded();


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #7972

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Fixes passenger and cargo loading behavior on turnaround when using GSX caused by several GSX variables returning unexpected data
- Workaround deboarding using buses with GSX causing plane to instantly deboard after the first bus

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
You will need GSX to test this PR
- Do a full boarding of the plane with GSX (Request boarding, etc) using a jetway
- Do a full deboarding of the plane with GSX (Request deboarding, etc) ) using a jetway
- (Turnaround, do not go back to the main menu and reload the flight) Do a full boarding of the plane with GSX using multiple buses
- Do a full deboarding of the plane with GSX using multiple buses

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
