### PR TITLE
feat: aviationweather.gov(noaa) metar source and efb fixes

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -57,6 +57,7 @@
 1. [FMS] Show ILS ident and frequency on ARRIVAL page - @tracernz (Mike)
 1. [EFB/ATSU] Use MSFS METAR data rather than FSX cloud data from FBW API - @tracernz (Mike)
 1. [APU] Added xfeed APU fuel capabilities - @Taz5150 (TazX [Z+1]#0405)
+1. [EFB/ATSU] Added NOAA (aviationweather.gov) as a METAR source - @tracernz (Mike)
 
 ## 0.10.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -58,6 +58,7 @@
 1. [EFB/ATSU] Use MSFS METAR data rather than FSX cloud data from FBW API - @tracernz (Mike)
 1. [APU] Added xfeed APU fuel capabilities - @Taz5150 (TazX [Z+1]#0405)
 1. [EFB/ATSU] Added NOAA (aviationweather.gov) as a METAR source - @tracernz (Mike)
+1. [EFB] Fixed the main page and landing calculator to use the selected METAR source - @tracernz (Mike)
 
 ## 0.10.0
 

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -4,7 +4,7 @@
 import React, { FC, useEffect, useState } from 'react';
 import { Metar as FbwApiMetar } from '@flybywiresim/api-client';
 import { Droplet, Speedometer2, ThermometerHalf, Wind } from 'react-bootstrap-icons';
-import { MetarParserType, parseMetar, useInterval, usePersistentNumberProperty, usePersistentProperty } from '@flybywiresim/fbw-sdk';
+import { ConfigWeatherMap, MetarParserType, parseMetar, useInterval, usePersistentNumberProperty, usePersistentProperty } from '@flybywiresim/fbw-sdk';
 import { Metar as MsfsMetar } from '@microsoft/msfs-sdk';
 import { t } from '../../translation';
 import { SimpleInput } from '../../UtilComponents/Form/SimpleInput/SimpleInput';
@@ -153,7 +153,7 @@ export const WeatherWidget: FC<WeatherWidgetProps> = ({ name, simbriefIcao, user
             return Promise.resolve();
         }
 
-        return FbwApiMetar.get(icao, source)
+        return FbwApiMetar.get(icao, ConfigWeatherMap[source])
             .then((result) => {
                 // For METAR source Microsoft result.metar is undefined without throwing an error.
                 // For the other METAR sources an error is thrown (Request failed with status code 404)

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Performance/Widgets/LandingWidget.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Performance/Widgets/LandingWidget.tsx
@@ -51,8 +51,8 @@ interface OutputDisplayProps {
 }
 
 const OutputDisplay = (props: OutputDisplayProps) => (
-    <div className={`flex flex-col justify-center items-center py-2 w-full ${props.error ? 'bg-red-800' : ''}`}>
-        <p className="flex-shrink-0 font-bold">{props.label}</p>
+    <div className={`flex w-full flex-col items-center justify-center py-2 ${props.error ? 'bg-red-800' : ''}`}>
+        <p className="shrink-0 font-bold">{props.label}</p>
         <p>
             {props.value}
         </p>
@@ -65,7 +65,7 @@ interface LabelProps {
 }
 
 const Label: FC<LabelProps> = ({ text, className, children }) => (
-    <div className="flex flex-row justify-between items-center">
+    <div className="flex flex-row items-center justify-between">
         <p className={`text-theme-text mr-4 ${className}`}>{text}</p>
         {children}
     </div>
@@ -423,19 +423,19 @@ export const LandingWidget = () => {
     };
 
     return (
-        <div className="flex overflow-hidden flex-row justify-between space-x-10 h-content-section-reduced">
+        <div className="h-content-section-reduced flex flex-row justify-between space-x-10 overflow-hidden">
             <div className="w-full">
-                <div className="flex flex-col justify-between w-full h-full">
+                <div className="flex h-full w-full flex-col justify-between">
                     <div className="mb-4">
-                        <div className="mt-4 mb-8">
+                        <div className="mb-8 mt-4">
                             <p>{t('Performance.Landing.AirportIcao')}</p>
-                            <div className="flex flex-row justify-between mt-4">
+                            <div className="mt-4 flex flex-row justify-between">
                                 <SimpleInput className="w-64 uppercase" value={icao} placeholder="ICAO" onChange={handleICAOChange} maxLength={4} />
                                 <div className="flex flex-row">
                                     <TooltipWrapper text={fillDataTooltip()}>
                                         <button
                                             onClick={isAutoFillIcaoValid() ? handleAutoFill : undefined}
-                                            className={`rounded-md rounded-r-none flex flex-row justify-center items-center px-8 py-2 space-x-4 text-theme-body transition duration-100 border-2 border-theme-highlight bg-theme-highlight outline-none ${!isAutoFillIcaoValid() ? 'opacity-50' : 'hover:text-theme-highlight hover:bg-theme-body'}`}
+                                            className={`text-theme-body border-theme-highlight bg-theme-highlight flex flex-row items-center justify-center space-x-4 rounded-md rounded-r-none border-2 px-8 py-2 outline-none transition duration-100 ${!isAutoFillIcaoValid() ? 'opacity-50' : 'hover:text-theme-highlight hover:bg-theme-body'}`}
                                             type="button"
                                         >
                                             <CloudArrowDown size={26} />
@@ -481,7 +481,7 @@ export const LandingWidget = () => {
                                     />
                                 </Label>
                                 <Label text={t('Performance.Landing.Temperature')}>
-                                    <div className="flex flex-row w-64">
+                                    <div className="flex w-64 flex-row">
                                         <SimpleInput
                                             className="w-full rounded-r-none"
                                             value={getVariableUnitDisplayValue<'C' | 'F'>(temperature, temperatureUnit as 'C' | 'F', 'F', Units.celsiusToFahrenheit)}
@@ -504,7 +504,7 @@ export const LandingWidget = () => {
                                     </div>
                                 </Label>
                                 <Label text={t('Performance.Landing.Qnh')}>
-                                    <div className="flex flex-row w-64">
+                                    <div className="flex w-64 flex-row">
                                         <SimpleInput
                                             className="w-full rounded-r-none"
                                             value={getVariableUnitDisplayValue<'hPa' | 'inHg'>(pressure, pressureUnit as 'hPa' | 'inHg', 'inHg', Units.hectopascalToInchOfMercury)}
@@ -583,7 +583,7 @@ export const LandingWidget = () => {
                                     />
                                 </Label>
                                 <Label text={t('Performance.Landing.RunwayLda')}>
-                                    <div className="flex flex-row w-64">
+                                    <div className="flex w-64 flex-row">
                                         <SimpleInput
                                             className="w-full rounded-r-none"
                                             value={getVariableUnitDisplayValue<'ft' | 'm'>(runwayLength, distanceUnit as 'ft' | 'm', 'ft', Units.metreToFoot)}
@@ -618,7 +618,7 @@ export const LandingWidget = () => {
                                     />
                                 </Label>
                                 <Label text={t('Performance.Landing.Weight')}>
-                                    <div className="flex flex-row w-64">
+                                    <div className="flex w-64 flex-row">
                                         <SimpleInput
                                             className="w-full rounded-r-none"
                                             value={getVariableUnitDisplayValue<'kg' | 'lb'>(weight, weightUnit as 'kg' | 'lb', 'lb', Units.kilogramToPound)}
@@ -690,10 +690,10 @@ export const LandingWidget = () => {
                                 </Label>
                             </div>
                         </div>
-                        <div className="flex flex-row mt-14 space-x-8">
+                        <div className="mt-14 flex flex-row space-x-8">
                             <button
                                 onClick={handleCalculateLanding}
-                                className={`rounded-md flex flex-row justify-center items-center py-2 space-x-4 w-full bg-theme-highlight outline-none border-2 border-theme-highlight text-theme-body hover:text-theme-highlight hover:bg-theme-body ${!areInputsValid() && 'opacity-50 pointer-events-none'}`}
+                                className={`bg-theme-highlight border-theme-highlight text-theme-body hover:text-theme-highlight hover:bg-theme-body flex w-full flex-row items-center justify-center space-x-4 rounded-md border-2 py-2 outline-none ${!areInputsValid() && 'pointer-events-none opacity-50'}`}
                                 type="button"
                                 disabled={!areInputsValid()}
                             >
@@ -702,7 +702,7 @@ export const LandingWidget = () => {
                             </button>
                             <button
                                 onClick={handleClearInputs}
-                                className="flex flex-row justify-center items-center py-2 space-x-4 w-full text-theme-body hover:text-utility-red bg-utility-red hover:bg-theme-body rounded-md border-2 border-utility-red outline-none"
+                                className="text-theme-body hover:text-utility-red bg-utility-red hover:bg-theme-body border-utility-red flex w-full flex-row items-center justify-center space-x-4 rounded-md border-2 py-2 outline-none"
                                 type="button"
                             >
                                 <Trash size={26} />
@@ -710,7 +710,7 @@ export const LandingWidget = () => {
                             </button>
                         </div>
                     </div>
-                    <div className="flex overflow-hidden flex-row w-full rounded-lg border-2 border-theme-accent divide-x-2 divide-theme-accent">
+                    <div className="border-theme-accent divide-theme-accent flex w-full flex-row divide-x-2 overflow-hidden rounded-lg border-2">
                         <OutputDisplay
                             label={t('Performance.Landing.MaximumManual')}
                             value={distanceUnit === 'ft'

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AtsuAocPage.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AtsuAocPage.tsx
@@ -85,6 +85,7 @@ export const AtsuAocPage = () => {
 
     const metarSourceButtons: ButtonType[] = [
         { name: 'MSFS', setting: 'MSFS' },
+        { name: 'NOAA', setting: 'NOAA' },
         { name: 'PilotEdge', setting: 'PILOTEDGE' },
         { name: 'IVAO', setting: 'IVAO' },
         { name: 'VATSIM', setting: 'VATSIM' },

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AtsuAocPage.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AtsuAocPage.tsx
@@ -87,12 +87,10 @@ export const AtsuAocPage = () => {
         { name: 'MSFS', setting: 'MSFS' },
         { name: 'NOAA', setting: 'NOAA' },
         { name: 'PilotEdge', setting: 'PILOTEDGE' },
-        { name: 'IVAO', setting: 'IVAO' },
         { name: 'VATSIM', setting: 'VATSIM' },
     ];
 
     const tafSourceButtons: ButtonType[] = [
-        { name: 'IVAO', setting: 'IVAO' },
         { name: 'NOAA', setting: 'NOAA' },
     ];
 

--- a/fbw-common/src/systems/datalink/router/src/webinterfaces/NXApiConnector.ts
+++ b/fbw-common/src/systems/datalink/router/src/webinterfaces/NXApiConnector.ts
@@ -2,7 +2,7 @@
 //  SPDX-License-Identifier: GPL-3.0
 
 import { Atis, Metar, Taf, Telex, AircraftStatus } from '@flybywiresim/api-client';
-import { NXDataStore } from '@flybywiresim/fbw-sdk';
+import { ConfigWeatherMap, NXDataStore } from '@flybywiresim/fbw-sdk';
 import {
     AtsuStatusCodes,
     AtsuMessage,
@@ -14,15 +14,6 @@ import {
     AtisMessage,
     AtisType,
 } from '@datalink/common';
-
-const WeatherMap = {
-    FAA: 'faa',
-    IVAO: 'ivao',
-    MSFS: 'ms',
-    NOAA: 'aviationweather',
-    PILOTEDGE: 'pilotedge',
-    VATSIM: 'vatsim',
-};
 
 /**
  * Defines the NXApi connector for the AOC system
@@ -120,7 +111,7 @@ export class NXApiConnector {
     public static async receiveMetar(icao: string, message: WeatherMessage): Promise<AtsuStatusCodes> {
         const storedMetarSrc = NXDataStore.get('CONFIG_METAR_SRC', 'MSFS');
 
-        return Metar.get(icao, WeatherMap[storedMetarSrc])
+        return Metar.get(icao, ConfigWeatherMap[storedMetarSrc])
             .then((data) => {
                 let metar = data.metar;
                 if (!metar || metar === undefined || metar === '') {
@@ -138,7 +129,7 @@ export class NXApiConnector {
     public static async receiveTaf(icao: string, message: WeatherMessage): Promise<AtsuStatusCodes> {
         const storedTafSrc = NXDataStore.get('CONFIG_TAF_SRC', 'NOAA');
 
-        return Taf.get(icao, WeatherMap[storedTafSrc])
+        return Taf.get(icao, ConfigWeatherMap[storedTafSrc])
             .then((data) => {
                 let taf = data.taf;
                 if (!taf || taf === undefined || taf === '') {
@@ -156,7 +147,7 @@ export class NXApiConnector {
     public static async receiveAtis(icao: string, type: AtisType, message: AtisMessage): Promise<AtsuStatusCodes> {
         const storedAtisSrc = NXDataStore.get('CONFIG_ATIS_SRC', 'FAA');
 
-        await Atis.get(icao, WeatherMap[storedAtisSrc])
+        await Atis.get(icao, ConfigWeatherMap[storedAtisSrc])
             .then((data) => {
                 let atis = undefined;
 

--- a/fbw-common/src/systems/shared/src/config.ts
+++ b/fbw-common/src/systems/shared/src/config.ts
@@ -1,0 +1,9 @@
+/** Mapping from FBW config weather providers to FBW API weather sources. */
+export enum ConfigWeatherMap {
+    FAA = 'faa',
+    IVAO = 'ivao',
+    MSFS = 'ms',
+    NOAA = 'aviationweather',
+    PILOTEDGE = 'pilotedge',
+    VATSIM = 'vatsim',
+}

--- a/fbw-common/src/systems/shared/src/index.ts
+++ b/fbw-common/src/systems/shared/src/index.ts
@@ -4,6 +4,7 @@ export * from './arinc429';
 export * from './ata';
 export * from './array';
 export * from './bitFlags';
+export * from './config';
 export * from './Constants';
 export * from './GenericDataListenerSync';
 export * from './logic';


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Depends on https://github.com/flybywiresim/api/pull/144 ✔️ 

- refactor: move weather source map to shared
  Want to share this between the ATSU and the EFB rather than two separate definitions that may get out of sync.
- fix(efb): use weather source map
  Map config weather providers to the API sources in the EFB so we actually get the selected weather source (it was defaulting to VATSIM before).
- feat(efb): add aviationweather.gov/noaa metar source
  Add NOAA/avitationweather.gov as a METAR source with their new API, from https://github.com/flybywiresim/api/pull/144
- fix(efb): remove non-working ivao taf and metar
  IVAO METARs are not even implemented in the FBW API, and the TAF source does not work as the old IVAO API is offline.
- chore(efb): auto-format landing widget
  Keeping the diff separate from my actual changes.
- fix(efb): use selected metar source for landing widget
  Use the configured METAR source rather than always using the API default (VATSIM).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Test that METARs, and TAFs work in the EFB and ATSU for NOAA, and for other providers.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
