### PR TITLE
feat: Support EX1 events to be used for fbw events

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -21,6 +21,7 @@
 1. [HOPPIE] Remove ATSU/AOC source checks - @auroraisluna (alepouna)
 1. [PFD] Graphical improvements and updates to the FMA - @BravoMike99 (bruno_pt99)
 1. [PFD] Hide '+' sign on V/S & FPA FMA if selected value is 0 - @BravoMike99 (bruno_pt99)
+1. [API] Added EX1 event handling for fbw.wasm c++ code - @frankkopp (Frank Kopp)
 
 ## 0.11.0
 

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
@@ -1425,8 +1425,11 @@ void SimConnectInterface::simConnectProcessDispatchMessage(SIMCONNECT_RECV* pDat
       break;
 
     case SIMCONNECT_RECV_ID_EVENT:
-      // get event
       simConnectProcessEvent(static_cast<SIMCONNECT_RECV_EVENT*>(pData));
+      break;
+
+    case SIMCONNECT_RECV_ID_EVENT_EX1:
+      simConnectProcessEvent_EX1(static_cast<SIMCONNECT_RECV_EVENT_EX1*>(pData));
       break;
 
     case SIMCONNECT_RECV_ID_SIMOBJECT_DATA:

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
@@ -1453,13 +1453,25 @@ void SimConnectInterface::simConnectProcessDispatchMessage(SIMCONNECT_RECV* pDat
 }
 
 void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* event) {
+  const DWORD eventId = event->uEventID;
+  const DWORD data0 = event->dwData;
+  processEventWithOneParam(eventId, data0);
+}
+
+void SimConnectInterface::simConnectProcessEvent_EX1(const SIMCONNECT_RECV_EVENT_EX1* event) {
+  const DWORD eventId = event->uEventID;
+  const DWORD data0 = event->dwData0;
+  processEventWithOneParam(eventId, data0);
+}
+
+void SimConnectInterface::processEventWithOneParam(const DWORD eventId, const DWORD data0) {
   // process depending on event id
-  switch (event->uEventID) {
-    case Events::AXIS_ELEVATOR_SET: {
-      simInput.inputs[AXIS_ELEVATOR_SET] = static_cast<long>(event->dwData) / 16384.0;
+  switch (eventId) {
+    case AXIS_ELEVATOR_SET: {
+      simInput.inputs[AXIS_ELEVATOR_SET] = static_cast<long>(data0) / 16384.0;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: AXIS_ELEVATOR_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_ELEVATOR_SET];
         std::cout << std::endl;
@@ -1467,11 +1479,11 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::AXIS_AILERONS_SET: {
-      simInput.inputs[AXIS_AILERONS_SET] = static_cast<long>(event->dwData) / 16384.0;
+    case AXIS_AILERONS_SET: {
+      simInput.inputs[AXIS_AILERONS_SET] = static_cast<long>(data0) / 16384.0;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: AXIS_AILERONS_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_AILERONS_SET];
         std::cout << std::endl;
@@ -1479,11 +1491,11 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::AXIS_RUDDER_SET: {
-      simInput.inputs[AXIS_RUDDER_SET] = static_cast<long>(event->dwData) / 16384.0;
+    case AXIS_RUDDER_SET: {
+      simInput.inputs[AXIS_RUDDER_SET] = static_cast<long>(data0) / 16384.0;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: AXIS_RUDDER_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_RUDDER_SET];
         std::cout << std::endl;
@@ -1491,11 +1503,11 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::RUDDER_SET: {
-      simInput.inputs[AXIS_RUDDER_SET] = static_cast<long>(event->dwData) / 16384.0;
+    case RUDDER_SET: {
+      simInput.inputs[AXIS_RUDDER_SET] = static_cast<long>(data0) / 16384.0;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_RUDDER_SET];
         std::cout << std::endl;
@@ -1503,8 +1515,8 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::RUDDER_LEFT: {
-      simInput.inputs[AXIS_RUDDER_SET] = std::fmin(1.0, simInput.inputs[AXIS_RUDDER_SET] + flightControlsKeyChangeRudder);
+    case RUDDER_LEFT: {
+      simInput.inputs[AXIS_RUDDER_SET] = fmin(1.0, simInput.inputs[AXIS_RUDDER_SET] + flightControlsKeyChangeRudder);
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_LEFT: ";
         std::cout << "(no data)";
@@ -1515,7 +1527,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::RUDDER_CENTER: {
+    case RUDDER_CENTER: {
       simInput.inputs[AXIS_RUDDER_SET] = 0.0;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_CENTER: ";
@@ -1527,8 +1539,8 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::RUDDER_RIGHT: {
-      simInput.inputs[AXIS_RUDDER_SET] = std::fmax(-1.0, simInput.inputs[AXIS_RUDDER_SET] - flightControlsKeyChangeRudder);
+    case RUDDER_RIGHT: {
+      simInput.inputs[AXIS_RUDDER_SET] = fmax(-1.0, simInput.inputs[AXIS_RUDDER_SET] - flightControlsKeyChangeRudder);
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_RIGHT: ";
         std::cout << "(no data)";
@@ -1539,19 +1551,19 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::RUDDER_AXIS_MINUS: {
+    case RUDDER_AXIS_MINUS: {
       double tmpValue = 0;
-      if (this->disableXboxCompatibilityRudderPlusMinus) {
+      if (disableXboxCompatibilityRudderPlusMinus) {
         // normal axis
-        tmpValue = +1.0 * ((static_cast<long>(event->dwData) + 16384.0) / 32768.0);
+        tmpValue = +1.0 * ((static_cast<long>(data0) + 16384.0) / 32768.0);
       } else {
         // xbox controller
-        tmpValue = +1.0 * (static_cast<long>(event->dwData) / 16384.0);
+        tmpValue = +1.0 * (static_cast<long>(data0) / 16384.0);
       }
 
       // This allows using two independent axis for rudder which are mapped to RUDDER AXIS LEFT and RUDDER AXIS RIGHT
       // As it might be incompatible with some controllers, it is configurable
-      if (this->enableRudder2AxisMode) {
+      if (enableRudder2AxisMode) {
         rudderLeftAxis = tmpValue;
         tmpValue = -1 * ((rudderRightAxis - rudderLeftAxis) / 2.0);
       }
@@ -1559,10 +1571,10 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       simInput.inputs[AXIS_RUDDER_SET] = tmpValue;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_AXIS_MINUS: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_RUDDER_SET];
-        if (this->enableRudder2AxisMode) {
+        if (enableRudder2AxisMode) {
           std::cout << " (left: " << rudderLeftAxis << ", right: " << rudderRightAxis << ")";
         }
         std::cout << std::endl;
@@ -1570,19 +1582,19 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::RUDDER_AXIS_PLUS: {
+    case RUDDER_AXIS_PLUS: {
       double tmpValue = 0;
-      if (this->disableXboxCompatibilityRudderPlusMinus) {
+      if (disableXboxCompatibilityRudderPlusMinus) {
         // normal axis
-        tmpValue = -1.0 * ((static_cast<long>(event->dwData) + 16384.0) / 32768.0);
+        tmpValue = -1.0 * ((static_cast<long>(data0) + 16384.0) / 32768.0);
       } else {
         // xbox controller
-        tmpValue = -1.0 * (static_cast<long>(event->dwData) / 16384.0);
+        tmpValue = -1.0 * (static_cast<long>(data0) / 16384.0);
       }
 
       // This allows using two independent axis for rudder which are mapped to RUDDER AXIS LEFT and RUDDER AXIS RIGHT
       // As it might be incompatible with some controllers, it is configurable
-      if (this->enableRudder2AxisMode) {
+      if (enableRudder2AxisMode) {
         rudderRightAxis = -tmpValue;
         tmpValue = -1 * ((rudderRightAxis - rudderLeftAxis) / 2.0);
       }
@@ -1590,10 +1602,10 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       simInput.inputs[AXIS_RUDDER_SET] = tmpValue;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_AXIS_PLUS: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_RUDDER_SET];
-        if (this->enableRudder2AxisMode) {
+        if (enableRudder2AxisMode) {
           std::cout << " (left: " << rudderLeftAxis << ", right: " << rudderRightAxis << ")";
         }
         std::cout << std::endl;
@@ -1601,7 +1613,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::RUDDER_TRIM_LEFT: {
+    case RUDDER_TRIM_LEFT: {
       simInputRudderTrim.rudderTrimSwitchLeft = true;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_TRIM_LEFT: ";
@@ -1611,7 +1623,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::RUDDER_TRIM_RESET: {
+    case RUDDER_TRIM_RESET: {
       simInputRudderTrim.rudderTrimReset = true;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_TRIM_RESET: ";
@@ -1621,7 +1633,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::RUDDER_TRIM_RIGHT: {
+    case RUDDER_TRIM_RIGHT: {
       simInputRudderTrim.rudderTrimSwitchRight = true;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_TRIM_RIGHT: ";
@@ -1631,29 +1643,29 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::RUDDER_TRIM_SET: {
+    case RUDDER_TRIM_SET: {
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_TRIM_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << std::endl;
       }
       break;
     }
 
-    case Events::RUDDER_TRIM_SET_EX1: {
+    case RUDDER_TRIM_SET_EX1: {
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_TRIM_SET_EX1: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << std::endl;
       }
       break;
     }
 
-    case Events::AILERON_SET: {
-      simInput.inputs[AXIS_AILERONS_SET] = static_cast<long>(event->dwData) / 16384.0;
+    case AILERON_SET: {
+      simInput.inputs[AXIS_AILERONS_SET] = static_cast<long>(data0) / 16384.0;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: AILERON_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_AILERONS_SET];
         std::cout << std::endl;
@@ -1661,8 +1673,8 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::AILERONS_LEFT: {
-      simInput.inputs[AXIS_AILERONS_SET] = std::fmin(1.0, simInput.inputs[AXIS_AILERONS_SET] + flightControlsKeyChangeAileron);
+    case AILERONS_LEFT: {
+      simInput.inputs[AXIS_AILERONS_SET] = fmin(1.0, simInput.inputs[AXIS_AILERONS_SET] + flightControlsKeyChangeAileron);
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: AILERONS_LEFT: ";
         std::cout << "(no data)";
@@ -1673,8 +1685,8 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::AILERONS_RIGHT: {
-      simInput.inputs[AXIS_AILERONS_SET] = std::fmax(-1.0, simInput.inputs[AXIS_AILERONS_SET] - flightControlsKeyChangeAileron);
+    case AILERONS_RIGHT: {
+      simInput.inputs[AXIS_AILERONS_SET] = fmax(-1.0, simInput.inputs[AXIS_AILERONS_SET] - flightControlsKeyChangeAileron);
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: AILERONS_RIGHT: ";
         std::cout << "(no data)";
@@ -1685,7 +1697,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::CENTER_AILER_RUDDER: {
+    case CENTER_AILER_RUDDER: {
       simInput.inputs[AXIS_RUDDER_SET] = 0.0;
       simInput.inputs[AXIS_AILERONS_SET] = 0.0;
       if (loggingFlightControlsEnabled) {
@@ -1700,11 +1712,11 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::ELEVATOR_SET: {
-      simInput.inputs[AXIS_ELEVATOR_SET] = static_cast<long>(event->dwData) / 16384.0;
+    case ELEVATOR_SET: {
+      simInput.inputs[AXIS_ELEVATOR_SET] = static_cast<long>(data0) / 16384.0;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: ELEVATOR_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_ELEVATOR_SET];
         std::cout << std::endl;
@@ -1712,8 +1724,8 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::ELEV_DOWN: {
-      simInput.inputs[AXIS_ELEVATOR_SET] = std::fmin(1.0, simInput.inputs[AXIS_ELEVATOR_SET] + flightControlsKeyChangeElevator);
+    case ELEV_DOWN: {
+      simInput.inputs[AXIS_ELEVATOR_SET] = fmin(1.0, simInput.inputs[AXIS_ELEVATOR_SET] + flightControlsKeyChangeElevator);
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: ELEV_DOWN: ";
         std::cout << "(no data)";
@@ -1724,8 +1736,8 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::ELEV_UP: {
-      simInput.inputs[AXIS_ELEVATOR_SET] = std::fmax(-1.0, simInput.inputs[AXIS_ELEVATOR_SET] - flightControlsKeyChangeElevator);
+    case ELEV_UP: {
+      simInput.inputs[AXIS_ELEVATOR_SET] = fmax(-1.0, simInput.inputs[AXIS_ELEVATOR_SET] - flightControlsKeyChangeElevator);
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: ELEV_UP: ";
         std::cout << "(no data)";
@@ -1736,114 +1748,114 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::AUTOPILOT_OFF: {
+    case AUTOPILOT_OFF: {
       simInputAutopilot.AP_disconnect = 1;
       std::cout << "WASM: event triggered: AUTOPILOT_OFF" << std::endl;
       break;
     }
 
-    case Events::AUTOPILOT_ON: {
+    case AUTOPILOT_ON: {
       simInputAutopilot.AP_engage = 1;
       std::cout << "WASM: event triggered: AUTOPILOT_ON" << std::endl;
       break;
     }
 
-    case Events::TOGGLE_FLIGHT_DIRECTOR: {
-      std::cout << "WASM: event triggered: TOGGLE_FLIGHT_DIRECTOR:" << static_cast<long>(event->dwData) << std::endl;
+    case TOGGLE_FLIGHT_DIRECTOR: {
+      std::cout << "WASM: event triggered: TOGGLE_FLIGHT_DIRECTOR:" << static_cast<long>(data0) << std::endl;
       break;
     }
 
-    case Events::AP_MASTER: {
+    case AP_MASTER: {
       simInputAutopilot.AP_1_push = 1;
       std::cout << "WASM: event triggered: AP_MASTER" << std::endl;
       break;
     }
 
-    case Events::AUTOPILOT_DISENGAGE_SET: {
-      if (static_cast<long>(event->dwData) == 1) {
+    case AUTOPILOT_DISENGAGE_SET: {
+      if (static_cast<long>(data0) == 1) {
         simInputAutopilot.AP_disconnect = 1;
         std::cout << "WASM: event triggered: AUTOPILOT_DISENGAGE_SET" << std::endl;
       }
       break;
     }
 
-    case Events::AUTOPILOT_DISENGAGE_TOGGLE: {
+    case AUTOPILOT_DISENGAGE_TOGGLE: {
       simInputAutopilot.AP_1_push = 1;
       std::cout << "WASM: event triggered: AUTOPILOT_DISENGAGE_TOGGLE" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_AP_1_PUSH: {
+    case A32NX_FCU_AP_1_PUSH: {
       simInputAutopilot.AP_1_push = 1;
       std::cout << "WASM: event triggered: A32NX_FCU_AP_1_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_AP_2_PUSH: {
+    case A32NX_FCU_AP_2_PUSH: {
       simInputAutopilot.AP_2_push = 1;
       std::cout << "WASM: event triggered: A32NX_FCU_AP_2_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_AP_DISCONNECT_PUSH: {
+    case A32NX_FCU_AP_DISCONNECT_PUSH: {
       simInputAutopilot.AP_disconnect = 1;
       std::cout << "WASM: event triggered: A32NX_FCU_AP_DISCONNECT_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_ATHR_PUSH: {
+    case A32NX_FCU_ATHR_PUSH: {
       simInputThrottles.ATHR_push = 1;
       std::cout << "WASM: event triggered: A32NX_FCU_ATHR_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_ATHR_DISCONNECT_PUSH: {
+    case A32NX_FCU_ATHR_DISCONNECT_PUSH: {
       simInputThrottles.ATHR_disconnect = 1;
       std::cout << "WASM: event triggered: A32NX_FCU_ATHR_DISCONNECT_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_SPD_INC: {
+    case A32NX_FCU_SPD_INC: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_INC)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: A32NX_FCU_SPD_INC" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_SPD_DEC: {
+    case A32NX_FCU_SPD_DEC: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_DEC)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: A32NX_FCU_SPD_DEC" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_SPD_SET: {
-      idFcuEventSetSPEED->set(static_cast<long>(event->dwData));
+    case A32NX_FCU_SPD_SET: {
+      idFcuEventSetSPEED->set(static_cast<long>(data0));
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_SET)", nullptr, nullptr, nullptr);
-      std::cout << "WASM: event triggered: A32NX_FCU_SPD_SET: " << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_SPD_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_SPD_PUSH:
-    case Events::AP_AIRSPEED_ON: {
+    case A32NX_FCU_SPD_PUSH:
+    case AP_AIRSPEED_ON: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_PUSH)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: A32NX_FCU_SPD_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_SPD_PULL:
-    case Events::AP_AIRSPEED_OFF: {
+    case A32NX_FCU_SPD_PULL:
+    case AP_AIRSPEED_OFF: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_PULL)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: A32NX_FCU_SPD_PULL" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_SPD_MACH_TOGGLE_PUSH:
-    case Events::AP_MACH_HOLD: {
+    case A32NX_FCU_SPD_MACH_TOGGLE_PUSH:
+    case AP_MACH_HOLD: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_TOGGLE_SPEED_MACH)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: A32NX_FCU_SPD_MACH_TOGGLE_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_HDG_INC: {
+    case A32NX_FCU_HDG_INC: {
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_HDG_INC_TRACK) } els{ (>H:A320_Neo_FCU_HDG_INC_HEADING) }",
           nullptr, nullptr, nullptr);
@@ -1851,7 +1863,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::A32NX_FCU_HDG_DEC: {
+    case A32NX_FCU_HDG_DEC: {
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_HDG_DEC_TRACK) } els{ (>H:A320_Neo_FCU_HDG_DEC_HEADING) }",
           nullptr, nullptr, nullptr);
@@ -1859,48 +1871,48 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::A32NX_FCU_HDG_SET: {
-      idFcuEventSetHDG->set(static_cast<long>(event->dwData));
+    case A32NX_FCU_HDG_SET: {
+      idFcuEventSetHDG->set(static_cast<long>(data0));
       execute_calculator_code("(>H:A320_Neo_FCU_HDG_SET)", nullptr, nullptr, nullptr);
-      std::cout << "WASM: event triggered: A32NX_FCU_HDG_SET: " << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_HDG_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_HDG_PUSH:
-    case Events::AP_HDG_HOLD_ON: {
+    case A32NX_FCU_HDG_PUSH:
+    case AP_HDG_HOLD_ON: {
       execute_calculator_code("(>H:A320_Neo_FCU_HDG_PUSH)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: A32NX_FCU_HDG_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_HDG_PULL:
-    case Events::AP_HDG_HOLD_OFF: {
+    case A32NX_FCU_HDG_PULL:
+    case AP_HDG_HOLD_OFF: {
       execute_calculator_code("(>H:A320_Neo_FCU_HDG_PULL)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: A32NX_FCU_HDG_PULL" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_TRK_FPA_TOGGLE_PUSH:
-    case Events::AP_VS_HOLD: {
+    case A32NX_FCU_TRK_FPA_TOGGLE_PUSH:
+    case AP_VS_HOLD: {
       execute_calculator_code("(L:A32NX_TRK_FPA_MODE_ACTIVE) ! (>L:A32NX_TRK_FPA_MODE_ACTIVE)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: A32NX_FCU_TRK_FPA_TOGGLE_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_TO_AP_HDG_PUSH: {
+    case A32NX_FCU_TO_AP_HDG_PUSH: {
       simInputAutopilot.HDG_push = 1;
       std::cout << "WASM: event triggered: A32NX_FCU_TO_AP_HDG_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_TO_AP_HDG_PULL: {
+    case A32NX_FCU_TO_AP_HDG_PULL: {
       simInputAutopilot.HDG_pull = 1;
       std::cout << "WASM: event triggered: A32NX_FCU_TO_AP_HDG_PULL" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_ALT_INC: {
-      long increment = static_cast<long>(event->dwData);
+    case A32NX_FCU_ALT_INC: {
+      long increment = static_cast<long>(data0);
       if (increment == 100) {
         execute_calculator_code(
             "3 (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) 100 + (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) "
@@ -1924,8 +1936,8 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::A32NX_FCU_ALT_DEC: {
-      long increment = static_cast<long>(event->dwData);
+    case A32NX_FCU_ALT_DEC: {
+      long increment = static_cast<long>(data0);
       if (increment == 100) {
         execute_calculator_code(
             "3 (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) 100 - 100 "
@@ -1950,8 +1962,8 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::A32NX_FCU_ALT_SET: {
-      long value = 100 * (static_cast<long>(event->dwData) / 100);
+    case A32NX_FCU_ALT_SET: {
+      long value = 100 * (static_cast<long>(data0) / 100);
       std::ostringstream stringStream;
       stringStream << value;
       stringStream << " (>K:3:AP_ALT_VAR_SET_ENGLISH)";
@@ -1960,8 +1972,8 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::A32NX_FCU_ALT_INCREMENT_TOGGLE:
-    case Events::AP_ALT_HOLD: {
+    case A32NX_FCU_ALT_INCREMENT_TOGGLE:
+    case AP_ALT_HOLD: {
       execute_calculator_code(
           "(L:XMLVAR_Autopilot_Altitude_Increment, number) 100 == "
           "if{ 1000 (>L:XMLVAR_Autopilot_Altitude_Increment) } "
@@ -1971,8 +1983,8 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::A32NX_FCU_ALT_INCREMENT_SET: {
-      long value = static_cast<long>(event->dwData);
+    case A32NX_FCU_ALT_INCREMENT_SET: {
+      long value = static_cast<long>(data0);
       if (value == 100 || value == 1000) {
         std::ostringstream stringStream;
         stringStream << value;
@@ -1983,23 +1995,23 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::A32NX_FCU_ALT_PUSH:
-    case Events::AP_ALT_HOLD_ON: {
+    case A32NX_FCU_ALT_PUSH:
+    case AP_ALT_HOLD_ON: {
       simInputAutopilot.ALT_push = 1;
       execute_calculator_code("(>H:A320_Neo_CDU_MODE_MANAGED_ALTITUDE)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: A32NX_FCU_ALT_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_ALT_PULL:
-    case Events::AP_ALT_HOLD_OFF: {
+    case A32NX_FCU_ALT_PULL:
+    case AP_ALT_HOLD_OFF: {
       simInputAutopilot.ALT_pull = 1;
       execute_calculator_code("(>H:A320_Neo_CDU_MODE_SELECTED_ALTITUDE)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: A32NX_FCU_ALT_PULL" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_VS_INC: {
+    case A32NX_FCU_VS_INC: {
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_VS_INC_FPA) } els{ (>H:A320_Neo_FCU_VS_INC_VS) } "
           "(>H:A320_Neo_CDU_VS)",
@@ -2008,7 +2020,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::A32NX_FCU_VS_DEC: {
+    case A32NX_FCU_VS_DEC: {
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_VS_DEC_FPA) } els{ (>H:A320_Neo_FCU_VS_DEC_VS) } "
           "(>H:A320_Neo_CDU_VS)",
@@ -2017,122 +2029,122 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::A32NX_FCU_VS_SET: {
-      idFcuEventSetVS->set(static_cast<long>(event->dwData));
+    case A32NX_FCU_VS_SET: {
+      idFcuEventSetVS->set(static_cast<long>(data0));
       execute_calculator_code("(>H:A320_Neo_FCU_VS_SET) (>H:A320_Neo_CDU_VS)", nullptr, nullptr, nullptr);
-      std::cout << "WASM: event triggered: A32NX_FCU_VS_SET: " << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_VS_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_VS_PUSH:
-    case Events::AP_VS_ON: {
+    case A32NX_FCU_VS_PUSH:
+    case AP_VS_ON: {
       execute_calculator_code("(>H:A320_Neo_FCU_VS_PUSH) (>H:A320_Neo_CDU_VS)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: A32NX_FCU_VS_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_VS_PULL:
-    case Events::AP_VS_OFF: {
+    case A32NX_FCU_VS_PULL:
+    case AP_VS_OFF: {
       execute_calculator_code("(>H:A320_Neo_FCU_VS_PULL) (>H:A320_Neo_CDU_VS)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: A32NX_FCU_VS_PULL" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_TO_AP_VS_PUSH: {
+    case A32NX_FCU_TO_AP_VS_PUSH: {
       simInputAutopilot.VS_push = 1;
       std::cout << "WASM: event triggered: A32NX_FCU_TO_AP_VS_PUSH" << std::endl;
       break;
     }
-    case Events::A32NX_FCU_TO_AP_VS_PULL: {
+    case A32NX_FCU_TO_AP_VS_PULL: {
       simInputAutopilot.VS_pull = 1;
       std::cout << "WASM: event triggered: A32NX_FCU_TO_AP_VS_PULL" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_LOC_PUSH: {
+    case A32NX_FCU_LOC_PUSH: {
       simInputAutopilot.LOC_push = 1;
       std::cout << "WASM: event triggered: A32NX_FCU_LOC_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_APPR_PUSH: {
+    case A32NX_FCU_APPR_PUSH: {
       simInputAutopilot.APPR_push = 1;
       std::cout << "WASM: event triggered: A32NX_FCU_APPR_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FCU_EXPED_PUSH:
-    case Events::AP_ATT_HOLD: {
+    case A32NX_FCU_EXPED_PUSH:
+    case AP_ATT_HOLD: {
       simInputAutopilot.EXPED_push = 1;
       std::cout << "WASM: event triggered: A32NX_FCU_EXPED_PUSH" << std::endl;
       break;
     }
 
-    case Events::A32NX_FMGC_DIR_TO_TRIGGER: {
+    case A32NX_FMGC_DIR_TO_TRIGGER: {
       simInputAutopilot.DIR_TO_trigger = 1;
       std::cout << "WASM: event triggered: A32NX_FMGC_DIR_TO_TRIGGER" << std::endl;
       break;
     }
 
-    case Events::A32NX_EFIS_L_CHRONO_PUSHED: {
+    case A32NX_EFIS_L_CHRONO_PUSHED: {
       execute_calculator_code("(>H:A32NX_EFIS_L_CHRONO_PUSHED)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: A32NX_EFIS_L_CHRONO_PUSHED" << std::endl;
       break;
     }
 
-    case Events::A32NX_EFIS_R_CHRONO_PUSHED: {
+    case A32NX_EFIS_R_CHRONO_PUSHED: {
       execute_calculator_code("(>H:A32NX_EFIS_R_CHRONO_PUSHED)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: A32NX_EFIS_R_CHRONO_PUSHED" << std::endl;
       break;
     }
 
-    case Events::AP_SPEED_SLOT_INDEX_SET: {
+    case AP_SPEED_SLOT_INDEX_SET: {
       // for the time being do not activate, it ends in a loop. more work has to be done to support this
-      // if (static_cast<long>(event->dwData) == 2) {
+      // if (static_cast<long>(event->data0) == 2) {
       //   execute_calculator_code("(>H:A320_Neo_FCU_SPEED_PUSH)", nullptr, nullptr, nullptr);
       // } else {
       //   execute_calculator_code("(>H:A320_Neo_FCU_SPEED_PULL)", nullptr, nullptr, nullptr);
       // }
-      std::cout << "WASM: event triggered: SPEED_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: SPEED_SLOT_INDEX_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
 
-    case Events::AP_SPD_VAR_INC: {
+    case AP_SPD_VAR_INC: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_INC)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: AP_SPD_VAR_INC" << std::endl;
       break;
     }
 
-    case Events::AP_SPD_VAR_DEC: {
+    case AP_SPD_VAR_DEC: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_DEC)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: AP_SPD_VAR_DEC" << std::endl;
       break;
     }
 
-    case Events::AP_MACH_VAR_INC: {
+    case AP_MACH_VAR_INC: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_INC)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: AP_MACH_VAR_INC" << std::endl;
       break;
     }
 
-    case Events::AP_MACH_VAR_DEC: {
+    case AP_MACH_VAR_DEC: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_DEC)", nullptr, nullptr, nullptr);
       std::cout << "WASM: event triggered: AP_MACH_VAR_DEC" << std::endl;
       break;
     }
 
-    case Events::AP_HEADING_SLOT_INDEX_SET: {
+    case AP_HEADING_SLOT_INDEX_SET: {
       // for the time being do not activate, it ends in a loop. more work has to be done to support this
-      // if (static_cast<long>(event->dwData) == 2) {
+      // if (static_cast<long>(event->data0) == 2) {
       //   execute_calculator_code("(>H:A320_Neo_FCU_VS_PUSH)", nullptr, nullptr, nullptr);
       // } else {
       //   execute_calculator_code("(>H:A320_Neo_FCU_VS_PULL)", nullptr, nullptr, nullptr);
       // }
-      std::cout << "WASM: event triggered: HEADING_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: HEADING_SLOT_INDEX_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
 
-    case Events::HEADING_BUG_INC: {
+    case HEADING_BUG_INC: {
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_HDG_INC_TRACK) } els{ (>H:A320_Neo_FCU_HDG_INC_HEADING) }",
           nullptr, nullptr, nullptr);
@@ -2140,7 +2152,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::HEADING_BUG_DEC: {
+    case HEADING_BUG_DEC: {
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_HDG_DEC_TRACK) } els{ (>H:A320_Neo_FCU_HDG_DEC_HEADING) }",
           nullptr, nullptr, nullptr);
@@ -2148,18 +2160,18 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::AP_ALTITUDE_SLOT_INDEX_SET: {
+    case AP_ALTITUDE_SLOT_INDEX_SET: {
       // for the time being do not activate, it ends in a loop. more work has to be done to support this
-      // if (static_cast<long>(event->dwData) == 2) {
+      // if (static_cast<long>(event->data0) == 2) {
       //   execute_calculator_code("(>H:A320_Neo_FCU_ALT_PUSH) (>H:A320_Neo_CDU_MODE_MANAGED_ALTITUDE)", nullptr, nullptr, nullptr);
       // } else {
       //   execute_calculator_code("(>H:A320_Neo_FCU_ALT_PULL) (>H:A320_Neo_CDU_MODE_SELECTED_ALTITUDE)", nullptr, nullptr, nullptr);
       // }
-      std::cout << "WASM: event triggered: ALTITUDE_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: ALTITUDE_SLOT_INDEX_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
 
-    case Events::AP_ALT_VAR_INC: {
+    case AP_ALT_VAR_INC: {
       execute_calculator_code(
           "3 (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) (L:XMLVAR_Autopilot_Altitude_Increment) + (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) "
           "(L:XMLVAR_Autopilot_Altitude_Increment) % - 49000 min (>K:2:AP_ALT_VAR_SET_ENGLISH) (>H:AP_KNOB_Up) "
@@ -2169,7 +2181,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::AP_ALT_VAR_DEC: {
+    case AP_ALT_VAR_DEC: {
       execute_calculator_code(
           "3 (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) (L:XMLVAR_Autopilot_Altitude_Increment) - (L:XMLVAR_Autopilot_Altitude_Increment) "
           "(A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) (L:XMLVAR_Autopilot_Altitude_Increment) % - (L:XMLVAR_Autopilot_Altitude_Increment) % "
@@ -2179,18 +2191,18 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::AP_VS_SLOT_INDEX_SET: {
+    case AP_VS_SLOT_INDEX_SET: {
       // for the time being do not activate, it ends in a loop. more work has to be done to support this
-      // if (static_cast<long>(event->dwData) == 2) {
+      // if (static_cast<long>(event->data0) == 2) {
       //   execute_calculator_code("(>H:A320_Neo_FCU_VS_PUSH)", nullptr, nullptr, nullptr);
       // } else {
       //   execute_calculator_code("(>H:A320_Neo_FCU_VS_PULL)", nullptr, nullptr, nullptr);
       // }
-      std::cout << "WASM: event triggered: VS_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: VS_SLOT_INDEX_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
 
-    case Events::AP_VS_VAR_INC: {
+    case AP_VS_VAR_INC: {
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_VS_INC_FPA) } els{ (>H:A320_Neo_FCU_VS_INC_VS) }", nullptr,
           nullptr, nullptr);
@@ -2198,7 +2210,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::AP_VS_VAR_DEC: {
+    case AP_VS_VAR_DEC: {
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_VS_DEC_FPA) } els{ (>H:A320_Neo_FCU_VS_DEC_VS) }", nullptr,
           nullptr, nullptr);
@@ -2206,122 +2218,122 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::AP_APR_HOLD: {
+    case AP_APR_HOLD: {
       simInputAutopilot.APPR_push = 1;
       std::cout << "WASM: event triggered: AP_APR_HOLD" << std::endl;
       break;
     }
 
-    case Events::AP_LOC_HOLD: {
+    case AP_LOC_HOLD: {
       simInputAutopilot.LOC_push = 1;
       std::cout << "WASM: event triggered: AP_LOC_HOLD" << std::endl;
       break;
     }
 
-    case Events::AUTO_THROTTLE_ARM: {
+    case AUTO_THROTTLE_ARM: {
       simInputThrottles.ATHR_push = 1;
       std::cout << "WASM: event triggered: AUTO_THROTTLE_ARM" << std::endl;
       break;
     }
 
-    case Events::AUTO_THROTTLE_DISCONNECT: {
+    case AUTO_THROTTLE_DISCONNECT: {
       simInputThrottles.ATHR_disconnect = 1;
       std::cout << "WASM: event triggered: AUTO_THROTTLE_DISCONNECT" << std::endl;
       break;
     }
 
-    case Events::A32NX_ATHR_RESET_DISABLE: {
+    case A32NX_ATHR_RESET_DISABLE: {
       simInputThrottles.ATHR_reset_disable = 1;
       std::cout << "WASM: event triggered: ATHR_RESET_DISABLE" << std::endl;
       break;
     }
 
-    case Events::AUTO_THROTTLE_TO_GA: {
+    case AUTO_THROTTLE_TO_GA: {
       throttleAxis[0]->onEventThrottleFull();
       throttleAxis[1]->onEventThrottleFull();
       std::cout << "WASM: event triggered: AUTO_THROTTLE_TO_GA (treated like THROTTLE_FULL)" << std::endl;
       break;
     }
 
-    case Events::A32NX_THROTTLE_MAPPING_SET_DEFAULTS: {
+    case A32NX_THROTTLE_MAPPING_SET_DEFAULTS: {
       std::cout << "WASM: event triggered: THROTTLE_MAPPING_SET_DEFAULTS" << std::endl;
       throttleAxis[0]->applyDefaults();
       throttleAxis[1]->applyDefaults();
       break;
     }
 
-    case Events::A32NX_THROTTLE_MAPPING_LOAD_FROM_FILE: {
+    case A32NX_THROTTLE_MAPPING_LOAD_FROM_FILE: {
       std::cout << "WASM: event triggered: THROTTLE_MAPPING_LOAD_FROM_FILE" << std::endl;
       throttleAxis[0]->loadFromFile();
       throttleAxis[1]->loadFromFile();
       break;
     }
 
-    case Events::A32NX_THROTTLE_MAPPING_LOAD_FROM_LOCAL_VARIABLES: {
+    case A32NX_THROTTLE_MAPPING_LOAD_FROM_LOCAL_VARIABLES: {
       std::cout << "WASM: event triggered: THROTTLE_MAPPING_LOAD_FROM_LOCAL_VARIABLES" << std::endl;
       throttleAxis[0]->loadFromLocalVariables();
       throttleAxis[1]->loadFromLocalVariables();
       break;
     }
 
-    case Events::A32NX_THROTTLE_MAPPING_SAVE_TO_FILE: {
+    case A32NX_THROTTLE_MAPPING_SAVE_TO_FILE: {
       std::cout << "WASM: event triggered: THROTTLE_MAPPING_SAVE_TO_FILE" << std::endl;
       throttleAxis[0]->saveToFile();
       throttleAxis[1]->saveToFile();
       break;
     }
 
-    case Events::THROTTLE_SET: {
-      throttleAxis[0]->onEventThrottleSet(static_cast<long>(event->dwData));
-      throttleAxis[1]->onEventThrottleSet(static_cast<long>(event->dwData));
+    case THROTTLE_SET: {
+      throttleAxis[0]->onEventThrottleSet(static_cast<long>(data0));
+      throttleAxis[1]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE_SET: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE_SET: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
-    case Events::THROTTLE1_SET: {
-      throttleAxis[0]->onEventThrottleSet(static_cast<long>(event->dwData));
+    case THROTTLE1_SET: {
+      throttleAxis[0]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE1_SET: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE1_SET: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
-    case Events::THROTTLE2_SET: {
-      throttleAxis[1]->onEventThrottleSet(static_cast<long>(event->dwData));
+    case THROTTLE2_SET: {
+      throttleAxis[1]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE2_SET: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE2_SET: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
-    case Events::THROTTLE_AXIS_SET_EX1: {
-      throttleAxis[0]->onEventThrottleSet(static_cast<long>(event->dwData));
-      throttleAxis[1]->onEventThrottleSet(static_cast<long>(event->dwData));
+    case THROTTLE_AXIS_SET_EX1: {
+      throttleAxis[0]->onEventThrottleSet(static_cast<long>(data0));
+      throttleAxis[1]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE_AXIS_SET_EX1: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE_AXIS_SET_EX1: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
-    case Events::THROTTLE1_AXIS_SET_EX1: {
-      throttleAxis[0]->onEventThrottleSet(static_cast<long>(event->dwData));
+    case THROTTLE1_AXIS_SET_EX1: {
+      throttleAxis[0]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE1_AXIS_SET_EX1: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE1_AXIS_SET_EX1: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
-    case Events::THROTTLE2_AXIS_SET_EX1: {
-      throttleAxis[1]->onEventThrottleSet(static_cast<long>(event->dwData));
+    case THROTTLE2_AXIS_SET_EX1: {
+      throttleAxis[1]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE2_AXIS_SET_EX1: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE2_AXIS_SET_EX1: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
-    case Events::THROTTLE_FULL: {
+    case THROTTLE_FULL: {
       throttleAxis[0]->onEventThrottleFull();
       throttleAxis[1]->onEventThrottleFull();
       if (loggingThrottlesEnabled) {
@@ -2330,7 +2342,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_CUT: {
+    case THROTTLE_CUT: {
       throttleAxis[0]->onEventThrottleCut();
       throttleAxis[1]->onEventThrottleCut();
       if (loggingThrottlesEnabled) {
@@ -2339,7 +2351,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_INCR: {
+    case THROTTLE_INCR: {
       throttleAxis[0]->onEventThrottleIncrease();
       throttleAxis[1]->onEventThrottleIncrease();
       if (loggingThrottlesEnabled) {
@@ -2348,7 +2360,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_DECR: {
+    case THROTTLE_DECR: {
       throttleAxis[0]->onEventThrottleDecrease();
       throttleAxis[1]->onEventThrottleDecrease();
       if (loggingThrottlesEnabled) {
@@ -2357,7 +2369,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_INCR_SMALL: {
+    case THROTTLE_INCR_SMALL: {
       throttleAxis[0]->onEventThrottleIncreaseSmall();
       throttleAxis[1]->onEventThrottleIncreaseSmall();
       if (loggingThrottlesEnabled) {
@@ -2366,7 +2378,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_DECR_SMALL: {
+    case THROTTLE_DECR_SMALL: {
       throttleAxis[0]->onEventThrottleDecreaseSmall();
       throttleAxis[1]->onEventThrottleDecreaseSmall();
       if (loggingThrottlesEnabled) {
@@ -2375,7 +2387,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_10: {
+    case THROTTLE_10: {
       throttleAxis[0]->onEventThrottleSet_10();
       throttleAxis[1]->onEventThrottleSet_10();
       if (loggingThrottlesEnabled) {
@@ -2384,7 +2396,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_20: {
+    case THROTTLE_20: {
       throttleAxis[0]->onEventThrottleSet_20();
       throttleAxis[1]->onEventThrottleSet_20();
       if (loggingThrottlesEnabled) {
@@ -2393,7 +2405,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_30: {
+    case THROTTLE_30: {
       throttleAxis[0]->onEventThrottleSet_30();
       throttleAxis[1]->onEventThrottleSet_30();
       if (loggingThrottlesEnabled) {
@@ -2402,7 +2414,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_40: {
+    case THROTTLE_40: {
       throttleAxis[0]->onEventThrottleSet_40();
       throttleAxis[1]->onEventThrottleSet_40();
       if (loggingThrottlesEnabled) {
@@ -2411,7 +2423,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_50: {
+    case THROTTLE_50: {
       throttleAxis[0]->onEventThrottleSet_50();
       throttleAxis[1]->onEventThrottleSet_50();
       if (loggingThrottlesEnabled) {
@@ -2420,7 +2432,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_60: {
+    case THROTTLE_60: {
       throttleAxis[0]->onEventThrottleSet_50();
       throttleAxis[1]->onEventThrottleSet_60();
       if (loggingThrottlesEnabled) {
@@ -2429,7 +2441,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_70: {
+    case THROTTLE_70: {
       throttleAxis[0]->onEventThrottleSet_70();
       throttleAxis[1]->onEventThrottleSet_70();
       if (loggingThrottlesEnabled) {
@@ -2438,7 +2450,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_80: {
+    case THROTTLE_80: {
       throttleAxis[0]->onEventThrottleSet_80();
       throttleAxis[1]->onEventThrottleSet_80();
       if (loggingThrottlesEnabled) {
@@ -2447,7 +2459,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_90: {
+    case THROTTLE_90: {
       throttleAxis[0]->onEventThrottleSet_90();
       throttleAxis[1]->onEventThrottleSet_90();
       if (loggingThrottlesEnabled) {
@@ -2456,7 +2468,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE1_FULL: {
+    case THROTTLE1_FULL: {
       throttleAxis[0]->onEventThrottleFull();
       if (loggingThrottlesEnabled) {
         std::cout << "WASM: THROTTLE1_FULL" << std::endl;
@@ -2464,7 +2476,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE1_CUT: {
+    case THROTTLE1_CUT: {
       throttleAxis[0]->onEventThrottleCut();
       if (loggingThrottlesEnabled) {
         std::cout << "WASM: THROTTLE1_CUT" << std::endl;
@@ -2472,7 +2484,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE1_INCR: {
+    case THROTTLE1_INCR: {
       throttleAxis[0]->onEventThrottleIncrease();
       if (loggingThrottlesEnabled) {
         std::cout << "WASM: THROTTLE1_INCR" << std::endl;
@@ -2480,7 +2492,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE1_DECR: {
+    case THROTTLE1_DECR: {
       throttleAxis[0]->onEventThrottleDecrease();
       if (loggingThrottlesEnabled) {
         std::cout << "WASM: THROTTLE1_DECR" << std::endl;
@@ -2488,7 +2500,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE1_INCR_SMALL: {
+    case THROTTLE1_INCR_SMALL: {
       throttleAxis[0]->onEventThrottleIncreaseSmall();
       if (loggingThrottlesEnabled) {
         std::cout << "WASM: THROTTLE1_INCR_SMALL" << std::endl;
@@ -2496,7 +2508,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE1_DECR_SMALL: {
+    case THROTTLE1_DECR_SMALL: {
       throttleAxis[0]->onEventThrottleDecreaseSmall();
       if (loggingThrottlesEnabled) {
         std::cout << "WASM: THROTTLE1_DECR_SMALL" << std::endl;
@@ -2504,7 +2516,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE2_FULL: {
+    case THROTTLE2_FULL: {
       throttleAxis[1]->onEventThrottleFull();
       if (loggingThrottlesEnabled) {
         std::cout << "WASM: THROTTLE2_FULL" << std::endl;
@@ -2512,7 +2524,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE2_CUT: {
+    case THROTTLE2_CUT: {
       throttleAxis[1]->onEventThrottleCut();
       if (loggingThrottlesEnabled) {
         std::cout << "WASM: THROTTLE2_CUT" << std::endl;
@@ -2520,7 +2532,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE2_INCR: {
+    case THROTTLE2_INCR: {
       throttleAxis[1]->onEventThrottleIncrease();
       if (loggingThrottlesEnabled) {
         std::cout << "WASM: THROTTLE2_INCR" << std::endl;
@@ -2528,7 +2540,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE2_DECR: {
+    case THROTTLE2_DECR: {
       throttleAxis[1]->onEventThrottleDecrease();
       if (loggingThrottlesEnabled) {
         std::cout << "WASM: THROTTLE2_DECR" << std::endl;
@@ -2536,7 +2548,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE2_INCR_SMALL: {
+    case THROTTLE2_INCR_SMALL: {
       throttleAxis[1]->onEventThrottleIncreaseSmall();
       if (loggingThrottlesEnabled) {
         std::cout << "WASM: THROTTLE2_INCR_SMALL" << std::endl;
@@ -2544,7 +2556,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE2_DECR_SMALL: {
+    case THROTTLE2_DECR_SMALL: {
       throttleAxis[1]->onEventThrottleDecreaseSmall();
       if (loggingThrottlesEnabled) {
         std::cout << "WASM: THROTTLE2_DECR_SMALL" << std::endl;
@@ -2552,7 +2564,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_REVERSE_THRUST_TOGGLE: {
+    case THROTTLE_REVERSE_THRUST_TOGGLE: {
       throttleAxis[0]->onEventReverseToggle();
       throttleAxis[1]->onEventReverseToggle();
       if (loggingThrottlesEnabled) {
@@ -2560,16 +2572,16 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       }
       break;
     }
-    case Events::THROTTLE_REVERSE_THRUST_HOLD: {
-      throttleAxis[0]->onEventReverseHold(static_cast<bool>(event->dwData));
-      throttleAxis[1]->onEventReverseHold(static_cast<bool>(event->dwData));
+    case THROTTLE_REVERSE_THRUST_HOLD: {
+      throttleAxis[0]->onEventReverseHold(static_cast<bool>(data0));
+      throttleAxis[1]->onEventReverseHold(static_cast<bool>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE_REVERSE_THRUST_HOLD: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE_REVERSE_THRUST_HOLD: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
-    case Events::SPOILERS_ON: {
+    case SPOILERS_ON: {
       spoilersHandler->onEventSpoilersOn();
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: SPOILERS_ON: ";
@@ -2583,7 +2595,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::SPOILERS_OFF: {
+    case SPOILERS_OFF: {
       spoilersHandler->onEventSpoilersOff();
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: SPOILERS_OFF: ";
@@ -2597,7 +2609,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::SPOILERS_TOGGLE: {
+    case SPOILERS_TOGGLE: {
       spoilersHandler->onEventSpoilersToggle();
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: SPOILERS_TOGGLE: ";
@@ -2611,11 +2623,11 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::SPOILERS_SET: {
-      spoilersHandler->onEventSpoilersSet(static_cast<long>(event->dwData));
+    case SPOILERS_SET: {
+      spoilersHandler->onEventSpoilersSet(static_cast<long>(data0));
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: SPOILERS_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << spoilersHandler->getHandlePosition();
         std::cout << " / ";
@@ -2625,11 +2637,11 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::AXIS_SPOILER_SET: {
-      spoilersHandler->onEventSpoilersAxisSet(static_cast<long>(event->dwData));
+    case AXIS_SPOILER_SET: {
+      spoilersHandler->onEventSpoilersAxisSet(static_cast<long>(data0));
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: AXIS_SPOILER_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << spoilersHandler->getHandlePosition();
         std::cout << " / ";
@@ -2639,7 +2651,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::SPOILERS_ARM_ON: {
+    case SPOILERS_ARM_ON: {
       spoilersHandler->onEventSpoilersArmOn();
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: SPOILERS_ARM_ON: ";
@@ -2653,7 +2665,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::SPOILERS_ARM_OFF: {
+    case SPOILERS_ARM_OFF: {
       spoilersHandler->onEventSpoilersArmOff();
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: SPOILERS_ARM_OFF: ";
@@ -2667,7 +2679,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::SPOILERS_ARM_TOGGLE: {
+    case SPOILERS_ARM_TOGGLE: {
       spoilersHandler->onEventSpoilersArmToggle();
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: SPOILERS_ARM_TOGGLE: ";
@@ -2681,11 +2693,11 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::SPOILERS_ARM_SET: {
-      spoilersHandler->onEventSpoilersArmSet(static_cast<long>(event->dwData) == 1);
+    case SPOILERS_ARM_SET: {
+      spoilersHandler->onEventSpoilersArmSet(static_cast<long>(data0) == 1);
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: SPOILERS_ARM_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << spoilersHandler->getHandlePosition();
         std::cout << " / ";
@@ -2695,13 +2707,13 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::SIM_RATE_INCR: {
+    case SIM_RATE_INCR: {
       // calculate frame rate that will be seen by FBW / AP
       double theoreticalFrameRate = (1 / sampleTime) / (simData.simulation_rate * 2);
       // determine if an increase of simulation rate can be allowed
       if ((simData.simulation_rate < maxSimulationRate && theoreticalFrameRate >= 5) || simData.simulation_rate < 1 ||
           !limitSimulationRateByPerformance) {
-        sendEvent(Events::SIM_RATE_INCR, 0, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
+        sendEvent(SIM_RATE_INCR, 0, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
         std::cout << "WASM: Simulation rate " << simData.simulation_rate;
         std::cout << " -> " << simData.simulation_rate * 2;
         std::cout << " (theoretical fps " << theoreticalFrameRate << ")" << std::endl;
@@ -2713,9 +2725,9 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::SIM_RATE_DECR: {
+    case SIM_RATE_DECR: {
       if (simData.simulation_rate > minSimulationRate) {
-        sendEvent(Events::SIM_RATE_DECR, 0, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
+        sendEvent(SIM_RATE_DECR, 0, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
         std::cout << "WASM: Simulation rate " << simData.simulation_rate;
         std::cout << " -> " << simData.simulation_rate / 2;
         std::cout << std::endl;
@@ -2727,9 +2739,9 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::SIM_RATE_SET: {
-      long targetSimulationRate = min(maxSimulationRate, max(1, static_cast<long>(event->dwData)));
-      sendEvent(Events::SIM_RATE_SET, targetSimulationRate, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
+    case SIM_RATE_SET: {
+      long targetSimulationRate = min(maxSimulationRate, max(1, static_cast<long>(data0)));
+      sendEvent(SIM_RATE_SET, targetSimulationRate, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
       std::cout << "WASM: Simulation Rate set to " << targetSimulationRate << std::endl;
       break;
     }

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.h
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.h
@@ -414,7 +414,7 @@ class SimConnectInterface {
   /**
    * @brief Process a SimConnect event.
    *
-   * These event are triggered by the SimConnect client usually calling
+   * These events are triggered by the SimConnect clients usually calling
    * `SimConnect_TransmitClientEvent` and have exactly one data parameter stored
    * in the event->dwData field of the SIMCONNECT_RECV_EVENT struct.
    *
@@ -426,7 +426,7 @@ class SimConnectInterface {
   /**
    * @brief Process a SimConnect EX1 event with up to 5 parameter.
    *
-   * These event are triggered by the SimConnect client usually calling
+   * These events are triggered by the SimConnect clients usually calling
    * `SimConnect_TransmitClientEvent_EX1` and have up to 5 data parameter stored
    * in the event->dwData0-4 fields of the SIMCONNECT_RECV_EVENT_EX1 struct.
    *

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.h
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.h
@@ -411,7 +411,41 @@ class SimConnectInterface {
 
   void simConnectProcessDispatchMessage(SIMCONNECT_RECV* pData, DWORD* cbData);
 
+  /**
+   * @brief Process a SimConnect event.
+   *
+   * These event are triggered by the SimConnect client usually calling
+   * `SimConnect_TransmitClientEvent` and have exactly one data parameter stored
+   * in the event->dwData field of the SIMCONNECT_RECV_EVENT struct.
+   *
+   * @param event The pointer to the corresponding event data
+   * @see https://docs.flightsimulator.com/flighting/html/Programming_Tools/SimConnect/API_Reference/Events_And_Data/SimConnect_TransmitClientEvent.htm
+   */
   void simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* event);
+
+  /**
+   * @brief Process a SimConnect EX1 event with up to 5 parameter.
+   *
+   * These event are triggered by the SimConnect client usually calling
+   * `SimConnect_TransmitClientEvent_EX1` and have up to 5 data parameter stored
+   * in the event->dwData0-4 fields of the SIMCONNECT_RECV_EVENT_EX1 struct.
+   *
+   * As currently the fbw only uses events with one parameter, this function is
+   * only used as a wrapper so that `SimConnect_TransmitClientEvent_EX1` can be
+   * used by clients. It will essentially call `processEventWithOneParam` and ignore
+   * all other parameters.
+   *
+   * @param event The pointer to the corresponding event data
+   * @see https://docs.flightsimulator.com/flighting/html/Programming_Tools/SimConnect/API_Reference/Events_And_Data/SimConnect_TransmitClientEvent_EX1.htm
+   */
+  void simConnectProcessEvent_EX1(const SIMCONNECT_RECV_EVENT_EX1* event);
+
+  /**
+   * @brief Process a SimConnect event with one parameter.
+   * @param eventId Specifies the ID of the client event.
+   * @param data0 Double word containing any additional number required by the event.
+   */
+  void processEventWithOneParam(const DWORD eventId, const DWORD data0);
 
   void simConnectProcessSimObjectData(const SIMCONNECT_RECV_SIMOBJECT_DATA* data);
 

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.h
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.h
@@ -440,13 +440,6 @@ class SimConnectInterface {
    */
   void simConnectProcessEvent_EX1(const SIMCONNECT_RECV_EVENT_EX1* event);
 
-  /**
-   * @brief Process a SimConnect event with one parameter.
-   * @param eventId Specifies the ID of the client event.
-   * @param data0 Double word containing any additional number required by the event.
-   */
-  void processEventWithOneParam(const DWORD eventId, const DWORD data0);
-
   void simConnectProcessSimObjectData(const SIMCONNECT_RECV_SIMOBJECT_DATA* data);
 
   void simConnectProcessClientData(const SIMCONNECT_RECV_CLIENT_DATA* data);
@@ -469,4 +462,13 @@ class SimConnectInterface {
   static bool isSimConnectDataTypeStruct(SIMCONNECT_DATATYPE dataType);
 
   static std::string getSimConnectExceptionString(SIMCONNECT_EXCEPTION exception);
+
+ private:
+
+  /**
+   * @brief Process a SimConnect event with one parameter.
+   * @param eventId Specifies the ID of the client event.
+   * @param data0 Double word containing any additional number required by the event.
+   */
+  void processEventWithOneParam(const DWORD eventId, const DWORD data0);
 };

--- a/fbw-a380x/src/wasm/fbw_a380/src/interface/SimConnectInterface.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/interface/SimConnectInterface.cpp
@@ -1448,8 +1448,11 @@ void SimConnectInterface::simConnectProcessDispatchMessage(SIMCONNECT_RECV* pDat
       break;
 
     case SIMCONNECT_RECV_ID_EVENT:
-      // get event
       simConnectProcessEvent(static_cast<SIMCONNECT_RECV_EVENT*>(pData));
+      break;
+
+    case SIMCONNECT_RECV_ID_EVENT_EX1:
+      simConnectProcessEvent_EX1(static_cast<SIMCONNECT_RECV_EVENT_EX1*>(pData));
       break;
 
     case SIMCONNECT_RECV_ID_SIMOBJECT_DATA:
@@ -1476,13 +1479,25 @@ void SimConnectInterface::simConnectProcessDispatchMessage(SIMCONNECT_RECV* pDat
 }
 
 void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* event) {
+  const DWORD eventId = event->uEventID;
+  const DWORD data0 = event->dwData;
+  processEventWithOneParam(eventId, data0);
+}
+
+void SimConnectInterface::simConnectProcessEvent_EX1(const SIMCONNECT_RECV_EVENT_EX1* event) {
+  const DWORD eventId = event->uEventID;
+  const DWORD data0 = event->dwData0;
+  processEventWithOneParam(eventId, data0);
+}
+
+void SimConnectInterface::processEventWithOneParam(const DWORD eventId, const DWORD data0) {
   // process depending on event id
-  switch (event->uEventID) {
+  switch (eventId) {
     case Events::AXIS_ELEVATOR_SET: {
-      simInput.inputs[AXIS_ELEVATOR_SET] = static_cast<long>(event->dwData) / 16384.0;
+      simInput.inputs[AXIS_ELEVATOR_SET] = static_cast<long>(data0) / 16384.0;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: AXIS_ELEVATOR_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_ELEVATOR_SET];
         std::cout << std::endl;
@@ -1491,10 +1506,10 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::AXIS_AILERONS_SET: {
-      simInput.inputs[AXIS_AILERONS_SET] = static_cast<long>(event->dwData) / 16384.0;
+      simInput.inputs[AXIS_AILERONS_SET] = static_cast<long>(data0) / 16384.0;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: AXIS_AILERONS_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_AILERONS_SET];
         std::cout << std::endl;
@@ -1503,10 +1518,10 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::AXIS_RUDDER_SET: {
-      simInput.inputs[AXIS_RUDDER_SET] = static_cast<long>(event->dwData) / 16384.0;
+      simInput.inputs[AXIS_RUDDER_SET] = static_cast<long>(data0) / 16384.0;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: AXIS_RUDDER_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_RUDDER_SET];
         std::cout << std::endl;
@@ -1515,10 +1530,10 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::RUDDER_SET: {
-      simInput.inputs[AXIS_RUDDER_SET] = static_cast<long>(event->dwData) / 16384.0;
+      simInput.inputs[AXIS_RUDDER_SET] = static_cast<long>(data0) / 16384.0;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_RUDDER_SET];
         std::cout << std::endl;
@@ -1566,10 +1581,10 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       double tmpValue = 0;
       if (this->disableXboxCompatibilityRudderPlusMinus) {
         // normal axis
-        tmpValue = +1.0 * ((static_cast<long>(event->dwData) + 16384.0) / 32768.0);
+        tmpValue = +1.0 * ((static_cast<long>(data0) + 16384.0) / 32768.0);
       } else {
         // xbox controller
-        tmpValue = +1.0 * (static_cast<long>(event->dwData) / 16384.0);
+        tmpValue = +1.0 * (static_cast<long>(data0) / 16384.0);
       }
 
       // This allows using two independent axis for rudder which are mapped to RUDDER AXIS LEFT and RUDDER AXIS RIGHT
@@ -1582,7 +1597,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       simInput.inputs[AXIS_RUDDER_SET] = tmpValue;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_AXIS_MINUS: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_RUDDER_SET];
         if (this->enableRudder2AxisMode) {
@@ -1597,10 +1612,10 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       double tmpValue = 0;
       if (this->disableXboxCompatibilityRudderPlusMinus) {
         // normal axis
-        tmpValue = -1.0 * ((static_cast<long>(event->dwData) + 16384.0) / 32768.0);
+        tmpValue = -1.0 * ((static_cast<long>(data0) + 16384.0) / 32768.0);
       } else {
         // xbox controller
-        tmpValue = -1.0 * (static_cast<long>(event->dwData) / 16384.0);
+        tmpValue = -1.0 * (static_cast<long>(data0) / 16384.0);
       }
 
       // This allows using two independent axis for rudder which are mapped to RUDDER AXIS LEFT and RUDDER AXIS RIGHT
@@ -1613,7 +1628,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       simInput.inputs[AXIS_RUDDER_SET] = tmpValue;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_AXIS_PLUS: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_RUDDER_SET];
         if (this->enableRudder2AxisMode) {
@@ -1657,7 +1672,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::RUDDER_TRIM_SET: {
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_TRIM_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << std::endl;
       }
       break;
@@ -1666,17 +1681,17 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::RUDDER_TRIM_SET_EX1: {
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: RUDDER_TRIM_SET_EX1: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << std::endl;
       }
       break;
     }
 
     case Events::AILERON_SET: {
-      simInput.inputs[AXIS_AILERONS_SET] = static_cast<long>(event->dwData) / 16384.0;
+      simInput.inputs[AXIS_AILERONS_SET] = static_cast<long>(data0) / 16384.0;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: AILERON_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_AILERONS_SET];
         std::cout << std::endl;
@@ -1724,10 +1739,10 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::ELEVATOR_SET: {
-      simInput.inputs[AXIS_ELEVATOR_SET] = static_cast<long>(event->dwData) / 16384.0;
+      simInput.inputs[AXIS_ELEVATOR_SET] = static_cast<long>(data0) / 16384.0;
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: ELEVATOR_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_ELEVATOR_SET];
         std::cout << std::endl;
@@ -1782,7 +1797,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::ELEVATOR_TRIM_SET: {
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: ELEVATOR_TRIM_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " (IGNORING)";
         std::cout << std::endl;
       }
@@ -1792,7 +1807,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::AXIS_ELEV_TRIM_SET: {
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: AXIS_ELEV_TRIM_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " (IGNORING)";
         std::cout << std::endl;
       }
@@ -1812,7 +1827,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::TOGGLE_FLIGHT_DIRECTOR: {
-      std::cout << "WASM: event triggered: TOGGLE_FLIGHT_DIRECTOR:" << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: TOGGLE_FLIGHT_DIRECTOR:" << static_cast<long>(data0) << std::endl;
       break;
     }
 
@@ -1823,7 +1838,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::AUTOPILOT_DISENGAGE_SET: {
-      if (static_cast<long>(event->dwData) == 1) {
+      if (static_cast<long>(data0) == 1) {
         simInputAutopilot.AP_disconnect = 1;
         std::cout << "WASM: event triggered: AUTOPILOT_DISENGAGE_SET" << std::endl;
       }
@@ -1879,9 +1894,9 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::A32NX_FCU_SPD_SET: {
-      idFcuEventSetSPEED->set(static_cast<long>(event->dwData));
+      idFcuEventSetSPEED->set(static_cast<long>(data0));
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_SET)", nullptr, nullptr, nullptr);
-      std::cout << "WASM: event triggered: A32NX_FCU_SPD_SET: " << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_SPD_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
 
@@ -1923,9 +1938,9 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::A32NX_FCU_HDG_SET: {
-      idFcuEventSetHDG->set(static_cast<long>(event->dwData));
+      idFcuEventSetHDG->set(static_cast<long>(data0));
       execute_calculator_code("(>H:A320_Neo_FCU_HDG_SET)", nullptr, nullptr, nullptr);
-      std::cout << "WASM: event triggered: A32NX_FCU_HDG_SET: " << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_HDG_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
 
@@ -1963,7 +1978,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::A32NX_FCU_ALT_INC: {
-      long increment = static_cast<long>(event->dwData);
+      long increment = static_cast<long>(data0);
       if (increment == 100) {
         execute_calculator_code(
             "3 (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) 100 + (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) "
@@ -1988,7 +2003,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::A32NX_FCU_ALT_DEC: {
-      long increment = static_cast<long>(event->dwData);
+      long increment = static_cast<long>(data0);
       if (increment == 100) {
         execute_calculator_code(
             "3 (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) 100 - 100 "
@@ -2014,7 +2029,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::A32NX_FCU_ALT_SET: {
-      long value = 100 * (static_cast<long>(event->dwData) / 100);
+      long value = 100 * (static_cast<long>(data0) / 100);
       std::ostringstream stringStream;
       stringStream << value;
       stringStream << " (>K:3:AP_ALT_VAR_SET_ENGLISH)";
@@ -2035,7 +2050,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::A32NX_FCU_ALT_INCREMENT_SET: {
-      long value = static_cast<long>(event->dwData);
+      long value = static_cast<long>(data0);
       if (value == 100 || value == 1000) {
         std::ostringstream stringStream;
         stringStream << value;
@@ -2081,9 +2096,9 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::A32NX_FCU_VS_SET: {
-      idFcuEventSetVS->set(static_cast<long>(event->dwData));
+      idFcuEventSetVS->set(static_cast<long>(data0));
       execute_calculator_code("(>H:A320_Neo_FCU_VS_SET) (>H:A320_Neo_CDU_VS)", nullptr, nullptr, nullptr);
-      std::cout << "WASM: event triggered: A32NX_FCU_VS_SET: " << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_VS_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
 
@@ -2151,12 +2166,12 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
 
     case Events::AP_SPEED_SLOT_INDEX_SET: {
       // for the time being do not activate, it ends in a loop. more work has to be done to support this
-      // if (static_cast<long>(event->dwData) == 2) {
+      // if (static_cast<long>(data0) == 2) {
       //   execute_calculator_code("(>H:A320_Neo_FCU_SPEED_PUSH)", nullptr, nullptr, nullptr);
       // } else {
       //   execute_calculator_code("(>H:A320_Neo_FCU_SPEED_PULL)", nullptr, nullptr, nullptr);
       // }
-      std::cout << "WASM: event triggered: SPEED_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: SPEED_SLOT_INDEX_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
 
@@ -2186,12 +2201,12 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
 
     case Events::AP_HEADING_SLOT_INDEX_SET: {
       // for the time being do not activate, it ends in a loop. more work has to be done to support this
-      // if (static_cast<long>(event->dwData) == 2) {
+      // if (static_cast<long>(data0) == 2) {
       //   execute_calculator_code("(>H:A320_Neo_FCU_VS_PUSH)", nullptr, nullptr, nullptr);
       // } else {
       //   execute_calculator_code("(>H:A320_Neo_FCU_VS_PULL)", nullptr, nullptr, nullptr);
       // }
-      std::cout << "WASM: event triggered: HEADING_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: HEADING_SLOT_INDEX_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
 
@@ -2213,12 +2228,12 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
 
     case Events::AP_ALTITUDE_SLOT_INDEX_SET: {
       // for the time being do not activate, it ends in a loop. more work has to be done to support this
-      // if (static_cast<long>(event->dwData) == 2) {
+      // if (static_cast<long>(data0) == 2) {
       //   execute_calculator_code("(>H:A320_Neo_FCU_ALT_PUSH) (>H:A320_Neo_CDU_MODE_MANAGED_ALTITUDE)", nullptr, nullptr, nullptr);
       // } else {
       //   execute_calculator_code("(>H:A320_Neo_FCU_ALT_PULL) (>H:A320_Neo_CDU_MODE_SELECTED_ALTITUDE)", nullptr, nullptr, nullptr);
       // }
-      std::cout << "WASM: event triggered: ALTITUDE_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: ALTITUDE_SLOT_INDEX_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
 
@@ -2244,12 +2259,12 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
 
     case Events::AP_VS_SLOT_INDEX_SET: {
       // for the time being do not activate, it ends in a loop. more work has to be done to support this
-      // if (static_cast<long>(event->dwData) == 2) {
+      // if (static_cast<long>(data0) == 2) {
       //   execute_calculator_code("(>H:A320_Neo_FCU_VS_PUSH)", nullptr, nullptr, nullptr);
       // } else {
       //   execute_calculator_code("(>H:A320_Neo_FCU_VS_PULL)", nullptr, nullptr, nullptr);
       // }
-      std::cout << "WASM: event triggered: VS_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << std::endl;
+      std::cout << "WASM: event triggered: VS_SLOT_INDEX_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
 
@@ -2335,87 +2350,87 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::THROTTLE_SET: {
-      throttleAxis[0]->onEventThrottleSet(static_cast<long>(event->dwData));
-      throttleAxis[1]->onEventThrottleSet(static_cast<long>(event->dwData));
-      throttleAxis[2]->onEventThrottleSet(static_cast<long>(event->dwData));
-      throttleAxis[3]->onEventThrottleSet(static_cast<long>(event->dwData));
+      throttleAxis[0]->onEventThrottleSet(static_cast<long>(data0));
+      throttleAxis[1]->onEventThrottleSet(static_cast<long>(data0));
+      throttleAxis[2]->onEventThrottleSet(static_cast<long>(data0));
+      throttleAxis[3]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE_SET: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE_SET: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
     case Events::THROTTLE1_SET: {
-      throttleAxis[0]->onEventThrottleSet(static_cast<long>(event->dwData));
+      throttleAxis[0]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE1_SET: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE1_SET: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
     case Events::THROTTLE2_SET: {
-      throttleAxis[1]->onEventThrottleSet(static_cast<long>(event->dwData));
+      throttleAxis[1]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE2_SET: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE2_SET: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
     case Events::THROTTLE3_SET: {
-      throttleAxis[2]->onEventThrottleSet(static_cast<long>(event->dwData));
+      throttleAxis[2]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE3_SET: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE3_SET: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
     case Events::THROTTLE4_SET: {
-      throttleAxis[3]->onEventThrottleSet(static_cast<long>(event->dwData));
+      throttleAxis[3]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE4_SET: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE4_SET: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
     case Events::THROTTLE_AXIS_SET_EX1: {
-      throttleAxis[0]->onEventThrottleSet(static_cast<long>(event->dwData));
-      throttleAxis[1]->onEventThrottleSet(static_cast<long>(event->dwData));
-      throttleAxis[2]->onEventThrottleSet(static_cast<long>(event->dwData));
-      throttleAxis[3]->onEventThrottleSet(static_cast<long>(event->dwData));
+      throttleAxis[0]->onEventThrottleSet(static_cast<long>(data0));
+      throttleAxis[1]->onEventThrottleSet(static_cast<long>(data0));
+      throttleAxis[2]->onEventThrottleSet(static_cast<long>(data0));
+      throttleAxis[3]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE_AXIS_SET_EX1: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE_AXIS_SET_EX1: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
     case Events::THROTTLE1_AXIS_SET_EX1: {
-      throttleAxis[0]->onEventThrottleSet(static_cast<long>(event->dwData));
+      throttleAxis[0]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE1_AXIS_SET_EX1: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE1_AXIS_SET_EX1: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
     case Events::THROTTLE2_AXIS_SET_EX1: {
-      throttleAxis[1]->onEventThrottleSet(static_cast<long>(event->dwData));
+      throttleAxis[1]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE2_AXIS_SET_EX1: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE2_AXIS_SET_EX1: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
     case Events::THROTTLE3_AXIS_SET_EX1: {
-      throttleAxis[2]->onEventThrottleSet(static_cast<long>(event->dwData));
+      throttleAxis[2]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE3_AXIS_SET_EX1: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE3_AXIS_SET_EX1: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
 
     case Events::THROTTLE4_AXIS_SET_EX1: {
-      throttleAxis[3]->onEventThrottleSet(static_cast<long>(event->dwData));
+      throttleAxis[3]->onEventThrottleSet(static_cast<long>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE4_AXIS_SET_EX1: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE4_AXIS_SET_EX1: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
@@ -2670,12 +2685,12 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
     case Events::THROTTLE_REVERSE_THRUST_HOLD: {
-      throttleAxis[0]->onEventReverseHold(static_cast<bool>(event->dwData));
-      throttleAxis[1]->onEventReverseHold(static_cast<bool>(event->dwData));
-      throttleAxis[2]->onEventReverseHold(static_cast<bool>(event->dwData));
-      throttleAxis[3]->onEventReverseHold(static_cast<bool>(event->dwData));
+      throttleAxis[0]->onEventReverseHold(static_cast<bool>(data0));
+      throttleAxis[1]->onEventReverseHold(static_cast<bool>(data0));
+      throttleAxis[2]->onEventReverseHold(static_cast<bool>(data0));
+      throttleAxis[3]->onEventReverseHold(static_cast<bool>(data0));
       if (loggingThrottlesEnabled) {
-        std::cout << "WASM: THROTTLE_REVERSE_THRUST_HOLD: " << static_cast<long>(event->dwData) << std::endl;
+        std::cout << "WASM: THROTTLE_REVERSE_THRUST_HOLD: " << static_cast<long>(data0) << std::endl;
       }
       break;
     }
@@ -2723,10 +2738,10 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::SPOILERS_SET: {
-      spoilersHandler->onEventSpoilersSet(static_cast<long>(event->dwData));
+      spoilersHandler->onEventSpoilersSet(static_cast<long>(data0));
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: SPOILERS_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << spoilersHandler->getHandlePosition();
         std::cout << " / ";
@@ -2737,10 +2752,10 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::AXIS_SPOILER_SET: {
-      spoilersHandler->onEventSpoilersAxisSet(static_cast<long>(event->dwData));
+      spoilersHandler->onEventSpoilersAxisSet(static_cast<long>(data0));
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: AXIS_SPOILER_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << spoilersHandler->getHandlePosition();
         std::cout << " / ";
@@ -2793,10 +2808,10 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::SPOILERS_ARM_SET: {
-      spoilersHandler->onEventSpoilersArmSet(static_cast<long>(event->dwData) == 1);
+      spoilersHandler->onEventSpoilersArmSet(static_cast<long>(data0) == 1);
       if (loggingFlightControlsEnabled) {
         std::cout << "WASM: SPOILERS_ARM_SET: ";
-        std::cout << static_cast<long>(event->dwData);
+        std::cout << static_cast<long>(data0);
         std::cout << " -> ";
         std::cout << spoilersHandler->getHandlePosition();
         std::cout << " / ";
@@ -2839,7 +2854,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     }
 
     case Events::SIM_RATE_SET: {
-      long targetSimulationRate = min(maxSimulationRate, max(1, static_cast<long>(event->dwData)));
+      long targetSimulationRate = min(maxSimulationRate, max(1, static_cast<long>(data0)));
       sendEvent(Events::SIM_RATE_SET, targetSimulationRate, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
       std::cout << "WASM: Simulation Rate set to " << targetSimulationRate << std::endl;
       break;

--- a/fbw-a380x/src/wasm/fbw_a380/src/interface/SimConnectInterface.h
+++ b/fbw-a380x/src/wasm/fbw_a380/src/interface/SimConnectInterface.h
@@ -456,13 +456,6 @@ class SimConnectInterface {
    */
   void simConnectProcessEvent_EX1(const SIMCONNECT_RECV_EVENT_EX1* event);
 
-  /**
-   * @brief Process a SimConnect event with one parameter.
-   * @param eventId Specifies the ID of the client event.
-   * @param data0 Double word containing any additional number required by the event.
-   */
-  void processEventWithOneParam(const DWORD eventId, const DWORD data0);
-
   void simConnectProcessSimObjectData(const SIMCONNECT_RECV_SIMOBJECT_DATA* data);
 
   void simConnectProcessClientData(const SIMCONNECT_RECV_CLIENT_DATA* data);
@@ -485,4 +478,13 @@ class SimConnectInterface {
   static bool isSimConnectDataTypeStruct(SIMCONNECT_DATATYPE dataType);
 
   static std::string getSimConnectExceptionString(SIMCONNECT_EXCEPTION exception);
+
+  private:
+
+   /**
+   * @brief Process a SimConnect event with one parameter.
+   * @param eventId Specifies the ID of the client event.
+   * @param data0 Double word containing any additional number required by the event.
+    */
+   void processEventWithOneParam(const DWORD eventId, const DWORD data0);
 };

--- a/fbw-a380x/src/wasm/fbw_a380/src/interface/SimConnectInterface.h
+++ b/fbw-a380x/src/wasm/fbw_a380/src/interface/SimConnectInterface.h
@@ -427,7 +427,41 @@ class SimConnectInterface {
 
   void simConnectProcessDispatchMessage(SIMCONNECT_RECV* pData, DWORD* cbData);
 
+  /**
+   * @brief Process a SimConnect event.
+   *
+   * These events are triggered by the SimConnect clients usually calling
+   * `SimConnect_TransmitClientEvent` and have exactly one data parameter stored
+   * in the event->dwData field of the SIMCONNECT_RECV_EVENT struct.
+   *
+   * @param event The pointer to the corresponding event data
+   * @see https://docs.flightsimulator.com/flighting/html/Programming_Tools/SimConnect/API_Reference/Events_And_Data/SimConnect_TransmitClientEvent.htm
+   */
   void simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* event);
+
+  /**
+   * @brief Process a SimConnect EX1 event with up to 5 parameter.
+   *
+   * These events are triggered by the SimConnect clients usually calling
+   * `SimConnect_TransmitClientEvent_EX1` and have up to 5 data parameter stored
+   * in the event->dwData0-4 fields of the SIMCONNECT_RECV_EVENT_EX1 struct.
+   *
+   * As currently the fbw only uses events with one parameter, this function is
+   * only used as a wrapper so that `SimConnect_TransmitClientEvent_EX1` can be
+   * used by clients. It will essentially call `processEventWithOneParam` and ignore
+   * all other parameters.
+   *
+   * @param event The pointer to the corresponding event data
+   * @see https://docs.flightsimulator.com/flighting/html/Programming_Tools/SimConnect/API_Reference/Events_And_Data/SimConnect_TransmitClientEvent_EX1.htm
+   */
+  void simConnectProcessEvent_EX1(const SIMCONNECT_RECV_EVENT_EX1* event);
+
+  /**
+   * @brief Process a SimConnect event with one parameter.
+   * @param eventId Specifies the ID of the client event.
+   * @param data0 Double word containing any additional number required by the event.
+   */
+  void processEventWithOneParam(const DWORD eventId, const DWORD data0);
 
   void simConnectProcessSimObjectData(const SIMCONNECT_RECV_SIMOBJECT_DATA* data);
 


### PR DESCRIPTION
Fixes #8325

## Summary of Changes
Adds EX1 event handling support to the fbw events. Although not required currently by the fbw events it still allows 3rd parties to treat the A32NX identically to other aircraft where the EX1 events supposedly are supported. 

## References
[docs.flightsimulator.com/flighting/html/Programming_Tools/SimConnect/API_Reference/Events_And_Data/SimConnect_TransmitClientEvent.htm](https://docs.flightsimulator.com/flighting/html/Programming_Tools/SimConnect/API_Reference/Events_And_Data/SimConnect_TransmitClientEvent.htm)

[docs.flightsimulator.com/flighting/html/Programming_Tools/SimConnect/API_Reference/Events_And_Data/SimConnect_TransmitClientEvent_EX1.htm](https://docs.flightsimulator.com/flighting/html/Programming_Tools/SimConnect/API_Reference/Events_And_Data/SimConnect_TransmitClientEvent_EX1.htm)

## Additional context
Discord user "hbilliet" could test this - they discovered it.

See discussion on Discord: https://discord.com/channels/738864299392630914/785976111875751956/1182012107546447945

Discord username (if different from GitHub): cdr_maverick

## Testing instructions
Main focus is test against any regression of normal function.
Test normal operations for the autoflight/autopilot functions in the aircraft and also using tools like SPAD, AaO, Mobiflight, etc.

If possible test calling events using `SimConnect_TransmitClientEvent_EX1`.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
