### PR TITLE
fix(fma): reduce ALT CST * font size

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/PFD/FMA.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/FMA.tsx
@@ -816,10 +816,10 @@ class B1Cell extends ShowForSecondsComponent<CellProps> {
 
         this.boxPathStringSub.set(boxPathString);
 
-        // VS FPA has a smaller font than the other active modes
-        const VsFPA = this.activeVerticalModeSub.get() === 14 || this.activeVerticalModeSub.get() === 15;
+        // VS FPA & ALT CST* have a smaller font than the other active modes
+        const smallFont = this.activeVerticalModeSub.get() === 14 || this.activeVerticalModeSub.get() === 15 || this.activeVerticalModeSub.get() === 21;
 
-        this.activeVerticalModeClassSub.set(VsFPA ? 'FontMediumSmaller MiddleAlign Green' : 'FontMedium MiddleAlign Green');
+        this.activeVerticalModeClassSub.set(smallFont ? 'FontMediumSmaller MiddleAlign Green' : 'FontMedium MiddleAlign Green');
 
         this.fmaTextRef.instance.innerHTML = `<tspan>${text}</tspan><tspan xml:space="preserve" class=${inSpeedProtection ? 'PulseCyanFill' : 'Cyan'}>${additionalText}</tspan>`;
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Reduces Altitude constraint star FMA font size since otherwise it would go outside the mode change FMA box.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before & After
![image](https://github.com/flybywiresim/aircraft/assets/119708186/c8b7d082-b3ec-425b-be85-4e2b0131a9f7)
![ALT CST ](https://github.com/flybywiresim/aircraft/assets/119708186/a80478ec-e6cd-4d70-9fe6-266f3a012120)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![image](https://github.com/flybywiresim/aircraft/assets/119708186/ae5ba9ee-82c9-443e-ac67-9d75fb391376)

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
Unnoticed bug caused by my FMA improvements PR which reduced the size of the mode change FMA boxes.
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
bruno_pt99
## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Make sure the airplane is flying towards a waypoint with a level at altitude constraint. 
You can achieve this by first inserting an altitude constraint at a waypoint using the F-PLN page (Right LSK of the associated waypoint via ALT CSTR field) and selecting a higher altitude than the constraint on the FCU while using managed climb for e.g.
Once constraint altitude is reached make sure ALT CST * FMA fits inside the white box. 


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
