### PR TITLE
fix(nd): adf tuning flags

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -52,6 +52,7 @@
 1. [GSX/FUEL] Refuel process now starts automatically when GSX fuel hose is connected - @Fragtality (Fragtality)
 1. [EFB] Instant refuel now allowed with GSX Fuel Sync active and reflects GSX refuel being active - @Fragtality (Fragtality)
 1. [FMS] Fixed PROG page REC MAX upper limit - @tshomas (shomas)
+1. [ND] Fixed manual/RMP tuning flags for ADFs - @tracernz (Mike)
 
 
 ## 0.11.0

--- a/fbw-common/src/systems/instruments/src/ND/shared/RadioNavInfo.tsx
+++ b/fbw-common/src/systems/instruments/src/ND/shared/RadioNavInfo.tsx
@@ -342,7 +342,7 @@ class TuningModeIndicator extends DisplayComponent<TuningModeIndicatorProps> {
     private readonly fm2NavTuningWord = Arinc429RegisterSubject.createEmpty();
 
     private readonly tuningMode = MappedSubject.create(([fm1Healthy, fm2Healthy, fm1NavTuningWord, fm2NavTuningWord]) => {
-        const bitIndex = 10 + this.props.index;
+        const bitIndex = 10 + this.props.index + (this.props.adf ? 2 : 0);
 
         if ((!fm1Healthy && !fm2Healthy) || (!fm1NavTuningWord.isNormalOperation() && !fm2NavTuningWord.isNormalOperation())) {
             return 'R';


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8441

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Take the flag bit logic from NDv1 into NDv2 to fix the regression.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://github.com/flybywiresim/aircraft/assets/9995998/f7a00da8-b778-4000-8be9-6cc5b030999f)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Switch the ADF/VOR switches to ADF. Tune ADF1 manually with VOR1 tuned automatically. Check that the M flag is visible. Repeat for ADF2.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
