### PR TITLE
fix: Fix FUEL PRED warning colour from ALT to DEST

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -35,6 +35,7 @@
 1. [EFCS] Implement calculated yaw damper gain  - @lukecologne (luke)
 1. [EFCS] Decrease yaw damper at low speeds on ground, down to 0 below 40kts - @lukecologne (luke)
 1. [FLIGHTMODEL] Fix pitch trim on approach - @donstim (donbikes)
+1. [FMS] Fix FUEL PRED warning colour from ALT to DEST - @tshomas (shomas)
 
 ## 0.11.0
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FuelPredPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FuelPredPage.js
@@ -160,7 +160,7 @@ class CDUFuelPredPage {
                 if (mcdu.altDestination) {
                     altIdentCell = mcdu.altDestination.ident;
                     altEFOBCell = (NXUnits.kgToUser(mcdu.getAltEFOB(true))).toFixed(1);
-                    altEFOBCellColor = mcdu.getAltEFOB(true) < mcdu._minDestFob ? "[color]amber" : "[color]green";
+                    altEFOBCellColor = "[color]green";
                 }
 
                 mcdu.tryUpdateRouteTrip(isFlying);
@@ -169,6 +169,7 @@ class CDUFuelPredPage {
                     destIdentCell = dest.ident;
                 }
                 destEFOBCell = (NXUnits.kgToUser(mcdu.getDestEFOB(true))).toFixed(1);
+                destEFOBCellColor = mcdu.getDestEFOB(true) < mcdu._minDestFob ? "[color]amber" : "[color]green";
                 // Should we use predicted values or liveETATo and liveUTCto?
                 destTimeCell = isFlying ? FMCMainDisplay.secondsToUTC(utcTime + FMCMainDisplay.minuteToSeconds(mcdu._routeTripTime))
                     : destTimeCell = FMCMainDisplay.minutesTohhmm(mcdu._routeTripTime);
@@ -184,7 +185,6 @@ class CDUFuelPredPage {
                     }
                 }
 
-                destEFOBCellColor = "[color]green";
                 destTimeCellColor = "[color]green";
 
 


### PR DESCRIPTION
## Summary of Changes
Fixes the amber warning on FUEL PRED page from displaying on the alternate EFOB, which doesn't have an amber trigger according to FCOM, and moves it to the destination EFOB which does have an amber trigger when below the MIN DEST EFOB value.

## Screenshots (if necessary)
Before
![image](https://github.com/flybywiresim/aircraft/assets/74841560/37b4c7f5-74b3-44ae-b35b-1c578943141b)

After
![image](https://github.com/flybywiresim/aircraft/assets/74841560/a264f51c-7027-4405-b7f1-36d62cf4753d)
![image](https://github.com/flybywiresim/aircraft/assets/74841560/b1dbc51a-31ed-4bbd-af23-ec139c6ab306)


## References
![image](https://github.com/flybywiresim/aircraft/assets/74841560/7cbea51d-bf3e-4bc6-9d75-43408738ec27)
![image](https://github.com/flybywiresim/aircraft/assets/74841560/46890102-d13f-45a4-b2e1-f7447468fbf8)

## Additional context
Please take extra caution with this PR, am not the best coder so I might have broken something.

Discord username (if different from GitHub): shomas

## Testing instructions
1. Set up a flight as per normal.
2. When engines are running, check the FUEL PRED page.
3. Top line DEST FUEL EFOB should be in green if fuel amount is above your MIN DEST EFOB.
4. Second line ALT FUEL EFOB should always be in green, not amber as previous.
5. Adjust the MIN DEST EFOB to be above your DEST FUEL EFOB, this should then change the digits to amber.
6. Test as required, frequent changes to MIN DEST EFOB to trigger and untrigger the warning.

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
