### PR TITLE
fix(efcs): prevent uncommanded roll over 400kts

### DIFF
--- a/fbw-a32nx/src/wasm/fbw_a320/src/model/LateralNormalLaw.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/model/LateralNormalLaw.cpp
@@ -261,11 +261,11 @@ void LateralNormalLaw::step(const real_T *rtu_In_time_dt, const real_T *rtu_In_T
   *rtu_In_high_aoa_prot_active, const boolean_T *rtu_In_high_speed_prot_active, const real_T *rtu_In_ap_phi_c_deg, const
   real_T *rtu_In_ap_beta_c_deg, const boolean_T *rtu_In_any_ap_engaged, real_T *rty_Out_xi_deg, real_T *rty_Out_zeta_deg)
 {
-  static const real_T c_0[4]{ 1.0, 1.2, 2.0, 2.0 };
+  static const real_T c_0[5]{ 1.0, 1.0, 1.2, 2.0, 2.0 };
+
+  static const int16_T b_0[5]{ -1, 0, 120, 320, 400 };
 
   static const int16_T b[4]{ 0, 120, 150, 380 };
-
-  static const int16_T b_0[4]{ 0, 120, 320, 400 };
 
   static const int8_T c[4]{ -15, -15, -15, -2 };
 
@@ -366,9 +366,12 @@ void LateralNormalLaw::step(const real_T *rtu_In_time_dt, const real_T *rtu_In_T
   v_cas_ms = std::fmax(*rtu_In_V_ias_kn, 80.0) * 0.5144;
   Vias = v_cas_ms * v_cas_ms * 0.6125;
   L_xi = Vias * 122.0 * 17.9 * -0.090320788790706555 / 1.0E+6;
-  r = 0.0;
-  if ((*rtu_In_V_ias_kn <= 400.0) && (*rtu_In_V_ias_kn >= 0.0)) {
-    rtb_in_flight = 4;
+  if (*rtu_In_V_ias_kn > 400.0) {
+    r = 2.0;
+  } else if (*rtu_In_V_ias_kn < -1.0) {
+    r = 1.0;
+  } else {
+    rtb_in_flight = 5;
     low_i = 0;
     low_ip1 = 2;
     while (rtb_in_flight > low_ip1) {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes a small issue where the omega_0 of the roll law was going to either 0 or NaN, when exceeding 400kts CAS, due to the default setting in MATLABs interp1d function to not extrapolate (the maximum x-value of the LUT was 400kts). Now, extrapolation is active and points have been added to ensure a 0-gradient at the edges (i.e. the value remains constant below 0kts and above 400kts).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
