### PR TITLE
fix: PTU Indication on SD Doesn't Appear

### DIFF
--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Hyd/elements/HydraulicSystem.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Hyd/elements/HydraulicSystem.tsx
@@ -96,7 +96,7 @@ const ElecPump = ({ x, y, label, side, systemPressureSwitch }: ElecPumpProps) =>
             <text x={isGreen ? 21 : -35} y={10} className={`F25 ${triangleColor === 'Amber' ? 'Amber' : 'White'}`}>
                 {label}
             </text>
-            <path d={`m 0 0 l ${isGreen ? '' : '-'}13 -9 l 0 18 z`} className={`${triangleColor} ${isElecPumpActive ? `${triangleColor}Fill` : ''} SW3`} />
+            <path d={`m 0 0 l ${isGreen ? '' : '-'}13 -9 l 0 18 z`} className={`${triangleColor} ${triangleColor}Fill SW3`} />
             <path d={`m 0 0 h ${isGreen ? '-30' : '27'}`} className={`${triangleColor} SW2 ${isElecPumpActive && systemPressureSwitch ? '' : 'Hide'}`} />
             <text x={-14} y={label === 'A' ? -14 : 34} className={isOverheat ? 'Amber F19' : 'Hide'}>OVHT</text>
         </g>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

Issue 8348
Fixes #[8348]

## Summary of Changes
Fixes inconsistent behavior of the PTU indication on SD while switching pages.

## Screenshots (if necessary)
https://github.com/flybywiresim/aircraft/assets/28344793/816267e0-4397-4e02-85b0-cb064444cc45

## References

## Additional context
Discord - daddy_g_09

## Testing instructions
1. Spawn in cold and dark state
2. Turn on BAT 1&2
3. Set the page on SD to any page other than HYD
4. Turn on Yellow ELEC HYD Pump
5. Switch to HYD page on SD to verify the correct PTU indication

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
