### PR TITLE
feat(A380X): broaden mfd texture for dual display, modify nlg animation

### DIFF
--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/A380_EXTERIOR.xml
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/A380_EXTERIOR.xml
@@ -19,7 +19,7 @@
             <!-- Nose Landing Gear -->
             <UseTemplate Name="ASOBO_GT_Anim">
                 <ANIM_NAME>c_gear</ANIM_NAME>
-                <ANIM_CODE>1 (A:GEAR POSITION:0, Percent over 100) - 100 *</ANIM_CODE>
+                <ANIM_CODE>(L:A32NX_GEAR_CENTER_POSITION)</ANIM_CODE>
             </UseTemplate>
 
             <!-- Nose Landing Gear Door FWD -->
@@ -451,7 +451,7 @@
             </UseTemplate>
         </Component>
 
-         <Component ID="Wingflex_Inboard_Right">
+        <Component ID="Wingflex_Inboard_Right">
             <!-- Wingflex Inboard Right  -->
             <UseTemplate Name="ASOBO_GT_Anim">
                 <ANIM_NAME>right_inboard_flex</ANIM_NAME>

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/panel/panel.cfg
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/panel/panel.cfg
@@ -15,18 +15,21 @@ Night=233,166,134
 Luminous=201,64,64
 
 [VCockpit01]
-size_mm=768,1024
-pixel_size=768,1024
-texture=$SCREEN_DU_MFDL
+size_mm=1536,1024
+pixel_size=1536,1024
+texture=$SCREEN_DU_MFD
 
-htmlgauge00=A380X/MFD/mfd.html?duID=2, 0,0,768,1024
+htmlgauge00=A380X/MFD/mfd.html?duID=2, 0,0,1536,1024
+
+# To enable both MFD screens without fms-v2 rpc sync, we map one texture across both screens,
+# and render both MFD screens within one texture/instrument
 
 [VCockpit02]
 size_mm=768,1024
 pixel_size=768,1024
 texture=$SCREEN_DU_MFDR
 
-# We don't load MFD2 for now, while waiting for fms-v2 rpc support
+# No separate MFDR, see above
 
 [VCockpit03]
 size_mm=768,1024


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
On behalf of Repsol, changes in panel.cfg and A380_EXTERIOR.XML to accompany changes in the model.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
No screenshots. 

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
Needs model

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
floridude

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
