### PR TITLE
build: remove nuking of node_modules/ in setup.sh

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -33,7 +33,7 @@ jobs:
           echo VITE_BUILD=false >> .env
       - name: Build A32NX
         run: |
-          ./scripts/dev-env/run.sh ./scripts/setup.sh
+          ./scripts/dev-env/run.sh ./scripts/setup.sh --clean
           ./scripts/dev-env/run.sh ./scripts/build_a32nx.sh --no-tty -j 4
       - name: Build ZIP files
         run: |

--- a/.github/workflows/ingamepanels-checklist-fix.yml
+++ b/.github/workflows/ingamepanels-checklist-fix.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-ingamepanels-checklist-fix:
-    # Prevent running this on forks 
+    # Prevent running this on forks
     if: github.repository_owner == 'flybywiresim'
     name: 'Build InGamePanels Checklist Fix'
     runs-on: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
           echo LOCALAZY_READ_KEY=${{ secrets.LOCALAZY_READ_KEY }} >> .env
       - name: Build In-Game Panels Checklist Fix
         run: |
-          ./scripts/dev-env/run.sh ./scripts/setup.sh
+          ./scripts/dev-env/run.sh ./scripts/setup.sh --clean
           ./scripts/dev-env/run.sh ./scripts/build_ingamepanels_checklist_fix.sh --no-tty -j 4
       - name: Build ZIP files
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,7 +35,7 @@ jobs:
           echo VITE_BUILD=false >> .env
       - name: Build A32NX
         run: |
-          ./scripts/dev-env/run.sh ./scripts/setup.sh
+          ./scripts/dev-env/run.sh ./scripts/setup.sh --clean
           ./scripts/dev-env/run.sh ./scripts/build_a32nx.sh --no-tty -j 4
           rm -rf fbw-a32nx/src
       - name: Build ZIP files

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
       - name: install
-        run: ./scripts/dev-env/run.sh ./scripts/setup.sh
+        run: ./scripts/dev-env/run.sh ./scripts/setup.sh --clean
       - name: npm run lint
         run: ./scripts/dev-env/run.sh npm run lint
       - name: lint-rust.sh
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
       - name: npm install
-        run: ./scripts/dev-env/run.sh ./scripts/setup.sh
+        run: ./scripts/dev-env/run.sh ./scripts/setup.sh --clean
       - name: npm test
         run: npm test
   build:
@@ -62,7 +62,7 @@ jobs:
           cat fbw-a32nx/.env
       - name: Build A32NX
         run: |
-          ./scripts/dev-env/run.sh ./scripts/setup.sh
+          ./scripts/dev-env/run.sh ./scripts/setup.sh --clean
           ./scripts/dev-env/run.sh ./scripts/build.sh --no-tty -j 4
           rm -rf fbw-a32nx/src
       - name: Generate install.json

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -27,7 +27,7 @@ jobs:
           echo VITE_BUILD=false >> .env
       - name: Build A32NX
         run: |
-          ./scripts/dev-env/run.sh ./scripts/setup.sh
+          ./scripts/dev-env/run.sh ./scripts/setup.sh --clean
           ./scripts/dev-env/run.sh ./scripts/build.sh --no-tty -j 4
       - name: Build ZIP file
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           echo VITE_BUILD=false >> .env
       - name: Build A32NX
         run: |
-          ./scripts/dev-env/run.sh ./scripts/setup.sh
+          ./scripts/dev-env/run.sh ./scripts/setup.sh --clean
           ./scripts/dev-env/run.sh ./scripts/build.sh --no-tty -j 4
       - name: Build ZIP file
         run: |

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,5 +3,4 @@
 set -ex
 
 cd /external
-rm -rf node_modules
 npm ci

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,4 +3,12 @@
 set -ex
 
 cd /external
+
+for arg in "$@"; do
+  if [ "$arg" = "--clean" ]; then
+    echo "Removing node_modules..."
+    rm -rf node_modules/
+  fi
+done
+
 npm ci


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

- Removes `rm -rf node_modules/` in `setup.sh`, which is overkill and was mostly used for when we built our own version of `msfs-sdk`. Speeds up process for switching branches locally. `npm ci` already does a clean install.
- The option is conserved via a `--clean` flag which can be passed to `setup.sh`, which is done in all CI workfflows

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
