### PR TITLE
fix: parseMetar to accept "=" as eom delimiter

### DIFF
--- a/fbw-common/src/systems/shared/src/parseMetar.tsx
+++ b/fbw-common/src/systems/shared/src/parseMetar.tsx
@@ -26,6 +26,7 @@ export function parseMetar(metarString: string): MetarParserType {
     const metarArray = metarString
         .trim()
         .replace(/^METAR\S*?\s/, '')
+        .replace(/=$/, '')
         // convert visibility range like `1 1/2 SM`
         .replace(/(\s)(\d)\s(\d)\/(\d)(SM)/, (all, a, b, c, d, e) => `${a + (Number(b) * Number(d) + Number(c))}/${d}${e}`)
         .split(' ');


### PR DESCRIPTION
## Summary of Changes
Some regions seem to deviate from the METAR standard and add an "=" at the end (e.g. https://www.avmet.ae/mtinfo.aspx) which broke our metar parser. 
This PR fixes this. 

## Screenshots (if necessary)
![image](https://github.com/flybywiresim/aircraft/assets/16833201/d9644305-d42e-4d94-8605-d791be688565)
![image](https://github.com/flybywiresim/aircraft/assets/16833201/315b43b8-05fc-4e91-aaea-5e8fab5eb997)

Discord username (if different from GitHub): cdr_maverick

## Testing instructions
Test if METARs are parsed correctly on the flyPad Dashboard for various ICAOs.
Good examples are WIEE or WILL - but anything from Indonesia seems to have the = at the end. 
(https://aviation.bmkg.go.id/latest/station.xml)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
