### PR TITLE
fix(fbw): delay init of fbw wasm to align with systems

### DIFF
--- a/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
@@ -74,6 +74,9 @@ bool FlyByWireInterface::update(double sampleTime) {
   // get data & inputs
   result &= readDataAndLocalVariables(sampleTime);
 
+  // get sim data
+  SimData simData = simConnectInterface.getSimData();
+
   // update performance monitoring
   result &= updatePerformanceMonitoring(sampleTime);
 
@@ -86,12 +89,11 @@ bool FlyByWireInterface::update(double sampleTime) {
   // handle initialization
   result &= handleFcuInitialization(calculatedSampleTime);
 
-  SimData simData = simConnectInterface.getSimData();
   // do not process laws in pause or slew
-  if (simConnectInterface.getSimData().slew_on) {
+  if (simData.slew_on) {
     wasInSlew = true;
     return result;
-  } else if (pauseDetected || simConnectInterface.getSimData().cameraState >= 10.0 || !idIsReady->get() || simData.simulationTime < 2) {
+  } else if (pauseDetected || simData.cameraState >= 10.0 || !idIsReady->get() || simData.simulationTime < 2) {
     return result;
   }
 
@@ -163,7 +165,7 @@ bool FlyByWireInterface::update(double sampleTime) {
   }
 
   // if default AP is on -> disconnect it
-  if (simConnectInterface.getSimData().autopilot_master_on) {
+  if (simData.autopilot_master_on) {
     simConnectInterface.sendEvent(SimConnectInterface::Events::AUTOPILOT_OFF);
   }
 

--- a/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
@@ -86,11 +86,12 @@ bool FlyByWireInterface::update(double sampleTime) {
   // handle initialization
   result &= handleFcuInitialization(calculatedSampleTime);
 
+  SimData simData = simConnectInterface.getSimData();
   // do not process laws in pause or slew
   if (simConnectInterface.getSimData().slew_on) {
     wasInSlew = true;
     return result;
-  } else if (pauseDetected || simConnectInterface.getSimData().cameraState >= 10.0) {
+  } else if (pauseDetected || simConnectInterface.getSimData().cameraState >= 10.0 || !idIsReady->get() || simData.simulationTime < 2) {
     return result;
   }
 
@@ -1354,8 +1355,8 @@ bool FlyByWireInterface::updateElac(double sampleTime, int elacIndex) {
 
       bool blueHighPressure = idHydBluePressurised->get();
 
-      bool elac2EmerPowersupplyActive = elac2EmerPowersupplyRelayOutput &&
-                                        (elac2EmerPowersupplyTimerRelayOutput || elac2EmerPowersupplyNoseWheelCondition || blueHighPressure);
+      bool elac2EmerPowersupplyActive = elac2EmerPowersupplyRelayOutput && (elac2EmerPowersupplyTimerRelayOutput ||
+                                                                            elac2EmerPowersupplyNoseWheelCondition || blueHighPressure);
 
       powerSupplyAvailable = elac2EmerPowersupplyActive ? idElecBat2HotBusPowered->get() : idElecDcBus2Powered->get();
     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR implements a delay before starting to update the fbw wasm:
* Delay until `A32NX_IS_READY` is true
* Delay until `SIMULATION TIME` is greater than 2s.

This is done to be more in line with the sytems wasm, which implements the same delay.
Previously, the fbw wasm started updating earlier than the systems wasm (particularly in air starts, as `SIMULATION TIME` does not update there until the "Ready to Fly" button is pressed), which resulted in some data generated by the systems, particularly electrical supplies, not being properly initialized when the fbw wasm starts updating. Now, the fbw wasm starts in sync with the systems wasm. This fixes two issues:
1. The FACs now are immediately powered when the fbw wasm starts to update, which gets rid of the FAC fault when starting in the air
2. The spoilers 3 and 4 now start properly retracted when spawning on the runway.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
