### PR TITLE
feat(EFB/SimBrief): Automatically import SimBrief Fuel & Payload

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -43,9 +43,10 @@
 1. [FLIGHTMODEL/ICE PROT] - Interim fix for A/I system bug and quicker windscreen clearing of ice - @donstim (donbikes)
 1. [ND] Worked around a font rendering bug with the ND chrono - @tracernz (Mike)
 1. [TELEX] Decrease API poll rate to random number between 45-70 seconds - @auroraisluna (alepouna)
-1. [AUTOFLIGHT] Fixed managed speed not engaging when V2 is confirmed after a departure runway change - @tracernz (Mi
+1. [AUTOFLIGHT] Fixed managed speed not engaging when V2 is confirmed after a departure runway change - @tracernz (Mike)
 1. [GSX/EFB] FBW Chocks & Cones are usable with GSX Fuel/Payload Sync and react to GSX Pushback - @Fragtality (Fragtality)
 1. [GSX] Fixed GSX pin not actually disabling NWS - @Maximilian-Reuter (\_Chaoz_)
+1. [EFB/SIMBRIEF] Option to import SimBrief Fuel & Payload when SimBrief Data is imported - @Fragtality (Fragtality)
 
 ## 0.11.0
 

--- a/fbw-a32nx/src/localization/flypad/en.json
+++ b/fbw-a32nx/src/localization/flypad/en.json
@@ -55,6 +55,7 @@
         "RearrangeWidgets": "Rearrange Widgets"
       },
       "Title": "Important Information",
+      "ToastPayloadImported": "Fuel & Payload imported!",
       "Weather": {
         "AirPressure": "Air Pressure",
         "DewPoint": "Dew Point",
@@ -508,6 +509,7 @@
     "AtsuAoc": {
       "AtisAtcSource": "ATIS/ATC Source",
       "AutomaticallyImportSimBriefData": "Automatically Import SimBrief Data",
+      "ImportSimBriefPayload": "Set Fuel & Payload when SimBrief Data was imported",
       "Enable": "Enable",
       "EnableTelex": "Enable TELEX",
       "ErrorReporting": "Error Reporting",

--- a/fbw-a32nx/src/localization/flypad/en.json
+++ b/fbw-a32nx/src/localization/flypad/en.json
@@ -509,7 +509,7 @@
     "AtsuAoc": {
       "AtisAtcSource": "ATIS/ATC Source",
       "AutomaticallyImportSimBriefData": "Automatically Import SimBrief Data",
-      "ImportSimBriefWeights": "Automatically Import SimBrief Fuel & Payload when SimBrief Data was imported",
+      "ImportSimBriefWeights": "Automatically set SimBrief Fuel & Payload on Import",
       "Enable": "Enable",
       "EnableTelex": "Enable TELEX",
       "ErrorReporting": "Error Reporting",

--- a/fbw-a32nx/src/localization/flypad/en.json
+++ b/fbw-a32nx/src/localization/flypad/en.json
@@ -55,7 +55,6 @@
         "RearrangeWidgets": "Rearrange Widgets"
       },
       "Title": "Important Information",
-      "ToastPayloadImported": "Fuel & Payload imported!",
       "Weather": {
         "AirPressure": "Air Pressure",
         "DewPoint": "Dew Point",
@@ -82,6 +81,7 @@
       "CostIndex": "Cost Index",
       "CruiseAlt": "Cruise Alt.",
       "ImportSimBriefData": "Import SimBrief Data",
+      "ToastFuelPayloadImported": "Fuel & Payload imported!",
       "Route": "Route",
       "SimBriefDataNotYetLoaded": "SimBrief data not yet loaded.",
       "Title": "Your Flight",
@@ -509,7 +509,7 @@
     "AtsuAoc": {
       "AtisAtcSource": "ATIS/ATC Source",
       "AutomaticallyImportSimBriefData": "Automatically Import SimBrief Data",
-      "ImportSimBriefPayload": "Set Fuel & Payload when SimBrief Data was imported",
+      "ImportSimBriefWeights": "Automatically Import SimBrief Fuel & Payload when SimBrief Data was imported",
       "Enable": "Enable",
       "EnableTelex": "Enable TELEX",
       "ErrorReporting": "Error Reporting",

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Dashboard/Widgets/FlightWidget.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Dashboard/Widgets/FlightWidget.tsx
@@ -141,7 +141,7 @@ export const FlightWidget = () => {
                 })
                 .then(() => {
                     history.push('/dashboard');
-                    toast.success(t('Dashboard.ImportantInformation.ToastPayloadImported'));
+                    toast.success(t('Dashboard.YourFlight.ToastFuelPayloadImported'));
                 });
         }
 

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Dashboard/Widgets/FlightWidget.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Dashboard/Widgets/FlightWidget.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 /* eslint-disable max-len */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { IconPlane } from '@tabler/icons';
 import { CloudArrowDown } from 'react-bootstrap-icons';
@@ -71,6 +71,7 @@ export const FlightWidget = () => {
     const [simbriefDataPending, setSimbriefDataPending] = useState(false);
     const [navigraphUsername] = usePersistentProperty('NAVIGRAPH_USERNAME');
     const [overrideSimBriefUserID] = usePersistentProperty('CONFIG_OVERRIDE_SIMBRIEF_USERID');
+    const [autoSimbriefImport] = usePersistentProperty('CONFIG_AUTO_SIMBRIEF_IMPORT');
     const [simbriefWeightsImport] = usePersistentProperty('CONFIG_SIMBRIEF_WEIGHTS_IMPORT');
     const [airframe] = useState(getAirframeType());
 
@@ -146,6 +147,12 @@ export const FlightWidget = () => {
 
         setSimbriefDataPending(false);
     };
+
+    useEffect(() => {
+        if ((!data || !isSimbriefDataLoaded()) && autoSimbriefImport === 'ENABLED') {
+            fetchData();
+        }
+    }, []);
 
     const simbriefDataLoaded = isSimbriefDataLoaded();
 

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Dashboard/Widgets/FlightWidget.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Dashboard/Widgets/FlightWidget.tsx
@@ -4,11 +4,12 @@
 
 /* eslint-disable max-len */
 import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { IconPlane } from '@tabler/icons';
 import { CloudArrowDown } from 'react-bootstrap-icons';
 import { usePersistentProperty } from '@flybywiresim/fbw-sdk';
 import { toast } from 'react-toastify';
-import { fetchSimbriefDataAction, isSimbriefDataLoaded } from '../../Store/features/simBrief';
+import { fetchSimbriefDataAction, isSimbriefDataLoaded, setPayloadImported, setFuelImported } from '../../Store/features/simBrief';
 import { useAppSelector, useAppDispatch } from '../../Store/store';
 
 import { ScrollableContainer } from '../../UtilComponents/ScrollableContainer';
@@ -21,8 +22,8 @@ interface InformationEntryProps {
 }
 
 const InformationEntry = ({ title, info }: InformationEntryProps) => (
-    <div className="flex flex-col items-center w-full justify-content">
-        <h3 className="font-light text-center">{title}</h3>
+    <div className="justify-content flex w-full flex-col items-center">
+        <h3 className="text-center font-light">{title}</h3>
         <h2 className="font-bold">{info}</h2>
     </div>
 );
@@ -34,8 +35,8 @@ interface NoSimBriefDataOverlayProps {
 }
 
 const NoSimBriefDataOverlay = ({ simbriefDataLoaded, simbriefDataPending, fetchData }: NoSimBriefDataOverlayProps) => (
-    <div className={`absolute inset-0 transition duration-200 bg-theme-body ${simbriefDataLoaded ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}>
-        <h1 className="flex justify-center items-center w-full h-full">
+    <div className={`bg-theme-body absolute inset-0 transition duration-200 ${simbriefDataLoaded ? 'pointer-events-none opacity-0' : 'opacity-100'}`}>
+        <h1 className="flex h-full w-full items-center justify-center">
             {simbriefDataPending ? (
                 <CloudArrowDown className="animate-bounce" size={40} />
             ) : (
@@ -52,7 +53,7 @@ const NoSimBriefDataOverlay = ({ simbriefDataLoaded, simbriefDataPending, fetchD
                             <button
                                 type="button"
                                 onClick={fetchData}
-                                className="flex justify-center items-center p-2 space-x-4 w-full rounded-md border-2 transition duration-100 text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body border-theme-highlight"
+                                className="text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body border-theme-highlight flex w-full items-center justify-center space-x-4 rounded-md border-2 p-2 transition duration-100"
                             >
                                 <CloudArrowDown size={26} />
                                 <p className="text-current">{t('Dashboard.YourFlight.ImportSimBriefData')}</p>
@@ -70,6 +71,7 @@ export const FlightWidget = () => {
     const [simbriefDataPending, setSimbriefDataPending] = useState(false);
     const [navigraphUsername] = usePersistentProperty('NAVIGRAPH_USERNAME');
     const [overrideSimBriefUserID] = usePersistentProperty('CONFIG_OVERRIDE_SIMBRIEF_USERID');
+    const [simbriefWeightsImport] = usePersistentProperty('CONFIG_SIMBRIEF_WEIGHTS_IMPORT');
     const [airframe] = useState(getAirframeType());
 
     const {
@@ -96,6 +98,8 @@ export const FlightWidget = () => {
 
     const dispatch = useAppDispatch();
 
+    const history = useHistory();
+
     const sta = new Date(parseInt(schedIn) * 1000);
     const schedInParsed = `${sta.getUTCHours().toString().padStart(2, '0')}${sta.getUTCMinutes().toString().padStart(2, '0')}Z`;
 
@@ -114,12 +118,30 @@ export const FlightWidget = () => {
     const fetchData = async () => {
         setSimbriefDataPending(true);
 
-        try {
-            const action = await fetchSimbriefDataAction(navigraphUsername ?? '', overrideSimBriefUserID ?? '');
-
-            dispatch(action);
-        } catch (e) {
-            toast.error(e.message);
+        if (simbriefWeightsImport === 'DISABLED') {
+            fetchSimbriefDataAction(navigraphUsername ?? '', overrideSimBriefUserID ?? '').then((action) => {
+                dispatch(action);
+            }).catch((e) => {
+                toast.error(e.message);
+            });
+        } else {
+            dispatch(setFuelImported(false));
+            dispatch(setPayloadImported(false));
+            fetchSimbriefDataAction(navigraphUsername ?? '', overrideSimBriefUserID ?? '').then((action) => {
+                dispatch(action);
+            }).catch((e) => {
+                toast.error(e.message);
+            })
+                .then(() => {
+                    history.push('/ground/fuel');
+                })
+                .then(() => {
+                    history.push('/ground/payload');
+                })
+                .then(() => {
+                    history.push('/dashboard');
+                    toast.success(t('Dashboard.ImportantInformation.ToastPayloadImported'));
+                });
         }
 
         setSimbriefDataPending(false);
@@ -129,7 +151,7 @@ export const FlightWidget = () => {
 
     return (
         <div className="w-1/2">
-            <div className="flex flex-row justify-between items-center mb-4">
+            <div className="mb-4 flex flex-row items-center justify-between">
                 <h1 className="font-bold">{t('Dashboard.YourFlight.Title')}</h1>
                 {simbriefDataLoaded && (
                     <h1>
@@ -141,8 +163,8 @@ export const FlightWidget = () => {
                     </h1>
                 )}
             </div>
-            <div className="overflow-hidden relative p-6 w-full rounded-lg border-2 h-content-section-reduced border-theme-accent">
-                <div className="flex flex-col justify-between h-full">
+            <div className="h-content-section-reduced border-theme-accent relative w-full overflow-hidden rounded-lg border-2 p-6">
+                <div className="flex h-full flex-col justify-between">
                     <div className="space-y-8">
                         <div className="flex flex-row justify-between">
                             <div>
@@ -150,47 +172,47 @@ export const FlightWidget = () => {
                                 <p className="w-52 text-sm">{departingName}</p>
                             </div>
                             <div>
-                                <h1 className="text-4xl font-bold text-right">{arrivingAirport}</h1>
-                                <p className="w-52 text-sm text-right">{arrivingName}</p>
+                                <h1 className="text-right text-4xl font-bold">{arrivingAirport}</h1>
+                                <p className="w-52 text-right text-sm">{arrivingName}</p>
                             </div>
                         </div>
                         <div>
-                            <div className="flex flex-row items-center w-full">
+                            <div className="flex w-full flex-row items-center">
                                 <p className={`font-body ${flightPlanProgress > 1 ? 'text-theme-highlight' : 'text-theme-text'}`}>
                                     {schedOutParsed}
                                 </p>
-                                <div className="flex relative flex-row mx-6 w-full h-1">
-                                    <div className="absolute inset-x-0 border-b-4 border-dashed border-theme-text" />
+                                <div className="relative mx-6 flex h-1 w-full flex-row">
+                                    <div className="border-theme-text absolute inset-x-0 border-b-4 border-dashed" />
 
-                                    <div className="relative w-full bg-theme-highlight" style={{ width: `${flightPlanProgress}%` }}>
+                                    <div className="bg-theme-highlight relative w-full" style={{ width: `${flightPlanProgress}%` }}>
                                         {!!flightPlanProgress && (
                                             <IconPlane
-                                                className="absolute right-0 transform translate-x-1/2 -translate-y-1/2 fill-current text-theme-highlight"
+                                                className="text-theme-highlight absolute right-0 -translate-y-1/2 translate-x-1/2 fill-current"
                                                 size={50}
                                                 strokeLinejoin="miter"
                                             />
                                         )}
                                     </div>
                                 </div>
-                                <p className={`text-right font-body ${Math.round(flightPlanProgress) >= 98 ? 'text-theme-highlight' : 'text-theme-text'}`}>
+                                <p className={`font-body text-right ${Math.round(flightPlanProgress) >= 98 ? 'text-theme-highlight' : 'text-theme-text'}`}>
                                     {schedInParsed}
                                 </p>
                             </div>
                         </div>
                         <div>
-                            <div className="flex flex-row justify-around mb-4">
+                            <div className="mb-4 flex flex-row justify-around">
                                 <InformationEntry title={t('Dashboard.YourFlight.Alternate')} info={altIcao ?? 'NONE'} />
-                                <div className="my-auto mx-4 w-1 h-8 bg-theme-accent" />
+                                <div className="bg-theme-accent mx-4 my-auto h-8 w-1" />
                                 <InformationEntry title={t('Dashboard.YourFlight.CompanyRoute')} info={departingIata + arrivingIata} />
-                                <div className="my-auto mx-4 w-1 h-8 bg-theme-accent" />
+                                <div className="bg-theme-accent mx-4 my-auto h-8 w-1" />
                                 <InformationEntry title={t('Dashboard.YourFlight.ZFW')} info={estimatedZfw} />
                             </div>
-                            <div className="my-auto w-full h-0.5 bg-theme-accent" />
-                            <div className="flex flex-row justify-around mt-4">
+                            <div className="bg-theme-accent my-auto h-0.5 w-full" />
+                            <div className="mt-4 flex flex-row justify-around">
                                 <InformationEntry title={t('Dashboard.YourFlight.CostIndex')} info={costInd} />
-                                <div className="my-auto mx-4 w-1 h-8 bg-theme-accent" />
+                                <div className="bg-theme-accent mx-4 my-auto h-8 w-1" />
                                 <InformationEntry title={t('Dashboard.YourFlight.AverageWind')} info={avgWind} />
-                                <div className="my-auto mx-4 w-1 h-8 bg-theme-accent" />
+                                <div className="bg-theme-accent mx-4 my-auto h-8 w-1" />
                                 <InformationEntry title={t('Dashboard.YourFlight.CruiseAlt')} info={crzAlt} />
                             </div>
                         </div>
@@ -198,7 +220,7 @@ export const FlightWidget = () => {
                             <h5 className="mb-2 text-2xl font-bold">{t('Dashboard.YourFlight.Route')}</h5>
                             <ScrollableContainer height={15}>
                                 <p className="font-mono text-2xl">
-                                    <span className="text-2xl text-theme-highlight">
+                                    <span className="text-theme-highlight text-2xl">
                                         {departingAirport}
                                         /
                                         {departingRunway}
@@ -206,7 +228,7 @@ export const FlightWidget = () => {
                                     {' '}
                                     {route}
                                     {' '}
-                                    <span className="text-2xl text-theme-highlight">
+                                    <span className="text-theme-highlight text-2xl">
                                         {arrivingAirport}
                                         /
                                         {arrivingRunway}
@@ -218,7 +240,7 @@ export const FlightWidget = () => {
                     <button
                         type="button"
                         onClick={fetchData}
-                        className="flex justify-center items-center p-2 space-x-4 w-full rounded-lg border-2 transition duration-100 text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body border-theme-highlight"
+                        className="text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body border-theme-highlight flex w-full items-center justify-center space-x-4 rounded-lg border-2 p-2 transition duration-100"
                     >
                         <CloudArrowDown size={26} />
                         <p className="text-current">{t('Dashboard.YourFlight.ImportSimBriefData')}</p>

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/FuelPage.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/FuelPage.tsx
@@ -3,15 +3,15 @@
 // SPDX-License-Identifier: GPL-3.0
 
 /* eslint-disable max-len */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { round } from 'lodash';
 import { CloudArrowDown, PlayFill, StopCircleFill } from 'react-bootstrap-icons';
 import { useSimVar, Units, usePersistentNumberProperty, usePersistentProperty } from '@flybywiresim/fbw-sdk';
 import Slider from 'rc-slider';
 import { t } from '../../translation';
 import { TooltipWrapper } from '../../UtilComponents/TooltipWrapper';
-import { isSimbriefDataLoaded } from '../../Store/features/simBrief';
-import { useAppSelector } from '../../Store/store';
+import { isSimbriefDataLoaded, setFuelImported } from '../../Store/features/simBrief';
+import { useAppDispatch, useAppSelector } from '../../Store/store';
 import { SelectGroup, SelectItem } from '../../UtilComponents/Form/Select';
 import { ProgressBar } from '../../UtilComponents/Progress/Progress';
 import { SimpleInput } from '../../UtilComponents/Form/SimpleInput/SimpleInput';
@@ -34,7 +34,7 @@ const TankReadoutWidget = ({ title, current, target, capacity, currentUnit, tank
     const getFuelBarPercent = (curr: number, max: number) => (Math.max(curr, 0) / max) * 100;
 
     return (
-        <div className={`overflow-hidden w-min p-4 space-y-3 bg-theme-body ${className}`} style={{ width: `${width}px` }}>
+        <div className={`bg-theme-body w-min space-y-3 overflow-hidden p-4 ${className}`} style={{ width: `${width}px` }}>
             <div className={inlinedTitle ? 'flex flex-row items-center justify-between' : undefined}>
                 <h2>{title}</h2>
                 <p>{`${convertedFuelValue}/${round(tankValue)} ${currentUnit}`}</p>
@@ -100,6 +100,16 @@ export const FuelPage = () => {
     const { units } = useAppSelector((state) => state.simbrief.data);
     const { planRamp } = useAppSelector((state) => state.simbrief.data.fuels);
     const simbriefDataLoaded = isSimbriefDataLoaded();
+    const dispatch = useAppDispatch();
+    const fuelImported = useAppSelector((state) => state.simbrief.fuelImported);
+    const [simbriefWeightsImport] = usePersistentProperty('CONFIG_SIMBRIEF_WEIGHTS_IMPORT');
+
+    useEffect(() => {
+        if (simbriefDataLoaded === true && simbriefWeightsImport === 'ENABLED' && fuelImported === false) {
+            handleFuelAutoFill();
+            dispatch(setFuelImported(true));
+        }
+    }, []);
 
     const isAirplaneCnD = () => !(simGroundSpeed > 0.1 || eng1Running || eng2Running || !isOnGround || (!busDC2 && !busDCHot1));
 
@@ -281,9 +291,9 @@ export const FuelPage = () => {
     const roundUpNearest100 = (plannedFuel: number) => Math.ceil(plannedFuel / 100) * 100;
 
     return (
-        <div className="flex relative flex-col justify-between mt-6 h-content-section-reduced">
+        <div className="h-content-section-reduced relative mt-6 flex flex-col justify-between">
             <div className="z-30">
-                <div className="flex absolute inset-x-0 top-0 flex-col items-center mx-auto space-y-3">
+                <div className="absolute inset-x-0 top-0 mx-auto flex flex-col items-center space-y-3">
                     <TankReadoutWidget
                         title={t('Ground.Fuel.TotalFuel')}
                         current={totalCurrent()}
@@ -292,7 +302,7 @@ export const FuelPage = () => {
                         currentUnit={currentUnit}
                         tankValue={totalFuel()}
                         convertedFuelValue={totalCurrent()}
-                        className="overflow-hidden rounded-2xl border-2 border-theme-accent"
+                        className="border-theme-accent overflow-hidden rounded-2xl border-2"
                         inlinedTitle
                         width={420}
                     />
@@ -304,13 +314,13 @@ export const FuelPage = () => {
                         currentUnit={currentUnit}
                         tankValue={centerTank()}
                         convertedFuelValue={convertFuelValueCenter(centerCurrent)}
-                        className="overflow-hidden rounded-2xl border-2 border-theme-accent"
+                        className="border-theme-accent overflow-hidden rounded-2xl border-2"
                         inlinedTitle
                         width={420}
                     />
                 </div>
-                <div className="flex absolute inset-x-0 top-40 flex-row justify-between">
-                    <div className="overflow-hidden w-min rounded-2xl border-2 border-theme-accent divide-y divide-theme-accent">
+                <div className="absolute inset-x-0 top-40 flex flex-row justify-between">
+                    <div className="border-theme-accent divide-theme-accent w-min divide-y overflow-hidden rounded-2xl border-2">
                         <TankReadoutWidget
                             title={t('Ground.Fuel.LeftInnerTank')}
                             current={LInnCurrent}
@@ -330,7 +340,7 @@ export const FuelPage = () => {
                             convertedFuelValue={convertFuelValueCenter(LOutCurrent)}
                         />
                     </div>
-                    <div className="overflow-hidden w-min rounded-2xl border-2 border-theme-accent divide-y divide-theme-accent">
+                    <div className="border-theme-accent divide-theme-accent w-min divide-y overflow-hidden rounded-2xl border-2">
                         <TankReadoutWidget
                             title={t('Ground.Fuel.RightInnerTank')}
                             current={RInnCurrent}
@@ -352,7 +362,7 @@ export const FuelPage = () => {
                     </div>
                 </div>
             </div>
-            <div className="flex flex-col justify-end items-center">
+            <div className="flex flex-col items-center justify-end">
                 {/* FIXME TODO: Replace with Tailwind JIT values later */}
                 <div className="absolute inset-x-0 bottom-0" style={{ transform: 'translate(0px, -150px)' }}>
                     <OverWingOutline className="absolute bottom-0 left-0 z-20" />
@@ -379,29 +389,29 @@ export const FuelPage = () => {
                     />
                     {/* tl overlay */}
                     <div
-                        className="absolute bottom-overlay-t-y left-overlay-tl z-10 bg-theme-body -rotate-26.5"
+                        className="bottom-overlay-t-y left-overlay-tl bg-theme-body -rotate-26.5 absolute z-10"
                         style={{ transform: 'rotate(-26.5deg)', width: '490px', height: '140px', bottom: '240px', left: '82px' }}
                     />
                     {/* tr overlay */}
                     <div
-                        className="absolute right-overlay-tr bottom-overlay-t-y z-10 bg-theme-body rotate-26.5"
+                        className="right-overlay-tr bottom-overlay-t-y bg-theme-body rotate-26.5 absolute z-10"
                         style={{ transform: 'rotate(26.5deg)', width: '490px', height: '140px', bottom: '240px', right: '82px' }}
                     />
                     {/* bl overlay */}
                     <div
-                        className="absolute bottom-overlay-b-y left-overlay-bl z-10 bg-theme-body -rotate-18.5"
+                        className="bottom-overlay-b-y left-overlay-bl bg-theme-body -rotate-18.5 absolute z-10"
                         style={{ transform: 'rotate(-18.5deg)', width: '484px', height: '101px', bottom: '78px', left: '144px' }}
                     />
                     {/* br overlay */}
                     <div
-                        className="absolute right-overlay-br bottom-overlay-b-y z-10 bg-theme-body rotate-18.5"
+                        className="right-overlay-br bottom-overlay-b-y bg-theme-body rotate-18.5 absolute z-10"
                         style={{ transform: 'rotate(18.5deg)', width: '484px', height: '101px', bottom: '78px', right: '144px' }}
                     />
                 </div>
 
-                <div className="flex overflow-x-hidden absolute bottom-0 left-0 z-10 flex-row max-w-3xl rounded-2xl border border-theme-accentborder-2">
-                    <div className="py-3 px-5 space-y-4">
-                        <div className="flex flex-row justify-between items-center">
+                <div className="border-theme-accentborder-2 absolute bottom-0 left-0 z-10 flex max-w-3xl flex-row overflow-x-hidden rounded-2xl border">
+                    <div className="space-y-4 px-5 py-3">
+                        <div className="flex flex-row items-center justify-between">
                             <div className="flex flex-row items-center space-x-3">
                                 <h2 className="font-medium">{t('Ground.Fuel.Refuel')}</h2>
                                 <p className={formatRefuelStatusClass()}>{formatRefuelStatusLabel()}</p>
@@ -425,12 +435,12 @@ export const FuelPage = () => {
                                         value={inputValue}
                                         onChange={(x) => updateDesiredFuel(x)}
                                     />
-                                    <div className="absolute top-2 right-4 text-lg text-gray-400">{currentUnit}</div>
+                                    <div className="absolute right-4 top-2 text-lg text-gray-400">{currentUnit}</div>
                                 </div>
                                 {simbriefDataLoaded && (
                                     <TooltipWrapper text={t('Ground.Fuel.TT.FillBlockFuelFromSimBrief')}>
                                         <div
-                                            className="flex justify-center items-center px-2 h-auto text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body rounded-md rounded-l-none border-2 border-theme-highlight transition duration-100"
+                                            className="text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body border-theme-highlight flex h-auto items-center justify-center rounded-md rounded-l-none border-2 px-2 transition duration-100"
                                             onClick={simbriefDataLoaded ? handleFuelAutoFill : undefined}
                                         >
                                             <CloudArrowDown size={26} />
@@ -442,7 +452,7 @@ export const FuelPage = () => {
                     </div>
 
                     <div
-                        className={`flex justify-center items-center w-20 ${formatRefuelStatusClass()} bg-current`}
+                        className={`flex w-20 items-center justify-center ${formatRefuelStatusClass()} bg-current`}
                         onClick={() => switchRefuelState()}
                     >
                         <div className={`${airplaneCanRefuel() ? 'text-white' : 'text-theme-unselected'}`}>
@@ -452,7 +462,7 @@ export const FuelPage = () => {
                     </div>
                 </div>
 
-                <div className="flex overflow-x-hidden absolute right-6 bottom-0 flex-col justify-center items-center py-3 px-6 space-y-2 rounded-2xl border border-theme-accent">
+                <div className="border-theme-accent absolute bottom-0 right-6 flex flex-col items-center justify-center space-y-2 overflow-x-hidden rounded-2xl border px-6 py-3">
                     <h2 className="flex font-medium">{t('Ground.Fuel.RefuelTime')}</h2>
 
                     <SelectGroup>

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A320_251N/A320Payload.tsx
@@ -14,6 +14,8 @@ import Card from '../../../../UtilComponents/Card/Card';
 import { SelectGroup, SelectItem } from '../../../../UtilComponents/Form/Select';
 import { SeatMapWidget } from '../Seating/SeatMapWidget';
 import { PromptModal, useModals } from '../../../../UtilComponents/Modals/Modals';
+import { setPayloadImported } from '../../../../Store/features/simBrief';
+import { useAppDispatch } from '../../../../Store/store';
 
 interface A320Props {
     simbriefUnits: string,
@@ -23,6 +25,8 @@ interface A320Props {
     simbriefBag: number,
     simbriefFreight: number,
     simbriefDataLoaded: boolean,
+    simbriefWeightsImport: string,
+    payloadImported: boolean,
     massUnitForDisplay: string,
     isOnGround: boolean,
 
@@ -39,6 +43,8 @@ export const A320Payload: React.FC<A320Props> = ({
     simbriefBag,
     simbriefFreight,
     simbriefDataLoaded,
+    simbriefWeightsImport,
+    payloadImported,
     massUnitForDisplay,
     isOnGround,
     boardingStarted,
@@ -137,6 +143,15 @@ export const A320Payload: React.FC<A320Props> = ({
         PERFORMING: 5,
         COMPLETED: 6,
     };
+
+    const dispatch = useAppDispatch();
+
+    useEffect(() => {
+        if (simbriefDataLoaded === true && simbriefWeightsImport === 'ENABLED' && payloadImported === false) {
+            setSimBriefValues();
+            dispatch(setPayloadImported(true));
+        }
+    }, []);
 
     const setSimBriefValues = () => {
         if (simbriefUnits === 'kgs') {
@@ -483,19 +498,19 @@ export const A320Payload: React.FC<A320Props> = ({
 
     return (
         <div>
-            <div className="relative h-content-section-reduced">
+            <div className="h-content-section-reduced relative">
                 <div className="mb-10">
-                    <div className="flex relative flex-col">
+                    <div className="relative flex flex-col">
                         <SeatOutlineBg stroke={getTheme(theme)[0]} highlight="#69BD45" />
                         <SeatMapWidget seatMap={seatMap} desiredFlags={desiredFlags} activeFlags={activeFlags} onClickSeat={onClickSeat} theme={getTheme(theme)} isMainDeck canvasX={243} canvasY={78} />
                     </div>
                 </div>
                 <CargoWidget cargo={cargo} cargoDesired={cargoDesired} cargoMap={cargoMap} onClickCargo={onClickCargo} />
 
-                <div className="flex relative right-0 flex-row justify-between px-4 mt-16">
-                    <div className="flex flex-col flex-grow pr-24">
-                        <div className="flex flex-row w-full">
-                            <Card className="w-full col-1" childrenContainerClassName={`w-full ${simbriefDataLoaded ? 'rounded-r-none' : ''}`}>
+                <div className="relative right-0 mt-16 flex flex-row justify-between px-4">
+                    <div className="flex grow flex-col pr-24">
+                        <div className="flex w-full flex-row">
+                            <Card className="col-1 w-full" childrenContainerClassName={`w-full ${simbriefDataLoaded ? 'rounded-r-none' : ''}`}>
                                 <PayloadInputTable
                                     loadsheet={Loadsheet}
                                     emptyWeight={emptyWeight}
@@ -524,7 +539,7 @@ export const A320Payload: React.FC<A320Props> = ({
                                     setDisplayZfw={setDisplayZfw}
                                 />
                                 <hr className="mb-4 border-gray-700" />
-                                <div className="flex flex-row justify-start items-center">
+                                <div className="flex flex-row items-center justify-start">
                                     <MiscParamsInput
                                         disable={gsxPayloadSyncEnabled === 1 && boardingStarted}
                                         minPaxWeight={Math.round(Loadsheet.specs.pax.minPaxWeight)}
@@ -548,9 +563,9 @@ export const A320Payload: React.FC<A320Props> = ({
                                 && (
                                     <TooltipWrapper text={t('Ground.Payload.TT.FillPayloadFromSimbrief')}>
                                         <div
-                                            className={`flex justify-center items-center px-2 h-auto text-theme-body
-                                                       hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body
-                                                       rounded-md rounded-l-none border-2 border-theme-highlight transition duration-100`}
+                                            className={`text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body border-theme-highlight flex
+                                                       h-auto items-center justify-center
+                                                       rounded-md rounded-l-none border-2 px-2 transition duration-100`}
                                             onClick={setSimBriefValues}
                                         >
                                             <CloudArrowDown size={26} />
@@ -559,12 +574,12 @@ export const A320Payload: React.FC<A320Props> = ({
                                 )}
                         </div>
                         {(gsxPayloadSyncEnabled !== 1) && (
-                            <div className="flex flex-row mt-4">
-                                <Card className="w-full h-full" childrenContainerClassName="flex flex-col w-full h-full">
-                                    <div className="flex flex-row justify-between items-center">
+                            <div className="mt-4 flex flex-row">
+                                <Card className="h-full w-full" childrenContainerClassName="flex flex-col w-full h-full">
+                                    <div className="flex flex-row items-center justify-between">
                                         <div className="flex font-medium">
                                             {t('Ground.Payload.BoardingTime')}
-                                            <span className="flex relative flex-row items-center ml-2 text-sm font-light">
+                                            <span className="relative ml-2 flex flex-row items-center text-sm font-light">
                                                 (
                                                 {remainingTimeString()}
                                                 )
@@ -608,12 +623,12 @@ export const A320Payload: React.FC<A320Props> = ({
                             </div>
                         )}
                         {gsxPayloadSyncEnabled === 1 && (
-                            <div className="pt-6 pl-2">
+                            <div className="pl-2 pt-6">
                                 {t('Ground.Payload.GSXPayloadSyncEnabled')}
                             </div>
                         )}
                     </div>
-                    <div className="border border-theme-accent col-1">
+                    <div className="border-theme-accent col-1 border">
                         <ChartWidget
                             width={525}
                             height={511}

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A380_842/A380Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/A380_842/A380Payload.tsx
@@ -14,6 +14,8 @@ import { SelectGroup, SelectItem } from '../../../../UtilComponents/Form/Select'
 import { SeatMapWidget } from '../Seating/SeatMapWidget';
 import { PromptModal, useModals } from '../../../../UtilComponents/Modals/Modals';
 import { A380SeatOutlineBg, A380SeatOutlineUpperBg } from '../../../../Assets/A380SeatOutlineBg';
+import { setPayloadImported } from '../../../../Store/features/simBrief';
+import { useAppDispatch } from '../../../../Store/store';
 
 interface A380Props {
     simbriefUnits: string,
@@ -23,6 +25,8 @@ interface A380Props {
     simbriefBag: number,
     simbriefFreight: number,
     simbriefDataLoaded: boolean,
+    simbriefWeightsImport: string,
+    payloadImported: boolean,
     massUnitForDisplay: string,
     isOnGround: boolean,
 
@@ -40,6 +44,8 @@ export const A380Payload: React.FC<A380Props> = ({
     simbriefBag,
     simbriefFreight,
     simbriefDataLoaded,
+    simbriefWeightsImport,
+    payloadImported,
     massUnitForDisplay,
     isOnGround,
     boardingStarted,
@@ -166,6 +172,15 @@ export const A380Payload: React.FC<A380Props> = ({
         PERFORMING: 5,
         COMPLETED: 6,
     };
+
+    const dispatch = useAppDispatch();
+
+    useEffect(() => {
+        if (simbriefDataLoaded === true && simbriefWeightsImport === 'ENABLED' && payloadImported === false) {
+            setSimBriefValues();
+            dispatch(setPayloadImported(true));
+        }
+    }, []);
 
     const setSimBriefValues = () => {
         if (simbriefUnits === 'kgs') {
@@ -510,9 +525,9 @@ export const A380Payload: React.FC<A380Props> = ({
 
     return (
         <div>
-            <div className="relative h-content-section-reduced">
+            <div className="h-content-section-reduced relative">
                 <div className="mb-10">
-                    <div className="flex relative flex-col">
+                    <div className="relative flex flex-col">
                         {displayPaxMainDeck && (
                             <A380SeatOutlineBg stroke={getTheme(theme)[0]} highlight="#69BD45" />
                         )}
@@ -520,8 +535,8 @@ export const A380Payload: React.FC<A380Props> = ({
                             <A380SeatOutlineUpperBg stroke={getTheme(theme)[0]} highlight="#69BD45" />
                         )}
                         <SeatMapWidget seatMap={seatMap} desiredFlags={desiredFlags} activeFlags={activeFlags} canvasX={146} canvasY={71} theme={getTheme(theme)} isMainDeck={displayPaxMainDeck} onClickSeat={onClickSeat} />
-                        <div className="flex absolute top-full flex-row px-4 w-full">
-                            <div><AirplaneFill size={25} className="my-1 mx-3" /></div>
+                        <div className="absolute top-full flex w-full flex-row px-4">
+                            <div><AirplaneFill size={25} className="mx-3 my-1" /></div>
                             <SelectGroup>
                                 <SelectItem
                                     selected={displayPaxMainDeck}
@@ -541,10 +556,10 @@ export const A380Payload: React.FC<A380Props> = ({
                 </div>
                 <CargoWidget cargo={cargo} cargoDesired={cargoDesired} cargoMap={cargoMap} onClickCargo={onClickCargo} />
 
-                <div className="flex relative right-0 flex-row justify-between px-4 mt-16">
-                    <div className="flex flex-col flex-grow pr-24">
-                        <div className="flex flex-row w-full">
-                            <Card className="w-full col-1" childrenContainerClassName={`w-full ${simbriefDataLoaded ? 'rounded-r-none' : ''}`}>
+                <div className="relative right-0 mt-16 flex flex-row justify-between px-4">
+                    <div className="flex grow flex-col pr-24">
+                        <div className="flex w-full flex-row">
+                            <Card className="col-1 w-full" childrenContainerClassName={`w-full ${simbriefDataLoaded ? 'rounded-r-none' : ''}`}>
                                 <PayloadInputTable
                                     loadsheet={Loadsheet}
                                     emptyWeight={emptyWeight}
@@ -573,7 +588,7 @@ export const A380Payload: React.FC<A380Props> = ({
                                     setDisplayZfw={setDisplayZfw}
                                 />
                                 <hr className="mb-4 border-gray-700" />
-                                <div className="flex flex-row justify-start items-center">
+                                <div className="flex flex-row items-center justify-start">
                                     <MiscParamsInput
                                         disable={gsxPayloadSyncEnabled === 1 && boardingStarted}
                                         minPaxWeight={Math.round(Loadsheet.specs.pax.minPaxWeight)}
@@ -598,9 +613,9 @@ export const A380Payload: React.FC<A380Props> = ({
                                 && (
                                     <TooltipWrapper text={t('Ground.Payload.TT.FillPayloadFromSimbrief')}>
                                         <div
-                                            className={`flex justify-center items-center px-2 h-auto text-theme-body
-                                                       hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body
-                                                       rounded-md rounded-l-none border-2 border-theme-highlight transition duration-100`}
+                                            className={`text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body border-theme-highlight flex
+                                                       h-auto items-center justify-center
+                                                       rounded-md rounded-l-none border-2 px-2 transition duration-100`}
                                             onClick={setSimBriefValues}
                                         >
                                             <CloudArrowDown size={26} />
@@ -609,12 +624,12 @@ export const A380Payload: React.FC<A380Props> = ({
                                 )}
                         </div>
                         {(gsxPayloadSyncEnabled !== 1) && (
-                            <div className="flex flex-row mt-4">
-                                <Card className="w-full h-full" childrenContainerClassName="flex flex-col w-full h-full">
-                                    <div className="flex flex-row justify-between items-center">
+                            <div className="mt-4 flex flex-row">
+                                <Card className="h-full w-full" childrenContainerClassName="flex flex-col w-full h-full">
+                                    <div className="flex flex-row items-center justify-between">
                                         <div className="flex font-medium">
                                             {t('Ground.Payload.BoardingTime')}
-                                            <span className="flex relative flex-row items-center ml-2 text-sm font-light">
+                                            <span className="relative ml-2 flex flex-row items-center text-sm font-light">
                                                 (
                                                 {remainingTimeString()}
                                                 )
@@ -662,12 +677,12 @@ export const A380Payload: React.FC<A380Props> = ({
                             </div>
                         )}
                         {gsxPayloadSyncEnabled === 1 && (
-                            <div className="pt-6 pl-2">
+                            <div className="pl-2 pt-6">
                                 {t('Ground.Payload.GSXPayloadSyncEnabled')}
                             </div>
                         )}
                     </div>
-                    <div className="border border-theme-accent col-1">
+                    <div className="border-theme-accent col-1 border">
                         <ChartWidget
                             width={525}
                             height={511}

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
@@ -22,6 +22,8 @@ export const Payload = () => {
     const [isOnGround] = useSimVar('SIM ON GROUND', 'Bool', 8_059);
     const [boardingStarted, setBoardingStarted] = useSimVar('L:A32NX_BOARDING_STARTED_BY_USR', 'Bool', 509);
     const [boardingRate, setBoardingRate] = usePersistentProperty('CONFIG_BOARDING_RATE', 'REAL');
+    const payloadImported = useAppSelector((state) => state.simbrief.payloadImported);
+    const [simbriefWeightsImport] = usePersistentProperty('CONFIG_SIMBRIEF_WEIGHTS_IMPORT');
 
     const simbriefDataLoaded = isSimbriefDataLoaded();
 
@@ -38,6 +40,8 @@ export const Payload = () => {
                 simbriefBag={simbriefBag}
                 simbriefFreight={simbriefFreight}
                 simbriefDataLoaded={simbriefDataLoaded}
+                simbriefWeightsImport={simbriefWeightsImport}
+                payloadImported={payloadImported}
                 massUnitForDisplay={massUnitForDisplay}
                 isOnGround={isOnGround}
                 boardingStarted={boardingStarted}
@@ -57,6 +61,8 @@ export const Payload = () => {
                 simbriefBag={simbriefBag}
                 simbriefFreight={simbriefFreight}
                 simbriefDataLoaded={simbriefDataLoaded}
+                simbriefWeightsImport={simbriefWeightsImport}
+                payloadImported={payloadImported}
                 massUnitForDisplay={massUnitForDisplay}
                 isOnGround={isOnGround}
                 boardingStarted={boardingStarted}

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AtsuAocPage.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AtsuAocPage.tsx
@@ -194,7 +194,7 @@ export const AtsuAocPage = () => {
                 <Toggle value={autoSimbriefImport === 'ENABLED'} onToggle={(toggleValue) => setAutoSimbriefImport(toggleValue ? 'ENABLED' : 'DISABLED')} />
             </SettingItem>
 
-            <SettingItem name={t('Settings.AtsuAoc.ImportSimBriefPayload')}>
+            <SettingItem name={t('Settings.AtsuAoc.ImportSimBriefWeights')}>
                 <Toggle value={simbriefWeightsImport === 'ENABLED'} onToggle={(toggleValue) => setSimbriefWeightsImport(toggleValue ? 'ENABLED' : 'DISABLED')} />
             </SettingItem>
 

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AtsuAocPage.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/AtsuAocPage.tsx
@@ -25,6 +25,7 @@ export const AtsuAocPage = () => {
     const [telexEnabled, setTelexEnabled] = usePersistentProperty('CONFIG_ONLINE_FEATURES_STATUS', 'DISABLED');
 
     const [autoSimbriefImport, setAutoSimbriefImport] = usePersistentProperty('CONFIG_AUTO_SIMBRIEF_IMPORT', 'DISABLED');
+    const [simbriefWeightsImport, setSimbriefWeightsImport] = usePersistentProperty('CONFIG_SIMBRIEF_WEIGHTS_IMPORT', 'DISABLED');
 
     const [hoppieEnabled, setHoppieEnabled] = usePersistentProperty('CONFIG_HOPPIE_ENABLED', 'DISABLED');
     const [hoppieUserId, setHoppieUserId] = usePersistentProperty('CONFIG_HOPPIE_USERID');
@@ -191,6 +192,10 @@ export const AtsuAocPage = () => {
 
             <SettingItem name={t('Settings.AtsuAoc.AutomaticallyImportSimBriefData')}>
                 <Toggle value={autoSimbriefImport === 'ENABLED'} onToggle={(toggleValue) => setAutoSimbriefImport(toggleValue ? 'ENABLED' : 'DISABLED')} />
+            </SettingItem>
+
+            <SettingItem name={t('Settings.AtsuAoc.ImportSimBriefPayload')}>
+                <Toggle value={simbriefWeightsImport === 'ENABLED'} onToggle={(toggleValue) => setSimbriefWeightsImport(toggleValue ? 'ENABLED' : 'DISABLED')} />
             </SettingItem>
 
             <SettingItem name={t('Settings.AtsuAoc.ErrorReporting')}>

--- a/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/simBrief.ts
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Store/features/simBrief.ts
@@ -50,7 +50,7 @@ export interface SimbriefData {
     costInd: string;
 }
 
-export const initialState: {data: SimbriefData} = {
+export const initialState: {data: SimbriefData, payloadImported: boolean, fuelImported: boolean} = {
     data: {
         airline: '',
         flightNum: '',
@@ -119,6 +119,8 @@ export const initialState: {data: SimbriefData} = {
         loadsheet: '',
         costInd: '',
     },
+    payloadImported: false,
+    fuelImported: false,
 };
 
 export const simbriefSlice = createSlice({
@@ -127,6 +129,12 @@ export const simbriefSlice = createSlice({
     reducers: {
         setSimbriefData: (state, action: PayloadAction<SimbriefData>) => {
             state.data = action.payload;
+        },
+        setPayloadImported: (state, action: PayloadAction<boolean>) => {
+            state.payloadImported = action.payload;
+        },
+        setFuelImported: (state, action: PayloadAction<boolean>) => {
+            state.fuelImported = action.payload;
         },
     },
 });
@@ -216,6 +224,6 @@ export async function fetchSimbriefDataAction(naivgraphUsername: string, overrid
  */
 export const isSimbriefDataLoaded = (): boolean => JSON.stringify((store.getState() as RootState).simbrief) !== JSON.stringify(initialState);
 
-export const { setSimbriefData } = simbriefSlice.actions;
+export const { setSimbriefData, setPayloadImported, setFuelImported } = simbriefSlice.actions;
 
 export default simbriefSlice.reducer;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #7772
(Together with PR #8407)

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

- When SimBrief Data was imported (either manual or automatic), the Fuel & Payload Pages automatically import their Data too. Approach:
  - The Fuel and Payload Page have an useEffect to import the Data when visited (only when SimBrief Data is loaded)
  - The Import Function navigates through the Pages (Dashboard->Fuel->Payload->Dashboard)
  - Two additional Flags in the SimBrief Store prevent that Payload or Fuel are imported every time the respective Page is revisited
- Auto-Import of SimBrief Data moved from EFB.tsx to FlightWidget.tsx (to not maintain two Copies of the same Code)
- Added Setting to enable/disable that Behavior

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![flightwidget-toast](https://github.com/flybywiresim/aircraft/assets/78614902/1ff0c9fe-92f0-422f-924c-558cfdf1a537)

![settings-atsu](https://github.com/flybywiresim/aircraft/assets/78614902/347724c6-910d-4d8a-9ca1-958ed24f8e62)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
Although the originating Issue is in the GSX Context, this Feature improves Comfort for everyone (using SimBrief). Only one Click needed - if at all - to get all relevant Data imported 😃 

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Fragtality

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Test 1

1. Prepare a Flightplan on SimBrief for the FBW
2. Load into the Plane and enable the new Setting in the EFB (Settings > ATSU/AOC). Ensure that your SimBrief Account is set.
3. Navigate to the Dashboard and hit "Import SimBrief Data" => A Notification should appear (like shown in the Screenshots)
4. Navigate to the Fuel & Payload Page => Each Page should display the planned Fuel / Payload from your SimBrief FP

Test 2

1. If you don't use the (already existing) Auto-Import Setting: Please enable it
2. Poweroff the EFB
3. Power it on again => You should see the same Effects as before (Notification, Fuel & Payload Page have the planned Values)

For additional Verification you can monitor the L-Vars `A32NX_FUEL_DESIRED` and `A32NX_AIRFRAME_ZFW_DESIRED` => these should immediately Change when the SimBrief Data was imported (without leaving the Dashboard).
(If you have a Tool at Hand to monitor L-Vars quick & easy)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
