### PR TITLE
fix: capt nd shows VOR1

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/ND/ND.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/ND/ND.tsx
@@ -282,6 +282,7 @@ export class NDComponent extends DisplayComponent<NDProps> {
                         trueTrackWord={this.trueTrackWord}
                         rangeValue={this.mapRangeRadius}
                         isUsingTrackUpMode={this.isUsingTrackUpMode}
+                        /* Capt ND shows ILS2  */
                         index={this.props.side === 'L' ? 2 : 1}
                     />
                     <RoseVorPage
@@ -293,7 +294,8 @@ export class NDComponent extends DisplayComponent<NDProps> {
                         trueTrackWord={this.trueTrackWord}
                         rangeValue={this.mapRangeRadius}
                         isUsingTrackUpMode={this.isUsingTrackUpMode}
-                        index={this.props.side === 'L' ? 2 : 1}
+                        /* Capt ND shows VOR1  */
+                        index={this.props.side === 'L' ? 1 : 2}
                     />
                     <RoseNavPage
                         bus={this.props.bus}


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Last PR erroneously swapped VOR1 and VOR2 on the NDs, this is fixed now.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
