### PR TITLE
feat: suppress cabin announcements when no pax

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,6 +19,7 @@
 1. [EFCS] Add precontrol to roll angle controller to improve dynamic response - @lukecologne (luke)
 1. [EFCS] Increase maximum sim rate limit to 8 due to improvements in roll law stability - @lukecologne (luke)
 1. [HOPPIE] Remove ATSU/AOC source checks - @auroraisluna (alepouna)
+1. [EFB] Added suppressing the cabin sounds (announcements/passanger ambience) when the flight is without passengers. - @LouisVenhoff (LouisDev)
 
 ## 0.11.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,7 +19,7 @@
 1. [EFCS] Add precontrol to roll angle controller to improve dynamic response - @lukecologne (luke)
 1. [EFCS] Increase maximum sim rate limit to 8 due to improvements in roll law stability - @lukecologne (luke)
 1. [HOPPIE] Remove ATSU/AOC source checks - @auroraisluna (alepouna)
-1. [EFB] Added suppressing the cabin sounds (announcements/passanger ambience) when the flight is without passengers. - @LouisVenhoff (LouisDev)
+1. [EFB] Added the ability to suppress the cabin sounds (Announcements/Passengers ambience/Music) when the flight is without PAX. - @LouisVenhoff (LouisDev)
 
 ## 0.11.0
 

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Efb.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Efb.tsx
@@ -126,7 +126,7 @@ const Efb = () => {
 
     useEffect(() => {
         document.documentElement.classList.add(`theme-${theme}`, 'animationsEnabled');
-        //syncGlobalSettings();
+        syncGlobalSettings();
     }, []);
 
     useEffect(() => {

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Efb.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Efb.tsx
@@ -25,7 +25,7 @@ import { Presets } from './Presets/Presets';
 import { clearEfbState, useAppDispatch, useAppSelector } from './Store/store';
 import { fetchSimbriefDataAction, isSimbriefDataLoaded } from './Store/features/simBrief';
 import { setFlightPlanProgress } from './Store/features/flightProgress';
-import { setPassengerAmbienceActive, setBoardingMusicActive, setCabinAnnouncementsActive } from './Store/features/globalSettings';
+import { setPassengerAmbienceSetting, setBoardingMusicSetting, setCabinAnnouncementsSetting } from './Store/features/globalSettings';
 import { Checklists, setAutomaticItemStates } from './Checklists/Checklists';
 import { CHECKLISTS } from './Checklists/Lists';
 import { setChecklistItems } from './Store/features/checklists';
@@ -301,9 +301,9 @@ const Efb = () => {
 
     // Writes the initial values from the global settings.
     const syncGlobalSettings = () => {
-       dispatch(setPassengerAmbienceActive(passengerAmbienceEnabled === 1));
-       dispatch(setCabinAnnouncementsActive(cabinAnnouncementsEnabled === 1));
-       dispatch(setBoardingMusicActive(boardingMusicEnabled === 1));
+       dispatch(setPassengerAmbienceSetting(passengerAmbienceEnabled === 1));
+       dispatch(setCabinAnnouncementsSetting(cabinAnnouncementsEnabled === 1));
+       dispatch(setBoardingMusicSetting(boardingMusicEnabled === 1));
     };
 
     const { offsetY } = useAppSelector((state) => state.keyboard);

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Efb.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Efb.tsx
@@ -107,7 +107,7 @@ const Efb = () => {
     const [autoLoadDawnDuskLightingPresetID] = usePersistentNumberProperty('LIGHT_PRESET_AUTOLOAD_DAWNDUSK', 0);
     const [autoLoadNightLightingPresetID] = usePersistentNumberProperty('LIGHT_PRESET_AUTOLOAD_NIGHT', 0);
     
-    //Data for global settings sync after system start
+    // Data for global settings sync after system start.
     const [passengerAmbienceEnabled] = usePersistentNumberProperty('SOUND_PASSENGER_AMBIENCE_ENABLED', 1);
     const [cabinAnnouncementsEnabled] = usePersistentNumberProperty('SOUND_ANNOUNCEMENTS_ENABLED', 1);
     const [boardingMusicEnabled] = usePersistentNumberProperty('SOUND_BOARDING_MUSIC_ENABLED', 1);
@@ -299,7 +299,7 @@ const Efb = () => {
     // </Pushback>
     // =========================================================================
 
-    //Writes the initial values fro the global settings
+    // Writes the initial values from the global settings.
     const syncGlobalSettings = () => 
     {
        dispatch(setPassengerAmbienceActive(passengerAmbienceEnabled === 1 ? true : false));

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Efb.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Efb.tsx
@@ -301,9 +301,9 @@ const Efb = () => {
 
     // Writes the initial values from the global settings.
     const syncGlobalSettings = () => {
-       dispatch(setPassengerAmbienceActive(passengerAmbienceEnabled === 1 ? true : false));
-       dispatch(setCabinAnnouncementsActive(cabinAnnouncementsEnabled === 1 ? true : false));
-       dispatch(setBoardingMusicActive(boardingMusicEnabled === 1 ? true : false));
+       dispatch(setPassengerAmbienceActive(passengerAmbienceEnabled === 1));
+       dispatch(setCabinAnnouncementsActive(cabinAnnouncementsEnabled === 1));
+       dispatch(setBoardingMusicActive(boardingMusicEnabled === 1));
     };
 
     const { offsetY } = useAppSelector((state) => state.keyboard);

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Efb.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Efb.tsx
@@ -300,12 +300,11 @@ const Efb = () => {
     // =========================================================================
 
     // Writes the initial values from the global settings.
-    const syncGlobalSettings = () => 
-    {
+    const syncGlobalSettings = () => {
        dispatch(setPassengerAmbienceActive(passengerAmbienceEnabled === 1 ? true : false));
        dispatch(setCabinAnnouncementsActive(cabinAnnouncementsEnabled === 1 ? true : false));
        dispatch(setBoardingMusicActive(boardingMusicEnabled === 1 ? true : false));
-    }
+    };
 
     const { offsetY } = useAppSelector((state) => state.keyboard);
 

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Efb.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Efb.tsx
@@ -25,6 +25,7 @@ import { Presets } from './Presets/Presets';
 import { clearEfbState, useAppDispatch, useAppSelector } from './Store/store';
 import { fetchSimbriefDataAction, isSimbriefDataLoaded } from './Store/features/simBrief';
 import { setFlightPlanProgress } from './Store/features/flightProgress';
+import { setPassengerAmbienceActive, setBoardingMusicActive, setCabinAnnouncementsActive } from './Store/features/globalSettings';
 import { Checklists, setAutomaticItemStates } from './Checklists/Checklists';
 import { CHECKLISTS } from './Checklists/Lists';
 import { setChecklistItems } from './Store/features/checklists';
@@ -105,6 +106,12 @@ const Efb = () => {
     const [autoLoadDayLightingPresetID] = usePersistentNumberProperty('LIGHT_PRESET_AUTOLOAD_DAY', 0);
     const [autoLoadDawnDuskLightingPresetID] = usePersistentNumberProperty('LIGHT_PRESET_AUTOLOAD_DAWNDUSK', 0);
     const [autoLoadNightLightingPresetID] = usePersistentNumberProperty('LIGHT_PRESET_AUTOLOAD_NIGHT', 0);
+    
+    //Data for global settings sync after system start
+    const [passengerAmbienceEnabled] = usePersistentNumberProperty('SOUND_PASSENGER_AMBIENCE_ENABLED', 1);
+    const [cabinAnnouncementsEnabled] = usePersistentNumberProperty('SOUND_ANNOUNCEMENTS_ENABLED', 1);
+    const [boardingMusicEnabled] = usePersistentNumberProperty('SOUND_BOARDING_MUSIC_ENABLED', 1);
+    
 
     const [lat] = useSimVar('PLANE LATITUDE', 'degree latitude', 4000);
     const [long] = useSimVar('PLANE LONGITUDE', 'degree longitude', 4000);
@@ -119,6 +126,7 @@ const Efb = () => {
 
     useEffect(() => {
         document.documentElement.classList.add(`theme-${theme}`, 'animationsEnabled');
+        syncGlobalSettings();
     }, []);
 
     useEffect(() => {
@@ -290,6 +298,14 @@ const Efb = () => {
 
     // </Pushback>
     // =========================================================================
+
+    //Writes the initial values fro the global settings
+    const syncGlobalSettings = () => 
+    {
+        dispatch(setPassengerAmbienceActive(passengerAmbienceEnabled === 1 ? true : false));
+        dispatch(setCabinAnnouncementsActive(cabinAnnouncementsEnabled === 1 ? true : false));
+        dispatch(setBoardingMusicActive(boardingMusicEnabled === 1 ? true : false));
+    }
 
     const { offsetY } = useAppSelector((state) => state.keyboard);
 

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Efb.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Efb.tsx
@@ -126,7 +126,7 @@ const Efb = () => {
 
     useEffect(() => {
         document.documentElement.classList.add(`theme-${theme}`, 'animationsEnabled');
-        syncGlobalSettings();
+        //syncGlobalSettings();
     }, []);
 
     useEffect(() => {
@@ -302,9 +302,9 @@ const Efb = () => {
     //Writes the initial values fro the global settings
     const syncGlobalSettings = () => 
     {
-        dispatch(setPassengerAmbienceActive(passengerAmbienceEnabled === 1 ? true : false));
-        dispatch(setCabinAnnouncementsActive(cabinAnnouncementsEnabled === 1 ? true : false));
-        dispatch(setBoardingMusicActive(boardingMusicEnabled === 1 ? true : false));
+       dispatch(setPassengerAmbienceActive(passengerAmbienceEnabled === 1 ? true : false));
+       dispatch(setCabinAnnouncementsActive(cabinAnnouncementsEnabled === 1 ? true : false));
+       dispatch(setBoardingMusicActive(boardingMusicEnabled === 1 ? true : false));
     }
 
     const { offsetY } = useAppSelector((state) => state.keyboard);

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
@@ -91,8 +91,6 @@ export const A320Payload: React.FC<A320Props> = ({
     const maxPax = useMemo(() => seatMap.reduce((a, b) => a + b.capacity, 0), [seatMap]);
     const maxCargo = useMemo(() => cargoMap.reduce((a, b) => a + b.weight, 0), [cargoMap]);
 
-    
-
     // Calculate Total Pax from Pax Flags
     const totalPax = useMemo(() => {
         let p = 0;
@@ -120,7 +118,7 @@ export const A320Payload: React.FC<A320Props> = ({
     const [gw] = useSimVar('L:A32NX_AIRFRAME_GW', 'number', 1_741);
     const [gwDesired] = useSimVar('L:A32NX_AIRFRAME_GW_DESIRED', 'number', 1_787);
 
-    //Cabin Sounds
+    // Cabin sounds.
     const [passengerAmbienceEnabled, setPassengerAmbienceEnabled] = usePersistentNumberProperty('SOUND_PASSENGER_AMBIENCE_ENABLED', 1);
     const [announcementsEnabled, setAnnouncementsEnabled] = usePersistentNumberProperty('SOUND_ANNOUNCEMENTS_ENABLED', 1);
     const [boardingMusicEnabled, setBoardingMusicEnabled] = usePersistentNumberProperty('SOUND_BOARDING_MUSIC_ENABLED', 1);
@@ -462,7 +460,7 @@ export const A320Payload: React.FC<A320Props> = ({
         gsxPayloadSyncEnabled,
     ]);
 
-    //If totalPax is 0, deactivate all sounds from the cabin
+    // If totalPax is 0, deactivate all sounds from the cabin.
     useEffect(() => {
         let cabinSoundStatus:number = 0;
         if(totalPax > 0)

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
@@ -14,7 +14,7 @@ import Card from '../../../../UtilComponents/Card/Card';
 import { SelectGroup, SelectItem } from '../../../../UtilComponents/Form/Select';
 import { SeatMapWidget } from '../Seating/SeatMapWidget';
 import { PromptModal, useModals } from '../../../../UtilComponents/Modals/Modals';
-import { useSelector } from 'react-redux';
+import { useAppSelector } from 'instruments/src/EFB/Store/store';
 
 interface A320Props {
     simbriefUnits: string,
@@ -464,15 +464,15 @@ export const A320Payload: React.FC<A320Props> = ({
     useEffect(() => {
         const cabinSoundStatus:number = (totalPax > 0 ? 1 : 0);
 
-        if (globalSettingsRedux.passengerAmbienceActive) {
+        if (globalSettingsRedux.passengerAmbienceSetting) {
             setPassengerAmbienceEnabled(cabinSoundStatus);
         }
 
-        if (globalSettingsRedux.cabinAnnouncementsActive) {
+        if (globalSettingsRedux.cabinAnnouncementsSetting) {
             setAnnouncementsEnabled(cabinSoundStatus);
         }
 
-        if (globalSettingsRedux.boardingMusicActive) {
+        if (globalSettingsRedux.boardingMusicSetting) {
             setBoardingMusicEnabled(cabinSoundStatus);
         }
     }, [totalPax]);

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
@@ -14,6 +14,7 @@ import Card from '../../../../UtilComponents/Card/Card';
 import { SelectGroup, SelectItem } from '../../../../UtilComponents/Form/Select';
 import { SeatMapWidget } from '../Seating/SeatMapWidget';
 import { PromptModal, useModals } from '../../../../UtilComponents/Modals/Modals';
+import { useSelector } from 'react-redux';
 
 interface A320Props {
     simbriefUnits: string,
@@ -58,6 +59,8 @@ export const A320Payload: React.FC<A320Props> = ({
     const [cFlagsDesired, setCFlagsDesired] = useSeatFlags(`L:${Loadsheet.seatMap[2].simVar}_DESIRED`, Loadsheet.seatMap[2].capacity, 457);
     const [dFlagsDesired, setDFlagsDesired] = useSeatFlags(`L:${Loadsheet.seatMap[3].simVar}_DESIRED`, Loadsheet.seatMap[3].capacity, 499);
 
+    const globalSettingsRedux = useSelector((state:any) => state.globalSettings);
+
     const activeFlags = useMemo(() => [aFlags, bFlags, cFlags, dFlags], [aFlags, bFlags, cFlags, dFlags]);
     const desiredFlags = useMemo(() => [aFlagsDesired, bFlagsDesired, cFlagsDesired, dFlagsDesired], [aFlagsDesired, bFlagsDesired, cFlagsDesired, dFlagsDesired]);
     const setDesiredFlags = useMemo(() => [setAFlagsDesired, setBFlagsDesired, setCFlagsDesired, setDFlagsDesired], []);
@@ -87,6 +90,8 @@ export const A320Payload: React.FC<A320Props> = ({
 
     const maxPax = useMemo(() => seatMap.reduce((a, b) => a + b.capacity, 0), [seatMap]);
     const maxCargo = useMemo(() => cargoMap.reduce((a, b) => a + b.weight, 0), [cargoMap]);
+
+    
 
     // Calculate Total Pax from Pax Flags
     const totalPax = useMemo(() => {
@@ -464,9 +469,19 @@ export const A320Payload: React.FC<A320Props> = ({
         {
             cabinSoundStatus = 1;
         }
-        setPassengerAmbienceEnabled(cabinSoundStatus);
-        setAnnouncementsEnabled(cabinSoundStatus);
-        setBoardingMusicEnabled(cabinSoundStatus);
+        if(globalSettingsRedux.passengerAmbienceActive)
+        {
+            setPassengerAmbienceEnabled(cabinSoundStatus);
+        }
+        if(globalSettingsRedux.cabinAnnouncementsActive)
+        {
+            setAnnouncementsEnabled(cabinSoundStatus);
+        }
+        if(globalSettingsRedux.boardindgMusicActive)
+        {
+            setBoardingMusicEnabled(cabinSoundStatus);
+        }
+        
     },[totalPax]);
 
     const remainingTimeString = () => {

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
@@ -462,24 +462,19 @@ export const A320Payload: React.FC<A320Props> = ({
 
     // If totalPax is 0, deactivate all sounds from the cabin.
     useEffect(() => {
-        let cabinSoundStatus:number = 0;
-        if(totalPax > 0)
-        {
-            cabinSoundStatus = 1;
-        }
-        if(globalSettingsRedux.passengerAmbienceActive)
-        {
+        const cabinSoundStatus:number = (totalPax > 0 ? 1 : 0);
+
+        if (globalSettingsRedux.passengerAmbienceActive) {
             setPassengerAmbienceEnabled(cabinSoundStatus);
         }
-        if(globalSettingsRedux.cabinAnnouncementsActive)
-        {
+
+        if (globalSettingsRedux.cabinAnnouncementsActive) {
             setAnnouncementsEnabled(cabinSoundStatus);
         }
-        if(globalSettingsRedux.boardindgMusicActive)
-        {
+
+        if (globalSettingsRedux.boardindgMusicActive) {
             setBoardingMusicEnabled(cabinSoundStatus);
         }
-        
     },[totalPax]);
 
     const remainingTimeString = () => {

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
@@ -59,7 +59,7 @@ export const A320Payload: React.FC<A320Props> = ({
     const [cFlagsDesired, setCFlagsDesired] = useSeatFlags(`L:${Loadsheet.seatMap[2].simVar}_DESIRED`, Loadsheet.seatMap[2].capacity, 457);
     const [dFlagsDesired, setDFlagsDesired] = useSeatFlags(`L:${Loadsheet.seatMap[3].simVar}_DESIRED`, Loadsheet.seatMap[3].capacity, 499);
 
-    const globalSettingsRedux = useSelector((state:any) => state.globalSettings);
+    const globalSettingsRedux = useAppSelector((state) => state.globalSettings);
 
     const activeFlags = useMemo(() => [aFlags, bFlags, cFlags, dFlags], [aFlags, bFlags, cFlags, dFlags]);
     const desiredFlags = useMemo(() => [aFlagsDesired, bFlagsDesired, cFlagsDesired, dFlagsDesired], [aFlagsDesired, bFlagsDesired, cFlagsDesired, dFlagsDesired]);
@@ -472,7 +472,7 @@ export const A320Payload: React.FC<A320Props> = ({
             setAnnouncementsEnabled(cabinSoundStatus);
         }
 
-        if (globalSettingsRedux.boardindgMusicActive) {
+        if (globalSettingsRedux.boardingMusicActive) {
             setBoardingMusicEnabled(cabinSoundStatus);
         }
     }, [totalPax]);

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
@@ -115,6 +115,11 @@ export const A320Payload: React.FC<A320Props> = ({
     const [gw] = useSimVar('L:A32NX_AIRFRAME_GW', 'number', 1_741);
     const [gwDesired] = useSimVar('L:A32NX_AIRFRAME_GW_DESIRED', 'number', 1_787);
 
+    //Cabin Sounds
+    const [passengerAmbienceEnabled, setPassengerAmbienceEnabled] = usePersistentNumberProperty('SOUND_PASSENGER_AMBIENCE_ENABLED', 1);
+    const [announcementsEnabled, setAnnouncementsEnabled] = usePersistentNumberProperty('SOUND_ANNOUNCEMENTS_ENABLED', 1);
+    const [boardingMusicEnabled, setBoardingMusicEnabled] = usePersistentNumberProperty('SOUND_BOARDING_MUSIC_ENABLED', 1);
+
     // CG MAC
     const [zfwCgMac] = useSimVar('L:A32NX_AIRFRAME_ZFW_CG_PERCENT_MAC', 'number', 1_223);
     const [desiredZfwCgMac] = useSimVar('L:A32NX_AIRFRAME_ZFW_CG_PERCENT_MAC_DESIRED', 'number', 1_279);
@@ -451,6 +456,18 @@ export const A320Payload: React.FC<A320Props> = ({
         boardingStarted,
         gsxPayloadSyncEnabled,
     ]);
+
+    //If totalPax is 0, deactivate all sounds from the cabin
+    useEffect(() => {
+        let cabinSoundStatus:number = 0;
+        if(totalPax > 0)
+        {
+            cabinSoundStatus = 1;
+        }
+        setPassengerAmbienceEnabled(cabinSoundStatus);
+        setAnnouncementsEnabled(cabinSoundStatus);
+        setBoardingMusicEnabled(cabinSoundStatus);
+    },[totalPax]);
 
     const remainingTimeString = () => {
         const minutes = Math.round(calculateBoardingTime / 60);

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
@@ -475,7 +475,7 @@ export const A320Payload: React.FC<A320Props> = ({
         if (globalSettingsRedux.boardindgMusicActive) {
             setBoardingMusicEnabled(cabinSoundStatus);
         }
-    },[totalPax]);
+    }, [totalPax]);
 
     const remainingTimeString = () => {
         const minutes = Math.round(calculateBoardingTime / 60);

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A380_842/A380Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A380_842/A380Payload.tsx
@@ -14,7 +14,8 @@ import { SelectGroup, SelectItem } from '../../../../UtilComponents/Form/Select'
 import { SeatMapWidget } from '../Seating/SeatMapWidget';
 import { PromptModal, useModals } from '../../../../UtilComponents/Modals/Modals';
 import { A380SeatOutlineBg, A380SeatOutlineUpperBg } from '../../../../Assets/A380SeatOutlineBg';
-import { useSelector } from 'react-redux';
+import { useAppSelector } from 'instruments/src/EFB/Store/store';
+
 
 interface A380Props {
     simbriefUnits: string,
@@ -80,7 +81,7 @@ export const A380Payload: React.FC<A380Props> = ({
     const [upperMidBDesired, setUpperMidBDesired] = useSeatFlags(`L:${Loadsheet.seatMap[12].simVar}_DESIRED`, Loadsheet.seatMap[12].capacity, 557);
     const [upperAftDesired, setUpperAftDesired] = useSeatFlags(`L:${Loadsheet.seatMap[13].simVar}_DESIRED`, Loadsheet.seatMap[13].capacity, 571);
 
-    const globalSettingsRedux = useSelector((state:any) => state.globalSettings);
+    const globalSettingsRedux = useAppSelector((state) => state.globalSettings);
 
     const activeFlags = useMemo(
         () => [mainFwdA, mainFwdB, mainMid1A, mainMid1B, mainMid1C, mainMid2A, mainMid2B, mainMid2C, mainAftA, mainAftB, upperFwd, upperMidA, upperMidB, upperAft],
@@ -492,15 +493,13 @@ export const A380Payload: React.FC<A380Props> = ({
     useEffect(() => {
         const cabinSoundStatus:number = (totalPax > 0 ? 1 : 0);
 
-        if (globalSettingsRedux.passengerAmbienceActive) {
+        if (globalSettingsRedux.passengerAmbienceSetting) {
             setPassengerAmbienceEnabled(cabinSoundStatus);
         }
-
-        if (globalSettingsRedux.cabinAnnouncementsActive) {
+        if (globalSettingsRedux.cabinAnnouncementsSetting) {
             setAnnouncementsEnabled(cabinSoundStatus);
         }
-
-        if (globalSettingsRedux.boardindgMusicActive) {
+        if (globalSettingsRedux.boardingMusicSetting) {
             setBoardingMusicEnabled(cabinSoundStatus);
         }
     }, [totalPax]);

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A380_842/A380Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A380_842/A380Payload.tsx
@@ -503,7 +503,7 @@ export const A380Payload: React.FC<A380Props> = ({
         if (globalSettingsRedux.boardindgMusicActive) {
             setBoardingMusicEnabled(cabinSoundStatus);
         }
-    },[totalPax]);
+    }, [totalPax]);
 
     const remainingTimeString = () => {
         const minutes = Math.round(calculateBoardingTime / 60);

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A380_842/A380Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A380_842/A380Payload.tsx
@@ -118,8 +118,6 @@ export const A380Payload: React.FC<A380Props> = ({
 
     const maxPax = useMemo(() => seatMap.reduce((a, b) => a + b.capacity, 0), [seatMap]);
     const maxCargo = useMemo(() => cargoMap.reduce((a, b) => a + b.weight, 0), [cargoMap]);
-    
-
 
     // Calculate Total Pax from Pax Flags
     const totalPax = useMemo(() => {
@@ -148,7 +146,7 @@ export const A380Payload: React.FC<A380Props> = ({
     const [gw] = useSimVar('L:A32NX_AIRFRAME_GW', 'number', 1_741);
     const [gwDesired] = useSimVar('L:A32NX_AIRFRAME_GW_DESIRED', 'number', 1_787);
 
-    //Cabin Sounds
+    // Cabin sounds.
     const [passengerAmbienceEnabled, setPassengerAmbienceEnabled] = usePersistentNumberProperty('SOUND_PASSENGER_AMBIENCE_ENABLED', 1);
     const [announcementsEnabled, setAnnouncementsEnabled] = usePersistentNumberProperty('SOUND_ANNOUNCEMENTS_ENABLED', 1);
     const [boardingMusicEnabled, setBoardingMusicEnabled] = usePersistentNumberProperty('SOUND_BOARDING_MUSIC_ENABLED', 1);
@@ -490,7 +488,7 @@ export const A380Payload: React.FC<A380Props> = ({
     ]);
 
 
-  //If totalPax is 0, deactivate all sounds from the cabin
+  // If totalPax is 0, deactivate all sounds from the cabin.
   useEffect(() => {
     let cabinSoundStatus:number = 0;
     if(totalPax > 0)
@@ -511,7 +509,6 @@ export const A380Payload: React.FC<A380Props> = ({
     }
     
 },[totalPax]);
-
 
     const remainingTimeString = () => {
         const minutes = Math.round(calculateBoardingTime / 60);

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A380_842/A380Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A380_842/A380Payload.tsx
@@ -14,6 +14,7 @@ import { SelectGroup, SelectItem } from '../../../../UtilComponents/Form/Select'
 import { SeatMapWidget } from '../Seating/SeatMapWidget';
 import { PromptModal, useModals } from '../../../../UtilComponents/Modals/Modals';
 import { A380SeatOutlineBg, A380SeatOutlineUpperBg } from '../../../../Assets/A380SeatOutlineBg';
+import { useSelector } from 'react-redux';
 
 interface A380Props {
     simbriefUnits: string,
@@ -79,6 +80,8 @@ export const A380Payload: React.FC<A380Props> = ({
     const [upperMidBDesired, setUpperMidBDesired] = useSeatFlags(`L:${Loadsheet.seatMap[12].simVar}_DESIRED`, Loadsheet.seatMap[12].capacity, 557);
     const [upperAftDesired, setUpperAftDesired] = useSeatFlags(`L:${Loadsheet.seatMap[13].simVar}_DESIRED`, Loadsheet.seatMap[13].capacity, 571);
 
+    const globalSettingsRedux = useSelector((state:any) => state.globalSettings);
+
     const activeFlags = useMemo(
         () => [mainFwdA, mainFwdB, mainMid1A, mainMid1B, mainMid1C, mainMid2A, mainMid2B, mainMid2C, mainAftA, mainAftB, upperFwd, upperMidA, upperMidB, upperAft],
         [mainFwdA, mainFwdB, mainMid1A, mainMid1B, mainMid1C, mainMid2A, mainMid2B, mainMid2C, mainAftA, mainAftB, upperFwd, upperMidA, upperMidB, upperAft],
@@ -115,6 +118,8 @@ export const A380Payload: React.FC<A380Props> = ({
 
     const maxPax = useMemo(() => seatMap.reduce((a, b) => a + b.capacity, 0), [seatMap]);
     const maxCargo = useMemo(() => cargoMap.reduce((a, b) => a + b.weight, 0), [cargoMap]);
+    
+
 
     // Calculate Total Pax from Pax Flags
     const totalPax = useMemo(() => {
@@ -485,17 +490,27 @@ export const A380Payload: React.FC<A380Props> = ({
     ]);
 
 
-    //If totalPax is 0, deactivate all sounds from the cabin
-     useEffect(() => {
-        let cabinSoundStatus:number = 0;
-        if(totalPax > 0)
-        {
-            cabinSoundStatus = 1;
-        }
+  //If totalPax is 0, deactivate all sounds from the cabin
+  useEffect(() => {
+    let cabinSoundStatus:number = 0;
+    if(totalPax > 0)
+    {
+        cabinSoundStatus = 1;
+    }
+    if(globalSettingsRedux.passengerAmbienceActive)
+    {
         setPassengerAmbienceEnabled(cabinSoundStatus);
+    }
+    if(globalSettingsRedux.cabinAnnouncementsActive)
+    {
         setAnnouncementsEnabled(cabinSoundStatus);
+    }
+    if(globalSettingsRedux.boardindgMusicActive)
+    {
         setBoardingMusicEnabled(cabinSoundStatus);
-    },[totalPax]);
+    }
+    
+},[totalPax]);
 
 
     const remainingTimeString = () => {

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A380_842/A380Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A380_842/A380Payload.tsx
@@ -489,26 +489,21 @@ export const A380Payload: React.FC<A380Props> = ({
 
 
   // If totalPax is 0, deactivate all sounds from the cabin.
-  useEffect(() => {
-    let cabinSoundStatus:number = 0;
-    if(totalPax > 0)
-    {
-        cabinSoundStatus = 1;
-    }
-    if(globalSettingsRedux.passengerAmbienceActive)
-    {
-        setPassengerAmbienceEnabled(cabinSoundStatus);
-    }
-    if(globalSettingsRedux.cabinAnnouncementsActive)
-    {
-        setAnnouncementsEnabled(cabinSoundStatus);
-    }
-    if(globalSettingsRedux.boardindgMusicActive)
-    {
-        setBoardingMusicEnabled(cabinSoundStatus);
-    }
-    
-},[totalPax]);
+    useEffect(() => {
+        const cabinSoundStatus:number = (totalPax > 0 ? 1 : 0);
+
+        if (globalSettingsRedux.passengerAmbienceActive) {
+            setPassengerAmbienceEnabled(cabinSoundStatus);
+        }
+
+        if (globalSettingsRedux.cabinAnnouncementsActive) {
+            setAnnouncementsEnabled(cabinSoundStatus);
+        }
+
+        if (globalSettingsRedux.boardindgMusicActive) {
+            setBoardingMusicEnabled(cabinSoundStatus);
+        }
+    },[totalPax]);
 
     const remainingTimeString = () => {
         const minutes = Math.round(calculateBoardingTime / 60);

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A380_842/A380Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A380_842/A380Payload.tsx
@@ -143,6 +143,11 @@ export const A380Payload: React.FC<A380Props> = ({
     const [gw] = useSimVar('L:A32NX_AIRFRAME_GW', 'number', 1_741);
     const [gwDesired] = useSimVar('L:A32NX_AIRFRAME_GW_DESIRED', 'number', 1_787);
 
+    //Cabin Sounds
+    const [passengerAmbienceEnabled, setPassengerAmbienceEnabled] = usePersistentNumberProperty('SOUND_PASSENGER_AMBIENCE_ENABLED', 1);
+    const [announcementsEnabled, setAnnouncementsEnabled] = usePersistentNumberProperty('SOUND_ANNOUNCEMENTS_ENABLED', 1);
+    const [boardingMusicEnabled, setBoardingMusicEnabled] = usePersistentNumberProperty('SOUND_BOARDING_MUSIC_ENABLED', 1);
+
     // CG MAC
     const [zfwCgMac] = useSimVar('L:A32NX_AIRFRAME_ZFW_CG_PERCENT_MAC', 'number', 1_223);
     const [desiredZfwCgMac] = useSimVar('L:A32NX_AIRFRAME_ZFW_CG_PERCENT_MAC_DESIRED', 'number', 1_279);
@@ -478,6 +483,20 @@ export const A380Payload: React.FC<A380Props> = ({
         boardingStarted,
         gsxPayloadSyncEnabled,
     ]);
+
+
+    //If totalPax is 0, deactivate all sounds from the cabin
+     useEffect(() => {
+        let cabinSoundStatus:number = 0;
+        if(totalPax > 0)
+        {
+            cabinSoundStatus = 1;
+        }
+        setPassengerAmbienceEnabled(cabinSoundStatus);
+        setAnnouncementsEnabled(cabinSoundStatus);
+        setBoardingMusicEnabled(cabinSoundStatus);
+    },[totalPax]);
+
 
     const remainingTimeString = () => {
         const minutes = Math.round(calculateBoardingTime / 60);

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AudioPage.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AudioPage.tsx
@@ -10,8 +10,8 @@ import { t } from '../../translation';
 import { SimpleInput } from '../../UtilComponents/Form/SimpleInput/SimpleInput';
 import { Toggle } from '../../UtilComponents/Form/Toggle';
 import { SettingItem, SettingsPage } from '../Settings';
-import { useDispatch } from 'react-redux';
 import { setCabinAnnouncementsActive, setPassengerAmbienceActive, setBoardingMusicActive } from '../../Store/features/globalSettings';
+import { useAppDispatch } from '../../Store/store';
 
 
 export const AudioPage = () => {
@@ -31,7 +31,7 @@ export const AudioPage = () => {
     const engineSliderRef = useRef<any>(null);
     const windSliderRef = useRef<any>(null);
 
-    const dispatch = useDispatch();
+    const dispatch = useAppDispatch();
 
 
     return (

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AudioPage.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AudioPage.tsx
@@ -10,6 +10,9 @@ import { t } from '../../translation';
 import { SimpleInput } from '../../UtilComponents/Form/SimpleInput/SimpleInput';
 import { Toggle } from '../../UtilComponents/Form/Toggle';
 import { SettingItem, SettingsPage } from '../Settings';
+import { useDispatch } from 'react-redux';
+import { setCabinAnnouncementsActive, setPassengerAmbienceActive, setBoardingMusicActive } from '../../Store/features/globalSettings';
+
 
 export const AudioPage = () => {
     const [ptuAudible, setPtuAudible] = usePersistentNumberProperty('SOUND_PTU_AUDIBLE_COCKPIT', 0);
@@ -27,6 +30,9 @@ export const AudioPage = () => {
     const exteriorSliderRef = useRef<any>(null);
     const engineSliderRef = useRef<any>(null);
     const windSliderRef = useRef<any>(null);
+
+    const dispatch = useDispatch();
+
 
     return (
         <SettingsPage name={t('Settings.Audio.Title')}>
@@ -96,15 +102,24 @@ export const AudioPage = () => {
             </SettingItem>
 
             <SettingItem name={t('Settings.Audio.PassengerAmbience')}>
-                <Toggle value={!!passengerAmbienceEnabled} onToggle={(value) => setPassengerAmbienceEnabled(value ? 1 : 0)} />
+                <Toggle value={!!passengerAmbienceEnabled} onToggle={(value) => {
+                    dispatch(setPassengerAmbienceActive(value))
+                    setPassengerAmbienceEnabled(value ? 1 : 0)
+                    }} />
             </SettingItem>
 
             <SettingItem name={t('Settings.Audio.Announcements')}>
-                <Toggle value={!!announcementsEnabled} onToggle={(value) => setAnnouncementsEnabled(value ? 1 : 0)} />
+                <Toggle value={!!announcementsEnabled} onToggle={(value) => {
+                    dispatch(setCabinAnnouncementsActive(value));
+                    setAnnouncementsEnabled(value ? 1 : 0)
+                    }} />
             </SettingItem>
 
             <SettingItem name={t('Settings.Audio.BoardingMusic')}>
-                <Toggle value={!!boardingMusicEnabled} onToggle={(value) => setBoardingMusicEnabled(value ? 1 : 0)} />
+                <Toggle value={!!boardingMusicEnabled} onToggle={(value) => {
+                    dispatch(setBoardingMusicActive(value));
+                    setBoardingMusicEnabled(value ? 1 : 0)
+                    }} />
             </SettingItem>
         </SettingsPage>
     );

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AudioPage.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AudioPage.tsx
@@ -10,7 +10,7 @@ import { t } from '../../translation';
 import { SimpleInput } from '../../UtilComponents/Form/SimpleInput/SimpleInput';
 import { Toggle } from '../../UtilComponents/Form/Toggle';
 import { SettingItem, SettingsPage } from '../Settings';
-import { setCabinAnnouncementsActive, setPassengerAmbienceActive, setBoardingMusicActive } from '../../Store/features/globalSettings';
+import { setCabinAnnouncementsSetting, setPassengerAmbienceSetting, setBoardingMusicSetting } from '../../Store/features/globalSettings';
 import { useAppDispatch } from '../../Store/store';
 
 
@@ -101,21 +101,21 @@ export const AudioPage = () => {
 
             <SettingItem name={t('Settings.Audio.PassengerAmbience')}>
                 <Toggle value={!!passengerAmbienceEnabled} onToggle={(value) => {
-                    dispatch(setPassengerAmbienceActive(value))
+                    dispatch(setPassengerAmbienceSetting(value))
                     setPassengerAmbienceEnabled(value ? 1 : 0)
                     }} />
             </SettingItem>
 
             <SettingItem name={t('Settings.Audio.Announcements')}>
                 <Toggle value={!!announcementsEnabled} onToggle={(value) => {
-                    dispatch(setCabinAnnouncementsActive(value));
+                    dispatch(setCabinAnnouncementsSetting(value));
                     setAnnouncementsEnabled(value ? 1 : 0)
                     }} />
             </SettingItem>
 
             <SettingItem name={t('Settings.Audio.BoardingMusic')}>
                 <Toggle value={!!boardingMusicEnabled} onToggle={(value) => {
-                    dispatch(setBoardingMusicActive(value));
+                    dispatch(setBoardingMusicSetting(value));
                     setBoardingMusicEnabled(value ? 1 : 0)
                     }} />
             </SettingItem>

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AudioPage.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AudioPage.tsx
@@ -32,8 +32,6 @@ export const AudioPage = () => {
     const windSliderRef = useRef<any>(null);
 
     const dispatch = useAppDispatch();
-
-
     return (
         <SettingsPage name={t('Settings.Audio.Title')}>
 

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/globalSettings.ts
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/globalSettings.ts
@@ -3,31 +3,31 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 // Store for all settings which should be global for the EFB but not neccesary for the simvars.
 
 interface GlobalSettingsState {
-    cabinAnnouncementsActive:boolean,
-    passengerAmbienceActive:boolean,
-    boardingMusicActive:boolean
+    cabinAnnouncementsSetting: boolean,
+    passengerAmbienceSetting: boolean,
+    boardingMusicSetting: boolean
 }
 
-let initialState:GlobalSettingsState = {cabinAnnouncementsActive: true, passengerAmbienceActive: true, boardingMusicActive: true}
+const initialState:GlobalSettingsState = {cabinAnnouncementsSetting: true, passengerAmbienceSetting: true, boardingMusicSetting: true}
 
 export const globalSettingsSlice = createSlice({
     name: "globalSettings",
     initialState: initialState,
     reducers: {
-        setCabinAnnouncementsActive:(state: any, action: PayloadAction<boolean>) => {
+        setCabinAnnouncementsSetting:(state: any, action: PayloadAction<boolean>) => {
             state.cabinAnnouncementsActive = action.payload;
         },
-        setPassengerAmbienceActive:(state: any, action: PayloadAction<boolean>) => {
+        setPassengerAmbienceSetting:(state: any, action: PayloadAction<boolean>) => {
             state.passengerAmbienceActive = action.payload
         },
-        setBoardingMusicActive:(state: any, action: PayloadAction<boolean>) => {
+        setBoardingMusicSetting:(state: any, action: PayloadAction<boolean>) => {
             state.boardingMusicActive = action.payload;
         }
     }
 });
 
-export const {setCabinAnnouncementsActive} = globalSettingsSlice.actions;
-export const {setPassengerAmbienceActive} = globalSettingsSlice.actions;
-export const {setBoardingMusicActive} = globalSettingsSlice.actions;
+export const {setCabinAnnouncementsSetting} = globalSettingsSlice.actions;
+export const {setPassengerAmbienceSetting} = globalSettingsSlice.actions;
+export const {setBoardingMusicSetting} = globalSettingsSlice.actions;
 
 export default globalSettingsSlice.reducer;

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/globalSettings.ts
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/globalSettings.ts
@@ -1,9 +1,8 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
-//Store for alle settings which should be application global for the EFB application but not neccesary for the simvars
+// Store for all settings which should be global for the EFB but not neccesary for the simvars.
 
-interface GlobalSettingsState
-{
+interface GlobalSettingsState {
     cabinAnnouncementsActive:boolean,
     passengerAmbienceActive:boolean,
     boardingMusicActive:boolean

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/globalSettings.ts
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/globalSettings.ts
@@ -16,13 +16,13 @@ export const globalSettingsSlice = createSlice({
     initialState:initialState,
     reducers:{
         setCabinAnnouncementsActive:(state:any, action:PayloadAction<boolean>) => {
-            state.value.cabinAnnouncementsActive = action.payload;
+            state.cabinAnnouncementsActive = action.payload;
         },
         setPassengerAmbienceActive:(state:any, action:PayloadAction<boolean>) => {
-            state.value.passengerAmbienceActive = action.payload
+            state.passengerAmbienceActive = action.payload
         },
         setBoardingMusicActive:(state:any, action:PayloadAction<boolean>) => {
-            state.value.boardingMusicActive = action.payload;
+            state.boardingMusicActive = action.payload;
         }
     }
 });

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/globalSettings.ts
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/globalSettings.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 // Store for all settings which should be global for the EFB but not neccesary for the simvars.
 
@@ -6,28 +6,28 @@ interface GlobalSettingsState {
     cabinAnnouncementsSetting: boolean,
     passengerAmbienceSetting: boolean,
     boardingMusicSetting: boolean
-}
+};
 
-const initialState:GlobalSettingsState = {cabinAnnouncementsSetting: true, passengerAmbienceSetting: true, boardingMusicSetting: true}
+const initialState:GlobalSettingsState = { cabinAnnouncementsSetting: true, passengerAmbienceSetting: true, boardingMusicSetting: true };
 
 export const globalSettingsSlice = createSlice({
-    name: "globalSettings",
+    name: 'globalSettings',
     initialState: initialState,
     reducers: {
-        setCabinAnnouncementsSetting:(state: any, action: PayloadAction<boolean>) => {
+        setCabinAnnouncementsSetting: (state: any, action: PayloadAction<boolean>) => {
             state.cabinAnnouncementsActive = action.payload;
         },
-        setPassengerAmbienceSetting:(state: any, action: PayloadAction<boolean>) => {
-            state.passengerAmbienceActive = action.payload
+        setPassengerAmbienceSetting: (state: any, action: PayloadAction<boolean>) => {
+            state.passengerAmbienceActive = action.payload;
         },
-        setBoardingMusicSetting:(state: any, action: PayloadAction<boolean>) => {
+        setBoardingMusicSetting: (state: any, action: PayloadAction<boolean>) => {
             state.boardingMusicActive = action.payload;
-        }
-    }
+        },
+    },
 });
 
-export const {setCabinAnnouncementsSetting} = globalSettingsSlice.actions;
-export const {setPassengerAmbienceSetting} = globalSettingsSlice.actions;
-export const {setBoardingMusicSetting} = globalSettingsSlice.actions;
+export const { setCabinAnnouncementsSetting } = globalSettingsSlice.actions;
+export const { setPassengerAmbienceSetting } = globalSettingsSlice.actions;
+export const { setBoardingMusicSetting } = globalSettingsSlice.actions;
 
 export default globalSettingsSlice.reducer;

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/globalSettings.ts
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/globalSettings.ts
@@ -8,19 +8,19 @@ interface GlobalSettingsState {
     boardingMusicActive:boolean
 }
 
-let initialState:GlobalSettingsState = {cabinAnnouncementsActive:true, passengerAmbienceActive:true, boardingMusicActive:true}
+let initialState:GlobalSettingsState = {cabinAnnouncementsActive: true, passengerAmbienceActive: true, boardingMusicActive: true}
 
 export const globalSettingsSlice = createSlice({
-    name:"globalSettings",
-    initialState:initialState,
-    reducers:{
-        setCabinAnnouncementsActive:(state:any, action:PayloadAction<boolean>) => {
+    name: "globalSettings",
+    initialState: initialState,
+    reducers: {
+        setCabinAnnouncementsActive:(state: any, action: PayloadAction<boolean>) => {
             state.cabinAnnouncementsActive = action.payload;
         },
-        setPassengerAmbienceActive:(state:any, action:PayloadAction<boolean>) => {
+        setPassengerAmbienceActive:(state: any, action: PayloadAction<boolean>) => {
             state.passengerAmbienceActive = action.payload
         },
-        setBoardingMusicActive:(state:any, action:PayloadAction<boolean>) => {
+        setBoardingMusicActive:(state: any, action: PayloadAction<boolean>) => {
             state.boardingMusicActive = action.payload;
         }
     }

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/globalSettings.ts
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/globalSettings.ts
@@ -1,0 +1,34 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+//Store for application global Settings
+
+interface GlobalSettingsState
+{
+    cabinAnnouncementsActive:boolean,
+    passengerAmbienceActive:boolean,
+    boardingMusicActive:boolean
+}
+
+let initialState:GlobalSettingsState = {cabinAnnouncementsActive:true, passengerAmbienceActive:true, boardingMusicActive:true}
+
+export const globalSettingsSlice = createSlice({
+    name:"globalSettings",
+    initialState:initialState,
+    reducers:{
+        setCabinAnnouncementsActive:(state:any, action:PayloadAction<boolean>) => {
+            state.value.cabinAnnouncementsActive = action.payload;
+        },
+        setPassengerAmbienceActive:(state:any, action:PayloadAction<boolean>) => {
+            state.value.passengerAmbienceActive = action.payload
+        },
+        setBoardingMusicActive:(state:any, action:PayloadAction<boolean>) => {
+            state.value.boardingMusicActive = action.payload;
+        }
+    }
+});
+
+export const {setCabinAnnouncementsActive} = globalSettingsSlice.actions;
+export const {setPassengerAmbienceActive} = globalSettingsSlice.actions;
+export const {setBoardingMusicActive} = globalSettingsSlice.actions;
+
+export default globalSettingsSlice.reducer;

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/globalSettings.ts
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/globalSettings.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
-//Store for application global Settings
+//Store for alle settings which should be application global for the EFB application but not neccesary for the simvars
 
 interface GlobalSettingsState
 {

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Store/store.ts
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Store/store.ts
@@ -16,6 +16,7 @@ import dispatchPageReducer from './features/dispatchPage';
 import failuresPageReducer from './features/failuresPage';
 import tooltipReducer from './features/tooltip';
 import pushbackReducer from './features/pushback';
+import globalSettingsReducer from './features/globalSettings';
 
 export type RootState = ReturnType<typeof combinedReducer>;
 export type AppDispatch = typeof store.dispatch;
@@ -36,6 +37,7 @@ const combinedReducer = combineReducers({
     failuresPage: failuresPageReducer,
     tooltip: tooltipReducer,
     pushback: pushbackReducer,
+    globalSettings: globalSettingsReducer
 });
 
 const rootReducer: Reducer = (state: RootState, action: AnyAction) => {

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Store/store.ts
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Store/store.ts
@@ -37,7 +37,7 @@ const combinedReducer = combineReducers({
     failuresPage: failuresPageReducer,
     tooltip: tooltipReducer,
     pushback: pushbackReducer,
-    globalSettings: globalSettingsReducer
+    globalSettings: globalSettingsReducer,
 });
 
 const rootReducer: Reducer = (state: RootState, action: AnyAction) => {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8298

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Added logic which disables all cabin sounds when the current flieght hasn´t any passangers
- Added "globalSettings" redux for storing data global in the "EFB" project without using the simvars. I need this for storing the sound states the player defines on the settings page
    

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): louisdev08

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Start a flight
2. Make sure there are passengers on Board and the cabin crew sounds (announcements, passenger ambience and boarding music) is enabled in the settings page of the EFD.
3. Switch on beacon lights or do another event which triggers a cabin crew announcement
4. While the flight attendant is doing the announcement, switch the pax to 0 in the EFB
5. When pax gets 0 the attendant immediately stops doing the announcement.


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
1. Build the **A32NX**
1. Install the **A32NX**  
