### PR TITLE
fix: fms-v2 fmgc variable ref

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/new/DataManager.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/new/DataManager.ts
@@ -252,7 +252,7 @@ export class DataManager {
         const waypoint: LatLonWaypoint = {
             type: PilotWaypointType.LatLon,
             storedIndex: index,
-            waypoint: Fmgc.WaypointFactory.fromLocation(ident, coordinates),
+            waypoint: WaypointFactory.fromLocation(ident, coordinates),
         };
 
         if (stored) {
@@ -285,7 +285,7 @@ export class DataManager {
         const waypoint: PbxWaypoint = {
             type: PilotWaypointType.Pbx,
             storedIndex: index,
-            waypoint: Fmgc.WaypointFactory.fromLocation(ident, coordinates),
+            waypoint: WaypointFactory.fromLocation(ident, coordinates),
             pbxPlace1: place1.ident.substring(0, 5),
             pbxBearing1: bearing1,
             pbxPlace2: place2.ident.substring(0, 5),
@@ -319,7 +319,7 @@ export class DataManager {
         const waypoint: PbdWaypoint = {
             type: PilotWaypointType.Pbd,
             storedIndex: index,
-            waypoint: Fmgc.WaypointFactory.fromLocation(ident, coordinates),
+            waypoint: WaypointFactory.fromLocation(ident, coordinates),
             pbdPlace: origin.ident,
             pbdBearing: bearing,
             pbdDistance: distance,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
Fix for fms-v2 branch: Do not explicitly reference the Fmgc namespace/variable, since WaypointFactory is exported via index.ts anyways. In the A380x MFD, Fmgc throws an "undefined" error. 

## References

## Additional context
as discussed in discord

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): floridude

## Testing instructions
Try storing/deleting pilot-defined waypoints. Untested on A32NX so far. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page