### PR TITLE
fix(mcdu): improve PERF pages

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -188,7 +188,8 @@
 1. [EFB] Added pause at T/D function - @2hwk (2Cas#1022)
 1. [LIGHTS] Fixed trim decal emissive and floods - @FinalLightNL (FinalLight#2113)
 1. [FLIGHTMODEL/FUEL] Fix outer tank transfer behaviour - @donstim (donbikes#4084)
-
+1. [FMS] Improve layout of PERF CLB, PERF CRZ and PERF DES pages according to H3 - @BlueberryKing (BlueberryKing)
+1. [FMS] Implement CHECK SPEED MODE message - @BlueberryKing (BlueberryKing)
 
 ## 0.9.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 1. [EFB/ATSU] Added NOAA (aviationweather.gov) as a METAR source - @tracernz (Mike)
 1. [EFB] Fixed the main page and landing calculator to use the selected METAR source - @tracernz (Mike)
+1. [FMS] Improve layout of PERF CLB, PERF CRZ and PERF DES pages according to H3 - @BlueberryKing (BlueberryKing)
+1. [FMS] Implement CHECK SPEED MODE message - @BlueberryKing (BlueberryKing)
 
 ## 0.11.0
 
@@ -188,8 +190,6 @@
 1. [EFB] Added pause at T/D function - @2hwk (2Cas#1022)
 1. [LIGHTS] Fixed trim decal emissive and floods - @FinalLightNL (FinalLight#2113)
 1. [FLIGHTMODEL/FUEL] Fix outer tank transfer behaviour - @donstim (donbikes#4084)
-1. [FMS] Improve layout of PERF CLB, PERF CRZ and PERF DES pages according to H3 - @BlueberryKing (BlueberryKing)
-1. [FMS] Implement CHECK SPEED MODE message - @BlueberryKing (BlueberryKing)
 
 ## 0.9.0
 

--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -1383,6 +1383,10 @@ These variables are the interface between the 3D model and the systems/code.
     - Bool
     - Indicates if the T/D REACHED message is shown on the PFD
 
+- A32NX_PFD_MSG_CHECK_SPEED_MODE
+    - Bool
+    - Indicates if the CHECK SPEED MODE message is shown on the PFD
+
 - A32NX_PFD_LINEAR_DEVIATION_ACTIVE
     - Bool
     - Indicates if the linear deviation is shown on the PFD

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Utils/NXSystemMessages.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Utils/NXSystemMessages.js
@@ -64,6 +64,7 @@ const NXSystemMessages = {
     awyWptMismatch:         new TypeIMessage("AWY/WPT MISMATCH"),
     cancelAtisUpdate:       new TypeIMessage("CANCEL UPDATE BEFORE"),
     checkMinDestFob:        new TypeIIMessage("CHECK MIN DEST FOB"),
+    checkSpeedMode:         new TypeIIMessage("CHECK SPEED MODE"),
     checkToData:            new TypeIIMessage("CHECK TAKE OFF DATA", true),
     checkWeight:            new TypeIIMessage("CHECK WEIGHT", true),
     comUnavailable:         new TypeIMessage("COM UNAVAILABLE"),

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -682,7 +682,11 @@ class CDUPerformancePage {
         const econDesMachPilotEntered = mcdu.managedSpeedDescendMachPilot !== undefined;
         const econDesMach = econDesMachPilotEntered ? mcdu.managedSpeedDescendMachPilot : mcdu.managedSpeedDescendMach;
 
-        const managedDescentSpeedCell = `{${econDesMachPilotEntered ? "big" : "small"}}${econDesMach !== undefined ? econDesMach.toFixed(2).replace("0.", ".") : "---"}{end}/{${econDesPilotEntered ? "big" : "small"}}${econDes !== undefined ? econDes.toFixed(0) : "---"}{end}[color]cyan`;
+        const managedDescentSpeedCellMach = `{${econDesMachPilotEntered ? "big" : "small"}}${econDesMach !== undefined ? econDesMach.toFixed(2).replace("0.", ".") : "---"}{end}`;
+        const managedDescentSpeedCellSpeed = `{${econDesPilotEntered ? "big" : "small"}}${econDes !== undefined ? econDes.toFixed(0) : "---"}{end}`;
+        const managedDescentSpeedCellSlash = `{${(econDesMachPilotEntered || econDesPilotEntered) ? "big" : "small"}}/{end}`;
+
+        const managedDescentSpeedCell = `${managedDescentSpeedCellMach}${managedDescentSpeedCellSlash}${managedDescentSpeedCellSpeed}[color]cyan`;
 
         const [selectedSpeedTitle, selectedSpeedCell] = CDUPerformancePage.getDesSelectedTitleAndValue(mcdu, isPhaseActive, isSelected);
         const timeLabel = isFlying ? "\xa0UTC" : "TIME";

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -696,14 +696,13 @@ class CDUPerformancePage {
         const econDesMach = econDesMachPilotEntered ? mcdu.managedSpeedDescendMachPilot : mcdu.managedSpeedDescendMach;
 
         // TODO: Figure out correct condition
-        const showManagedSpeed = hasFromToPair && mcdu.costIndexSet && Number.isFinite(mcdu.costIndex);
-        const managedDescentSpeedCellMach = `{${econDesMachPilotEntered ? "big" : "small"}}${econDesMach !== undefined ? econDesMach.toFixed(2).replace("0.", ".") : "---"}{end}`;
-        const managedDescentSpeedCellSpeed = `{${econDesPilotEntered ? "big" : "small"}}${econDes !== undefined ? econDes.toFixed(0) : "---"}{end}`;
-        const managedDescentSpeedCellSlash = `{${(econDesMachPilotEntered || econDesPilotEntered) ? "big" : "small"}}/{end}`;
+        const showManagedSpeed = hasFromToPair && mcdu.costIndexSet && Number.isFinite(mcdu.costIndex) && econDesMach !== undefined && econDes !== undefined;
+        const managedDescentSpeedCellMach = `{${econDesMachPilotEntered ? "big" : "small"}}${econDesMach.toFixed(2).replace("0.", ".")}{end}`;
+        const managedDescentSpeedCellSpeed = `{${econDesPilotEntered ? "big" : "small"}}/${econDes.toFixed(0)}{end}`;
 
         const managedDescentSpeedCell = showManagedSpeed
-            ? `\xa0${managedDescentSpeedCellMach}${managedDescentSpeedCellSlash}${managedDescentSpeedCellSpeed}[color]cyan`
-            : "{small}\xa0---/---{end}[color]white";
+            ? `\xa0${managedDescentSpeedCellMach}${managedDescentSpeedCellSpeed}[color]cyan`
+            : "\xa0{small}---/---{end}[color]white";
 
         const [selectedSpeedTitle, selectedSpeedCell] = CDUPerformancePage.getDesSelectedTitleAndValue(mcdu, isPhaseActive, isSelected);
         const timeLabel = isFlying ? "\xa0UTC" : "TIME";

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -552,7 +552,7 @@ class CDUPerformancePage {
             if (hasPreselectedSpeedOrMach) {
                 preselCell = `\xa0${mcdu.preSelectedCrzSpeed < 1 ? mcdu.preSelectedCrzSpeed.toFixed(2).replace("0.", ".") : mcdu.preSelectedCrzSpeed.toFixed(0)}[color]cyan`;
             } else {
-                preselCell = "*[ ][color]cyan";
+                preselCell = "{small}*{end}[ ][color]cyan";
             }
         }
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -408,14 +408,14 @@ class CDUPerformancePage {
         let managedSpeedCell = '';
         if (isPhaseActive) {
             if (mcdu.managedSpeedTarget === mcdu.managedSpeedClimb) {
-                managedSpeedCell = `{small}${mcdu.managedSpeedClimb.toFixed(0)}/${mcdu.managedSpeedClimbMach.toFixed(2).replace('0.', '.')}{end}`;
-            } else if (Simplane.getAutoPilotMachModeActive() || SimVar.GetSimVarValue('K:AP_MANAGED_SPEED_IN_MACH_ON', 'Bool')) {
-                managedSpeedCell = `{small}${mcdu.managedSpeedClimbMach.toFixed(2).replace('0.', '.')}{end}`;
+                managedSpeedCell = `\xa0${mcdu.managedSpeedClimb.toFixed(0)}/${mcdu.managedSpeedClimbMach.toFixed(2).replace('0.', '.')}`;
+            } else if (mcdu.managedSpeedTargetIsMach) {
+                managedSpeedCell = `\xa0${mcdu.managedSpeedClimbMach.toFixed(2).replace('0.', '.')}`;
             } else {
-                managedSpeedCell = `{small}${mcdu.managedSpeedTarget.toFixed(0)}{end}`;
+                managedSpeedCell = `\xa0${mcdu.managedSpeedTarget.toFixed(0)}`;
             }
         } else {
-            managedSpeedCell = `${canClickManagedSpeed ? '*' : ''}${mcdu.managedSpeedClimb > mcdu.climbSpeedLimit ? mcdu.climbSpeedLimit.toFixed(0) : mcdu.managedSpeedClimb.toFixed(0)}`;
+            managedSpeedCell = `${canClickManagedSpeed ? '*' : '\xa0'}${mcdu.managedSpeedClimb > mcdu.climbSpeedLimit ? mcdu.climbSpeedLimit.toFixed(0) : mcdu.managedSpeedClimb.toFixed(0)}`;
 
             mcdu.onLeftInput[3] = (value, scratchpadCallback) => {
                 if (mcdu.trySetPreSelectedClimbSpeed(value)) {
@@ -425,7 +425,7 @@ class CDUPerformancePage {
                 }
             };
         }
-        const [selectedSpeedTitle, selectedSpeedCell] = CDUPerformancePage.getSelectedTitleAndValue(isPhaseActive, isSelected, mcdu.preSelectedClbSpeed);
+        const [selectedSpeedTitle, selectedSpeedCell] = CDUPerformancePage.getClbSelectedTitleAndValue(mcdu, isPhaseActive, isSelected, mcdu.preSelectedClbSpeed);
         mcdu.onLeftInput[1] = (value, scratchpadCallback) => {
             if (mcdu.tryUpdateCostIndex(value)) {
                 CDUPerformancePage.ShowCLBPage(mcdu);
@@ -492,9 +492,9 @@ class CDUPerformancePage {
             ["CI"],
             [`${costIndexCell}[color]cyan`, predToCell, predToLabel],
             ["MANAGED", toDistLabel, toUtcLabel],
-            [`\xa0${managedSpeedCell}[color]green`, !isSelected ? predToDistanceCell : "", !isSelected ? predToTimeCell : ""],
-            [`${selectedSpeedTitle}`],
-            [`${selectedSpeedCell}`, isSelected ? predToDistanceCell : "", isSelected ? predToTimeCell : ""],
+            [`{small}${managedSpeedCell}{end}[color]green`, !isSelected ? predToDistanceCell : "", !isSelected ? predToTimeCell : ""],
+            [selectedSpeedTitle],
+            [selectedSpeedCell, isSelected ? predToDistanceCell : "", isSelected ? predToTimeCell : ""],
             [""],
             isPhaseActive ? ["{small}EXPEDITE{end}[color]green", expeditePredToDistanceCell, expeditePredToTimeCell] : [""],
             bottomRowLabels,
@@ -527,7 +527,7 @@ class CDUPerformancePage {
         let managedSpeedCell = "---/---";
         if (Number.isFinite(mcdu.cruiseFlightLevel) && Number.isFinite(mcdu.managedSpeedCruise) && Number.isFinite(mcdu.managedSpeedCruiseMach)) {
             const shouldShowCruiseMach = mcdu.cruiseFlightLevel > 250;
-            managedSpeedCell = `${canClickManagedSpeed ? "*" : ""}${shouldShowCruiseMach ? mcdu.managedSpeedCruiseMach.toFixed(2).replace("0.", ".") : mcdu.managedSpeedCruise.toFixed(0)}[color]green`;
+            managedSpeedCell = `{small}${canClickManagedSpeed ? "*" : "\xa0"}${shouldShowCruiseMach ? mcdu.managedSpeedCruiseMach.toFixed(2).replace("0.", ".") : mcdu.managedSpeedCruise.toFixed(0)}{end}[color]green`;
         }
         const preselTitle = isPhaseActive ? "" : "PRESEL";
         let preselCell = "";
@@ -621,7 +621,7 @@ class CDUPerformancePage {
             ["CI"],
             [`${costIndexCell}[color]cyan`, toReasonCell],
             ["MANAGED", toDistLabel, toUtcLabel],
-            [`\xa0${managedSpeedCell}`, toDistCell, toTimeCell],
+            [managedSpeedCell, toDistCell, toTimeCell],
             [preselTitle, "DES CABIN RATE"],
             [preselCell, `\xa0{cyan}${desCabinRateCell}{end}{white}{small}FT/MN{end}{end}`],
             [""],
@@ -679,8 +679,7 @@ class CDUPerformancePage {
 
         const managedDescentSpeedCell = `{${econDesMachPilotEntered ? "big" : "small"}}${econDesMach !== undefined ? econDesMach.toFixed(2).replace("0.", ".") : "---"}{end}/{${econDesPilotEntered ? "big" : "small"}}${econDes !== undefined ? econDes.toFixed(0) : "---"}{end}[color]cyan`;
 
-        // The way the arguments are supplied here is a hack to display the correct things
-        const [selectedSpeedTitle, selectedSpeedCell] = CDUPerformancePage.getSelectedTitleAndValue(true, isPhaseActive && isSelected, 0);
+        const [selectedSpeedTitle, selectedSpeedCell] = CDUPerformancePage.getDesSelectedTitleAndValue(mcdu, isPhaseActive, isSelected);
         const timeLabel = isFlying ? "\xa0UTC" : "TIME";
         const [destEfobCell, destTimeCell] = CDUPerformancePage.formatDestEfobAndTime(mcdu, isFlying);
         const [toUtcLabel, toDistLabel] = isPhaseActive ? ["\xa0UTC", "DIST"] : ["", ""];
@@ -746,8 +745,8 @@ class CDUPerformancePage {
             [costIndexCell, predToCell, predToLabel],
             ["MANAGED", toDistLabel, toUtcLabel],
             [`\xa0${managedDescentSpeedCell}[color]cyan`, !isSelected ? predToDistanceCell : "", !isSelected ? predToTimeCell : ""],
-            [`\xa0${selectedSpeedTitle}`],
-            [`\xa0${selectedSpeedCell}`, isSelected ? predToDistanceCell : "", isSelected ? predToTimeCell : ""],
+            [selectedSpeedTitle],
+            [selectedSpeedCell, isSelected ? predToDistanceCell : "", isSelected ? predToTimeCell : ""],
             [""],
             [""],
             bottomRowLabels,
@@ -1089,17 +1088,48 @@ class CDUPerformancePage {
         ]);
     }
 
-    static getSelectedTitleAndValue(_isPhaseActive, _isSelected, _preSel) {
-        if (_isPhaseActive) {
-            return _isSelected
-                ? ["SELECTED", "\xa0" + Math.round(Simplane.getAutoPilotMachModeActive()
-                    ? SimVar.GetGameVarValue('FROM MACH TO KIAS', 'number', Simplane.getAutoPilotMachHoldValue())
-                    : Simplane.getAutoPilotAirspeedHoldValue()) + "[color]green"]
-                : ["", ""];
+    static getClbSelectedTitleAndValue(mcdu, isPhaseActive, isSelected, preSel) {
+        if (!isPhaseActive) {
+            return ["PRESEL", (isFinite(preSel) ? "\xa0" + preSel : "*[ ]") + "[color]cyan"];
+        }
+
+        if (!isSelected) {
+            return ["", ""];
+        }
+
+        const aircraftAltitude = SimVar.GetSimVarValue('INDICATED ALTITUDE', 'feet');
+        const selectedSpdMach = SimVar.GetSimVarValue('L:A32NX_AUTOPILOT_SPEED_SELECTED', 'number');
+
+        if (selectedSpdMach < 1) {
+            return ["SELECTED", `\xa0${selectedSpdMach.toFixed(2).replace('0.', '.')}[color]green`];
         } else {
-            return ["PRESEL", (isFinite(_preSel) ? "" + _preSel : "*[ ]") + "[color]cyan"];
+            const machAtManualCrossoverAlt = mcdu.casToMachManualCrossoverCurve.evaluate(selectedSpdMach)
+            const manualCrossoverAltitude = mcdu.computeManualCrossoverAltitude(machAtManualCrossoverAlt);
+            const shouldShowMach = aircraftAltitude < manualCrossoverAltitude && (!mcdu._cruiseEntered || !mcdu.cruiseFlightLevel || manualCrossoverAltitude < mcdu.cruiseFlightLevel * 100);
+
+            return ["SELECTED", `\xa0${Math.round(selectedSpdMach)}${shouldShowMach ? ("{small}/" + machAtManualCrossoverAlt.toFixed(2).replace('0.', '.') + "{end}") : ""}[color]green`];
         }
     }
+
+    static getDesSelectedTitleAndValue(mcdu, isPhaseActive, isSelected) {
+        if (!isPhaseActive || !isSelected) {
+            return ["", ""];
+        }
+
+        const aircraftAltitude = SimVar.GetSimVarValue('INDICATED ALTITUDE', 'feet');
+        const selectedSpdMach = SimVar.GetSimVarValue('L:A32NX_AUTOPILOT_SPEED_SELECTED', 'number');
+
+        if (selectedSpdMach < 1) {
+            const casAtCrossoverAltitude = mcdu.machToCasManualCrossoverCurve.evaluate(selectedSpdMach);
+            const manualCrossoverAltitude = mcdu.computeManualCrossoverAltitude(selectedSpdMach);
+            const shouldShowCas = aircraftAltitude > manualCrossoverAltitude;
+
+            return ["SELECTED", `\xa0${shouldShowCas ? "{small}" + Math.round(casAtCrossoverAltitude) + "/{end}" : ""}${selectedSpdMach.toFixed(2).replace('0.', '.')}[color]green`];
+        } else {
+            return ["SELECTED", `\xa0${Math.round(selectedSpdMach)}[color]green`];
+        }
+    }
+
     static formatAltitudeOrLevel(altitudeToFormat, transitionAltitude) {
         if (transitionAltitude >= 100 && altitudeToFormat > transitionAltitude) {
             return `FL${(altitudeToFormat / 100).toFixed(0).toString().padStart(3,"0")}`;

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -415,7 +415,12 @@ class CDUPerformancePage {
                 managedSpeedCell = `\xa0${mcdu.managedSpeedTarget.toFixed(0)}`;
             }
         } else {
-            managedSpeedCell = `${canClickManagedSpeed ? '*' : '\xa0'}${mcdu.managedSpeedClimb > mcdu.climbSpeedLimit ? mcdu.climbSpeedLimit.toFixed(0) : mcdu.managedSpeedClimb.toFixed(0)}`;
+            let climbSpeed = Math.min(mcdu.managedSpeedClimb, mcdu.getNavModeSpeedConstraint());
+            if (mcdu.climbSpeedLimit !== undefined && SimVar.GetSimVarValue("INDICATED ALTITUDE", "feet") < mcdu.climbSpeedLimitAlt) {
+                climbSpeed = Math.min(climbSpeed, mcdu.climbSpeedLimit);
+            }
+
+            managedSpeedCell = `${canClickManagedSpeed ? '*' : '\xa0'}${climbSpeed.toFixed(0)}`;
 
             mcdu.onLeftInput[3] = (value, scratchpadCallback) => {
                 if (mcdu.trySetPreSelectedClimbSpeed(value)) {

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -3738,7 +3738,8 @@ class FMCMainDisplay extends BaseAirliners {
             return true;
         }
 
-        if (s.includes(".")) {
+        const SPD_REGEX = /\d{1,3}/;
+        if (s.match(SPD_REGEX) === null) {
             this.setScratchpadMessage(NXSystemMessages.formatError);
             return false;
         }
@@ -3749,7 +3750,7 @@ class FMCMainDisplay extends BaseAirliners {
             return false
         }
 
-        if (spd < 100 && spd > 350) {
+        if (spd < 100 || spd > 350) {
             this.setScratchpadMessage(NXSystemMessages.entryOutOfRange);
             return false;
         }
@@ -3770,6 +3771,12 @@ class FMCMainDisplay extends BaseAirliners {
                 this.updatePreSelSpeedMach(undefined);
             }
             return true;
+        }
+
+        const MACH_OR_SPD_REGEX = /^(\.\d{1,2}|\d{1,3})$/;
+        if (s.match(MACH_OR_SPD_REGEX) === null) {
+            this.setScratchpadMessage(NXSystemMessages.formatError);
+            return false;
         }
 
         const v = parseFloat(s);
@@ -5114,8 +5121,8 @@ class FMCMainDisplay extends BaseAirliners {
             return true;
         }
 
-        const regex = /^(\.\d{1,2})?\/(\d{3})?$/;
-        const match = value.match(regex)
+        const MACH_SLASH_SPD_REGEX = /^(\.\d{1,2})?\/(\d{3})?$/;
+        const match = value.match(MACH_SLASH_SPD_REGEX);
 
         if (match !== null) {
             const speed = parseInt(match[2]);

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -1495,6 +1495,10 @@ class FMCMainDisplay extends BaseAirliners {
             return Infinity;
         }
 
+        return this.getNavModeSpeedConstraint();
+    }
+
+    getNavModeSpeedConstraint() {
         const activeLegIndex = this.guidanceController.activeTransIndex >= 0 ? this.guidanceController.activeTransIndex : this.guidanceController.activeLegIndex;
         const constraints = this.managedProfile.get(activeLegIndex);
         if (constraints) {

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -270,8 +270,8 @@ class FMCMainDisplay extends BaseAirliners {
         this.casToMachManualCrossoverCurve.add(300, 0.8);
         this.casToMachManualCrossoverCurve.add(350, 0.82);
 
-        // This is used to determine the Mach number corresponding to a CAS at the manual crossover altitude
-        // The curve was calculated numerically and approximated using a few interpolated values
+        // This is used to determine the CAS corresponding to a Mach number at the manual crossover altitude
+        // Effectively, the manual crossover altitude is FL305 up to M.80, then decreases linearly to the crossover altitude of (VMO, MMO)
         this.machToCasManualCrossoverCurve = new Avionics.Curve();
         this.machToCasManualCrossoverCurve.interpolationFunction = Avionics.CurveTool.NumberInterpolation;
         this.machToCasManualCrossoverCurve.add(0, 0);
@@ -5121,6 +5121,7 @@ class FMCMainDisplay extends BaseAirliners {
             const speed = parseInt(match[2]);
             if (Number.isFinite(speed)) {
                 if (speed < 100 || speed > 350) {
+                    this.setScratchpadText(NXSystemMessages.entryOutOfRange);
                     return false;
                 }
 
@@ -5130,6 +5131,7 @@ class FMCMainDisplay extends BaseAirliners {
             const mach = Math.round(parseFloat(match[1]) * 1000) / 1000;
             if (Number.isFinite(mach)) {
                 if (mach < 0.15 || mach > 0.82) {
+                    this.setScratchpadText(NXSystemMessages.entryOutOfRange);
                     return false
                 }
 
@@ -5141,10 +5143,13 @@ class FMCMainDisplay extends BaseAirliners {
             const speed = parseInt(value);
             if (Number.isFinite(speed)) {
                 if (speed < 100 || speed > 350) {
+                    this.setScratchpadText(NXSystemMessages.entryOutOfRange);
                     return false;
                 }
 
-                const mach = this.casToMachManualCrossoverCurve.evaluate(speed)
+                // This is the maximum managed Mach number you can get, even with CI 100.
+                // Through direct testing by a pilot, it was also determined that the plane gives Mach 0.80 for all of the tested CAS entries.
+                const mach = 0.8;
 
                 this.managedSpeedDescendPilot = speed;
                 this.managedSpeedDescendMachPilot = mach;
@@ -5153,6 +5158,7 @@ class FMCMainDisplay extends BaseAirliners {
             }
         }
 
+        this.setScratchpadText(NXSystemMessages.formatError);
         return false;
     }
 

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/GuidanceController.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/GuidanceController.ts
@@ -47,7 +47,6 @@ export interface Fmgc {
     getDescentSpeedLimit(): SpeedLimit,
     getPreSelectedClbSpeed(): Knots,
     getPreSelectedCruiseSpeed(): Knots,
-    getPreSelectedDescentSpeed(): Knots,
     getTakeoffFlapsSetting(): FlapConf | undefined
     getManagedDescentSpeed(): Knots,
     getManagedDescentSpeedMach(): Mach,

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VerticalProfileComputationParameters.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VerticalProfileComputationParameters.ts
@@ -44,7 +44,6 @@ export interface VerticalProfileComputationParameters {
     flightPhase: FmgcFlightPhase,
     preselectedClbSpeed: Knots,
     preselectedCruiseSpeed: Knots,
-    preselectedDescentSpeed: Knots,
     takeoffFlapsSetting?: FlapConf
     estimatedDestinationFuel: Pounds,
 
@@ -106,7 +105,6 @@ export class VerticalProfileComputationParametersObserver {
             flightPhase: this.fmgc.getFlightPhase(),
             preselectedClbSpeed: this.fmgc.getPreSelectedClbSpeed(),
             preselectedCruiseSpeed: this.fmgc.getPreSelectedCruiseSpeed(),
-            preselectedDescentSpeed: this.fmgc.getPreSelectedDescentSpeed(),
             takeoffFlapsSetting: this.fmgc.getTakeoffFlapsSetting(),
             estimatedDestinationFuel: UnitType.TONNE.convertTo(this.fmgc.getDestEFOB(false), UnitType.POUND),
 

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/climb/SpeedProfile.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/climb/SpeedProfile.ts
@@ -86,16 +86,15 @@ export class McduSpeedProfile implements SpeedProfile {
     }
 
     getTarget(distanceFromStart: NauticalMiles, altitude: Feet, managedSpeedType: ManagedSpeedType): Knots {
-        const { fcuSpeed, flightPhase, preselectedClbSpeed, preselectedCruiseSpeed, preselectedDescentSpeed } = this.parameters.get();
+        const { fcuSpeed, flightPhase, preselectedClbSpeed, preselectedCruiseSpeed } = this.parameters.get();
 
         let preselectedSpeed = -1;
         if (flightPhase < FmgcFlightPhase.Climb && preselectedClbSpeed > 100) {
             preselectedSpeed = preselectedClbSpeed;
         } else if (flightPhase < FmgcFlightPhase.Cruise && preselectedCruiseSpeed > 100) {
             preselectedSpeed = preselectedCruiseSpeed;
-        } else if (flightPhase < FmgcFlightPhase.Descent && preselectedDescentSpeed > 100) {
-            preselectedSpeed = preselectedDescentSpeed;
         }
+
         const hasPreselectedSpeed = preselectedSpeed > 0;
 
         const isPredictingForCurrentPhase = managedSpeedType === ManagedSpeedType.Climb && flightPhase === FmgcFlightPhase.Climb

--- a/fbw-a32nx/src/systems/instruments/src/PFD/FMA.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/FMA.tsx
@@ -56,6 +56,8 @@ export class FMA extends DisplayComponent<{ bus: ArincEventBus, isAttExcessive: 
 
     private tdReached = false;
 
+    private checkSpeedMode = false;
+
     private tcasRaInhibited = Subject.create(false);
 
     private trkFpaDeselected = Subject.create(false);
@@ -74,7 +76,7 @@ export class FMA extends DisplayComponent<{ bus: ArincEventBus, isAttExcessive: 
         const sharedModeActive = this.activeLateralMode === 32 || this.activeLateralMode === 33
             || this.activeLateralMode === 34 || (this.activeLateralMode === 20 && this.activeVerticalMode === 24);
         const BC3Message = getBC3Message(this.props.isAttExcessive.get(), this.armedVerticalModeSub.get(),
-            this.setHoldSpeed, this.trkFpaDeselected.get(), this.tcasRaInhibited.get(), this.fcdcDiscreteWord1, this.fwcFlightPhase, this.tdReached)[0] !== null;
+            this.setHoldSpeed, this.trkFpaDeselected.get(), this.tcasRaInhibited.get(), this.fcdcDiscreteWord1, this.fwcFlightPhase, this.tdReached, this.checkSpeedMode)[0] !== null;
 
         const engineMessage = this.athrModeMessage;
         const AB3Message = (this.machPreselVal !== -1
@@ -160,6 +162,11 @@ export class FMA extends DisplayComponent<{ bus: ArincEventBus, isAttExcessive: 
 
         sub.on('tdReached').whenChanged().handle((tdr) => {
             this.tdReached = tdr;
+            this.handleFMABorders();
+        });
+
+        sub.on('checkSpeedMode').whenChanged().handle((csm) => {
+            this.checkSpeedMode = csm;
             this.handleFMABorders();
         });
     }
@@ -1192,6 +1199,7 @@ const getBC3Message = (
     fcdcWord1: Arinc429Word,
     fwcFlightPhase: number,
     tdReached: boolean,
+    checkSpeedMode: boolean,
 ) => {
     const armedVerticalBitmask = armedVerticalMode;
     const TCASArmed = (armedVerticalBitmask >> 6) & 1;
@@ -1237,7 +1245,7 @@ const getBC3Message = (
     } else if (false) {
         text = 'MORE DRAG';
         className = 'FontMedium White';
-    } else if (false) {
+    } else if (checkSpeedMode) {
         text = 'CHECK SPEED MODE';
         className = 'FontMedium White';
     } else if (false) {
@@ -1283,9 +1291,19 @@ class BC3Cell extends DisplayComponent<{ isAttExcessive: Subscribable<boolean>, 
 
     private tdReached = false;
 
+    private checkSpeedMode = false;
+
     private fillBC3Cell() {
         const [text, className] = getBC3Message(
-            this.isAttExcessive, this.armedVerticalMode, this.setHoldSpeed, this.trkFpaDeselected, this.tcasRaInhibited, this.fcdcDiscreteWord1, this.fwcFlightPhase, this.tdReached,
+            this.isAttExcessive,
+            this.armedVerticalMode,
+            this.setHoldSpeed,
+            this.trkFpaDeselected,
+            this.tcasRaInhibited,
+            this.fcdcDiscreteWord1,
+            this.fwcFlightPhase,
+            this.tdReached,
+            this.checkSpeedMode,
         );
         this.classNameSub.set(`MiddleAlign ${className}`);
         if (text !== null) {
@@ -1336,6 +1354,11 @@ class BC3Cell extends DisplayComponent<{ isAttExcessive: Subscribable<boolean>, 
 
         sub.on('tdReached').whenChanged().handle((tdr) => {
             this.tdReached = tdr;
+            this.fillBC3Cell();
+        });
+
+        sub.on('checkSpeedMode').whenChanged().handle((csm) => {
+            this.checkSpeedMode = csm;
             this.fillBC3Cell();
         });
     }

--- a/fbw-a32nx/src/systems/instruments/src/PFD/FMA.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/FMA.tsx
@@ -1245,7 +1245,7 @@ const getBC3Message = (
     } else if (false) {
         text = 'MORE DRAG';
         className = 'FontMedium White';
-    } else if (checkSpeedMode) {
+    } else if (checkSpeedMode && !isAttExcessive) {
         text = 'CHECK SPEED MODE';
         className = 'FontMedium White';
     } else if (false) {

--- a/fbw-a32nx/src/systems/instruments/src/PFD/shared/PFDSimvarPublisher.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/shared/PFDSimvarPublisher.tsx
@@ -87,6 +87,7 @@ export type PFDSimvars = AdirsSimVars & SwitchingPanelVSimVars & {
     tdReached: boolean;
     trkFpaDeselectedTCAS: boolean;
     tcasRaInhibited: boolean;
+    checkSpeedMode: boolean;
     radioAltitude1: number;
     radioAltitude2: number;
     crzAltMode: boolean;
@@ -241,6 +242,7 @@ export enum PFDVars {
     trkFpaDeselectedTCAS = 'L:A32NX_AUTOPILOT_TCAS_MESSAGE_TRK_FPA_DESELECTION',
     tdReached = 'L:A32NX_PFD_MSG_TD_REACHED',
     tcasRaInhibited = 'L:A32NX_AUTOPILOT_TCAS_MESSAGE_RA_INHIBITED',
+    checkSpeedMode = 'L:A32NX_PFD_MSG_CHECK_SPEED_MODE',
     radioAltitude1 = 'L:A32NX_RA_1_RADIO_ALTITUDE',
     radioAltitude2 = 'L:A32NX_RA_2_RADIO_ALTITUDE',
     crzAltMode = 'L:A32NX_FMA_CRUISE_ALT_MODE',
@@ -400,6 +402,7 @@ export class PFDSimvarPublisher extends UpdatableSimVarPublisher<PFDSimvars> {
         ['tdReached', { name: PFDVars.tdReached, type: SimVarValueType.Bool }],
         ['trkFpaDeselectedTCAS', { name: PFDVars.trkFpaDeselectedTCAS, type: SimVarValueType.Bool }],
         ['tcasRaInhibited', { name: PFDVars.tcasRaInhibited, type: SimVarValueType.Bool }],
+        ['checkSpeedMode', { name: PFDVars.checkSpeedMode, type: SimVarValueType.Bool }],
         ['radioAltitude1', { name: PFDVars.radioAltitude1, type: SimVarValueType.Number }],
         ['radioAltitude2', { name: PFDVars.radioAltitude2, type: SimVarValueType.Number }],
         ['crzAltMode', { name: PFDVars.crzAltMode, type: SimVarValueType.Bool }],


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8190 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Various layout improvements of the PERF CLB, PERF CRZ and PERF DES pages.
- Implement option to preselect a managed descent speed.
- Implement CHECK SPEED MODE message.
- Only allow preselecting a selected CLB speed in CAS.
- Allow preselecting a cruise speed as CAS or Mach.
- Show cruise speed as CAS below FL250 and as Mach above FL250.
- Implement option to modify PRED TO altitude on PERF CLB and PERF DES pages.
- Add DES predictions in selected modes.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://github.com/flybywiresim/aircraft/assets/22713769/d313a85b-5b89-4009-bc03-62a7130f2239)
![image](https://github.com/flybywiresim/aircraft/assets/22713769/54694953-6a47-448c-8c04-8da340305b1e)
![image](https://github.com/flybywiresim/aircraft/assets/22713769/6083304c-a9f7-4a7e-b1d8-72f630e813c2)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
Limitations:
- No EXPEDITE predictions yet on the PERF DES page.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BlueberryKing

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- CHECK SPEED MODE
  - This message should appear when you the Climb or Cruise phase starts with a selected speed on the FCU, but no preselected speed on the respective CLB or CRZ page.
- CLB speed preselection
  - Check that you can preselect a speed between 100 kts and 350 kts. Check that you cannot preselect a Mach number.
  - Check that you can clear the preselected speed with the CLR key. Check that you can also clear it by clicking the LSK next to the managed speed target
  - Check that the preselected speed activates when the aircraft enters the CLB phase and that you do not see a CHECK SPEED MODE message
- CRZ speed preselection
  - Check that you can preselect a speed between 100 kts and 350 kts or a Mach number.
  - Check that you can clear the preselected speed with the CLR key. Check that you can also clear it by clicking the LSK next to the managed speed target
  - Check that the preselected speed activates when the aircraft enters the CRZ phase and that you do not see a CHECK SPEED MODE message
- DES speed preselection
  - Check that you can enter a Mach number as "MM/" or a CAS as "/CAS" on the DES page. This should be the managed target speed when the DES phase activates
  - Check that you can enter a CAS as "CAS", the Mach number should automatically be filled in as 0.80.
  - Check that you can clear this field to return to the precomputed Mach/CAS based on the cost index.
- CLB and DES predictions on the PERF page
  - In the CLB or DES phases respectively, check that you can modify the altitudes in the PRED TO field. On the CLB phase, any altitude between the aircraft's current altitude and the cruise altitude should be allowed. On the DES page, any altitude below the aircraft's current altitude should be allowed. Using CLR on the PRED TO field should return to the FCU altitude.
-  Speed shown on the CRZ page
   - The speed shown on the CRZ page should be a Mach number if the cruise level is above FL250, a CAS otherwise.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
