### PR TITLE
feat(a380-elec): more accurate dc ess behavior

### DIFF
--- a/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/CdsDisplayUnit.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/CdsDisplayUnit.tsx
@@ -38,8 +38,8 @@ export enum DisplayUnitID {
 }
 
 const DisplayUnitToDCBus: { [k in DisplayUnitID]: DcElectricalBus[] } = {
-    [DisplayUnitID.CaptPfd]: [DcElectricalBus.DcEssSched],                      // powered by 409PP
-    [DisplayUnitID.CaptNd]: [DcElectricalBus.DcEssSched, DcElectricalBus.Dc1],  // powered by 415PP or 105PP
+    [DisplayUnitID.CaptPfd]: [DcElectricalBus.DcEssInFlight],                      // powered by 409PP
+    [DisplayUnitID.CaptNd]: [DcElectricalBus.DcEssInFlight, DcElectricalBus.Dc1],  // powered by 415PP or 105PP
     [DisplayUnitID.CaptMfd]: [DcElectricalBus.DcEss, DcElectricalBus.Dc1],      // powered by 423PP or 111PP
     [DisplayUnitID.FoPfd]: [DcElectricalBus.Dc2],
     [DisplayUnitID.FoNd]: [DcElectricalBus.Dc1, DcElectricalBus.Dc2],

--- a/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/CdsDisplayUnit.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/CdsDisplayUnit.tsx
@@ -38,13 +38,13 @@ export enum DisplayUnitID {
 }
 
 const DisplayUnitToDCBus: { [k in DisplayUnitID]: DcElectricalBus[] } = {
-    [DisplayUnitID.CaptPfd]: [DcElectricalBus.DcEss],
-    [DisplayUnitID.CaptNd]: [DcElectricalBus.DcEss, DcElectricalBus.Dc1],
-    [DisplayUnitID.CaptMfd]: [DcElectricalBus.DcEss, DcElectricalBus.Dc1],
+    [DisplayUnitID.CaptPfd]: [DcElectricalBus.DcEssSched],                      // powered by 409PP
+    [DisplayUnitID.CaptNd]: [DcElectricalBus.DcEssSched, DcElectricalBus.Dc1],  // powered by 415PP or 105PP
+    [DisplayUnitID.CaptMfd]: [DcElectricalBus.DcEss, DcElectricalBus.Dc1],      // powered by 423PP or 111PP
     [DisplayUnitID.FoPfd]: [DcElectricalBus.Dc2],
     [DisplayUnitID.FoNd]: [DcElectricalBus.Dc1, DcElectricalBus.Dc2],
     [DisplayUnitID.FoMfd]: [DcElectricalBus.Dc1, DcElectricalBus.Dc2],
-    [DisplayUnitID.Ewd]: [DcElectricalBus.DcEss],
+    [DisplayUnitID.Ewd]: [DcElectricalBus.DcEss],                               // powered by 423PP
     [DisplayUnitID.Sd]: [DcElectricalBus.Dc2],
 };
 

--- a/fbw-a380x/src/systems/shared/src/electrical.ts
+++ b/fbw-a380x/src/systems/shared/src/electrical.ts
@@ -2,5 +2,5 @@ export enum DcElectricalBus {
     Dc1 = 'DC_1',
     Dc2 = 'DC_2',
     DcEss = 'DC_ESS',
-    DcEssSched = '108PH',
+    DcEssInFlight = '108PH',
 }

--- a/fbw-a380x/src/systems/shared/src/electrical.ts
+++ b/fbw-a380x/src/systems/shared/src/electrical.ts
@@ -2,4 +2,5 @@ export enum DcElectricalBus {
     Dc1 = 'DC_1',
     Dc2 = 'DC_2',
     DcEss = 'DC_ESS',
+    DcEssSched = '108PH',
 }

--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
@@ -756,7 +756,7 @@ void FlyByWireInterface::setupLocalVariables() {
   idUpperRudderPosition = std::make_unique<LocalVariable>("A32NX_HYD_UPPER_RUDDER_DEFLECTION");
   idLowerRudderPosition = std::make_unique<LocalVariable>("A32NX_HYD_LOWER_RUDDER_DEFLECTION");
 
-  idElecDcEssBusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_DC_ESS_BUS_IS_POWERED");
+  idElecDcEssBusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_108PH_BUS_IS_POWERED");
   idElecDcEhaBusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_247PP_BUS_IS_POWERED");
   idElecDc1BusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_DC_1_BUS_IS_POWERED");
 

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/avionics_data_communication_network.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/avionics_data_communication_network.rs
@@ -103,19 +103,19 @@ impl A380AvionicsDataCommunicationNetwork {
         ]);
 
         let afdx_switches = [
-            (1, (ElectricalBusType::DirectCurrentEssential, None)),
+            (1, (ElectricalBusType::DirectCurrentEssential, None)), // powered by 425PP
             (2, (ElectricalBusType::DirectCurrent(2), None)),
-            (3, (ElectricalBusType::DirectCurrentEssential, None)),
+            (3, (ElectricalBusType::DirectCurrentEssential, None)), // powered by 433PP
             (4, (ElectricalBusType::DirectCurrent(2), None)),
-            (5, (ElectricalBusType::DirectCurrentEssential, None)),
+            (5, (ElectricalBusType::DirectCurrentNamed("108PH"), None)), // powered by 415PP
             (6, (ElectricalBusType::DirectCurrent(2), None)),
             (7, (ElectricalBusType::DirectCurrent(2), None)),
-            (9, (ElectricalBusType::DirectCurrentEssential, None)),
+            (9, (ElectricalBusType::DirectCurrentEssential, None)), // powered by 433PP
             (
                 11,
                 (
                     ElectricalBusType::DirectCurrent(1),
-                    Some(ElectricalBusType::DirectCurrentEssential),
+                    Some(ElectricalBusType::DirectCurrentNamed("108PH")), // powered by 417PP
                 ),
             ),
             (12, (ElectricalBusType::DirectCurrent(1), None)),
@@ -123,7 +123,7 @@ impl A380AvionicsDataCommunicationNetwork {
                 13,
                 (
                     ElectricalBusType::DirectCurrent(1),
-                    Some(ElectricalBusType::DirectCurrentEssential),
+                    Some(ElectricalBusType::DirectCurrentNamed("108PH")), // powered by 417PP
                 ),
             ),
             (14, (ElectricalBusType::DirectCurrent(1), None)),
@@ -131,7 +131,7 @@ impl A380AvionicsDataCommunicationNetwork {
                 15,
                 (
                     ElectricalBusType::DirectCurrent(1),
-                    Some(ElectricalBusType::DirectCurrentEssential),
+                    Some(ElectricalBusType::DirectCurrentNamed("108PH")), // powered by 417PP
                 ),
             ),
             (16, (ElectricalBusType::DirectCurrent(1), None)),
@@ -140,7 +140,7 @@ impl A380AvionicsDataCommunicationNetwork {
                 19,
                 (
                     ElectricalBusType::DirectCurrent(1),
-                    Some(ElectricalBusType::DirectCurrentEssential),
+                    Some(ElectricalBusType::DirectCurrentNamed("108PH")), // powered by 417PP
                 ),
             ),
         ]
@@ -165,13 +165,13 @@ impl A380AvionicsDataCommunicationNetwork {
 
         let io_modules = FxHashMap::from_iter(
             [
-                ("A1", 1, ElectricalBusType::DirectCurrentEssential),
+                ("A1", 1, ElectricalBusType::DirectCurrentEssential), // powered by 425PP
                 ("A2", 2, ElectricalBusType::DirectCurrent(2)),
-                ("A3", 1, ElectricalBusType::DirectCurrentEssential),
+                ("A3", 1, ElectricalBusType::DirectCurrentEssential), // powered by 425PP
                 ("A4", 2, ElectricalBusType::DirectCurrent(2)),
-                ("A5", 3, ElectricalBusType::DirectCurrentEssential),
+                ("A5", 3, ElectricalBusType::DirectCurrentEssential), // powered by 433PP
                 ("A6", 4, ElectricalBusType::DirectCurrent(2)),
-                ("A7", 3, ElectricalBusType::DirectCurrentEssential),
+                ("A7", 3, ElectricalBusType::DirectCurrentEssential), // powered by 433PP
                 ("A8", 4, ElectricalBusType::DirectCurrent(2)),
             ]
             .map(|(name, connected_switch, power_supply)| {
@@ -192,22 +192,22 @@ impl A380AvionicsDataCommunicationNetwork {
         let cpio_modules = FxHashMap::from_iter(
             [
                 ("A1", 7, ElectricalBusType::DirectCurrent(1)),
-                ("A2", 5, ElectricalBusType::DirectCurrentEssential),
-                ("A3", 5, ElectricalBusType::DirectCurrentEssential),
+                ("A2", 5, ElectricalBusType::DirectCurrentNamed("108PH")), // powered by 419PP
+                ("A3", 5, ElectricalBusType::DirectCurrentNamed("108PH")), // powered by 415PP
                 ("A4", 6, ElectricalBusType::DirectCurrent(2)),
                 ("B1", 7, ElectricalBusType::DirectCurrent(1)),
-                ("B2", 5, ElectricalBusType::DirectCurrentEssential),
-                ("B3", 5, ElectricalBusType::DirectCurrentEssential),
+                ("B2", 5, ElectricalBusType::DirectCurrentNamed("108PH")), // powered by 419PP
+                ("B3", 5, ElectricalBusType::DirectCurrentNamed("108PH")), // powered by 417PP
                 ("B4", 6, ElectricalBusType::DirectCurrent(2)),
-                ("C1", 3, ElectricalBusType::DirectCurrentEssential),
+                ("C1", 3, ElectricalBusType::DirectCurrentEssential), // powered by 433PP
                 ("C2", 4, ElectricalBusType::DirectCurrent(2)),
                 ("D1", 3, ElectricalBusType::DirectCurrent(1)),
                 ("D3", 3, ElectricalBusType::DirectCurrent(1)),
                 ("E1", 5, ElectricalBusType::DirectCurrent(1)),
                 ("E2", 6, ElectricalBusType::DirectCurrent(2)),
-                ("F1", 5, ElectricalBusType::DirectCurrentEssential),
+                ("F1", 5, ElectricalBusType::DirectCurrentNamed("108PH")), // powered by 419PP
                 ("F2", 6, ElectricalBusType::DirectCurrentGndFltService),
-                ("F3", 5, ElectricalBusType::DirectCurrentEssential),
+                ("F3", 5, ElectricalBusType::DirectCurrentNamed("108PH")), // powered by 419PP
                 ("F4", 6, ElectricalBusType::DirectCurrentGndFltService),
                 ("G1", 7, ElectricalBusType::DirectCurrent(1)),
                 ("G2", 6, ElectricalBusType::DirectCurrent(2)),

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/avionics_data_communication_network.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/avionics_data_communication_network.rs
@@ -576,6 +576,7 @@ mod tests {
         dc_1_bus: ElectricalBus,
         dc_2_bus: ElectricalBus,
         dc_ess_bus: ElectricalBus,
+        dc_ess_in_flight_bus: ElectricalBus,
         is_elec_powered: bool,
     }
     impl AdcnTestAircraft {
@@ -589,6 +590,10 @@ mod tests {
                 dc_1_bus: ElectricalBus::new(context, ElectricalBusType::DirectCurrent(1)),
                 dc_2_bus: ElectricalBus::new(context, ElectricalBusType::DirectCurrent(2)),
                 dc_ess_bus: ElectricalBus::new(context, ElectricalBusType::DirectCurrentEssential),
+                dc_ess_in_flight_bus: ElectricalBus::new(
+                    context,
+                    ElectricalBusType::DirectCurrentNamed("108PH"),
+                ),
                 is_elec_powered: false,
             }
         }
@@ -639,6 +644,7 @@ mod tests {
                 electricity.flow(&self.powered_source_dc, &self.dc_1_bus);
                 electricity.flow(&self.powered_source_dc, &self.dc_2_bus);
                 electricity.flow(&self.powered_source_dc, &self.dc_ess_bus);
+                electricity.flow(&self.powered_source_dc, &self.dc_ess_in_flight_bus);
             }
         }
 

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/direct_current.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/direct_current.rs
@@ -322,7 +322,7 @@ impl A380DirectCurrentElectrical {
             .update(context, ess_in_flight_sply1);
         self.ess_in_flight_contactor.close_when(
             electricity.is_powered(&self.dc_ess_bus)
-                && (self.ess_in_flight_contactor.is_closed() && bus_ctrl
+                && (self.ess_in_flight_contactor.is_closed() && !bus_ctrl
                     || self.ess_in_flight_sply2.output()
                     || emer_config
                     || ac_state.ac_ess_bus_powered(electricity)),

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/direct_current.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/direct_current.rs
@@ -2,9 +2,10 @@ use super::{
     A380AlternatingCurrentElectricalSystem, A380DirectCurrentElectricalSystem,
     A380ElectricalOverheadPanel,
 };
+use std::time::Duration;
 use systems::accept_iterable;
 use systems::electrical::{BatteryChargeRectifierUnit, BatteryPushButtons, EmergencyElectrical};
-use systems::shared::RamAirTurbineController;
+use systems::shared::{DelayedFalseLogicGate, RamAirTurbineController};
 use systems::simulation::{InitContext, UpdateContext};
 use systems::{
     electrical::{Battery, Contactor, ElectricalBus, Electricity, StaticInverter},
@@ -50,6 +51,10 @@ pub(super) struct A380DirectCurrentElectrical {
     dc_gnd_flt_service_bus: ElectricalBus,
     tr_2_to_dc_gnd_flt_service_bus_contactor: Contactor,
     dc_bus_2_to_dc_gnd_flt_service_bus_contactor: Contactor,
+
+    ess_in_flight_sply2: DelayedFalseLogicGate,
+    ess_in_flight_contactor: Contactor,
+    dc_ess_subbus: ElectricalBus,
 }
 impl A380DirectCurrentElectrical {
     pub fn new(context: &mut InitContext) -> Self {
@@ -117,6 +122,13 @@ impl A380DirectCurrentElectrical {
             ),
             tr_2_to_dc_gnd_flt_service_bus_contactor: Contactor::new(context, "990PX"),
             dc_bus_2_to_dc_gnd_flt_service_bus_contactor: Contactor::new(context, "970PN"),
+
+            ess_in_flight_sply2: DelayedFalseLogicGate::new(Duration::from_secs(10)),
+            ess_in_flight_contactor: Contactor::new(context, "10PH"),
+            dc_ess_subbus: ElectricalBus::new(
+                context,
+                ElectricalBusType::DirectCurrentNamed("108PH"),
+            ),
         }
     }
 
@@ -293,6 +305,31 @@ impl A380DirectCurrentElectrical {
             &self.dc_bus_2_to_dc_gnd_flt_service_bus_contactor,
             &self.dc_gnd_flt_service_bus,
         );
+    }
+
+    pub(super) fn update_subbuses(
+        &mut self,
+        context: &UpdateContext,
+        electricity: &mut Electricity,
+        ac_state: &impl A380AlternatingCurrentElectricalSystem,
+        flt_condition: bool,
+        emer_config: bool,
+    ) {
+        // 15XH - 493XPA BUS CTL
+        let bus_ctrl = self.static_inverter_contactor.is_closed() && !flt_condition;
+        let ess_in_flight_sply1 = ac_state.any_non_essential_bus_powered(electricity);
+        self.ess_in_flight_sply2
+            .update(context, ess_in_flight_sply1);
+        self.ess_in_flight_contactor.close_when(
+            electricity.is_powered(&self.dc_ess_bus)
+                && (self.ess_in_flight_contactor.is_closed() && bus_ctrl
+                    || self.ess_in_flight_sply2.output()
+                    || emer_config
+                    || ac_state.ac_ess_bus_powered(electricity)),
+        );
+        electricity.flow(&self.dc_ess_bus, &self.ess_in_flight_contactor);
+        // 108PH is powered by 111PH which is powered by DC ESS through the ESS IN FLIGHT contactor
+        electricity.flow(&self.ess_in_flight_contactor, &self.dc_ess_subbus);
     }
 
     #[cfg(test)]

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/direct_current.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/direct_current.rs
@@ -440,6 +440,9 @@ impl SimulationElement for A380DirectCurrentElectrical {
         self.dc_bus_2_to_dc_gnd_flt_service_bus_contactor
             .accept(visitor);
 
+        self.ess_in_flight_contactor.accept(visitor);
+        self.dc_ess_subbus.accept(visitor);
+
         visitor.visit(self);
     }
 }

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/electrical/mod.rs
@@ -1827,9 +1827,8 @@ mod a380_electrical_circuit_tests {
     }
 
     /// # Source
-    /// A380 FCOM
-    /*
-    TODO: check what actually happens in this configuration. The FCOM is contradicting itself.
+    /// A380 FCOM. The configuration shown in the FCOM for this case is wrong.
+    /// The test is checking for the correct behavior.
     #[test]
     fn distribution_one_gen_off_on_each_side_with_apu() {
         let test_bed = test_bed_with()
@@ -1848,7 +1847,7 @@ mod a380_electrical_circuit_tests {
             .is_single(PotentialOrigin::EngineGenerator(2)));
         assert!(test_bed
             .ac_bus_output(3)
-            .is_single(PotentialOrigin::EngineGenerator(4)));
+            .is_single(PotentialOrigin::ApuGenerator(1)));
         assert!(test_bed
             .ac_bus_output(4)
             .is_single(PotentialOrigin::EngineGenerator(4)));
@@ -1860,7 +1859,7 @@ mod a380_electrical_circuit_tests {
             .is_single(PotentialOrigin::ApuGenerator(1)));
         assert!(test_bed
             .ac_eha_bus_output()
-            .is_single(PotentialOrigin::EngineGenerator(4)));
+            .is_single(PotentialOrigin::ApuGenerator(1)));
         assert!(test_bed.static_inverter_input().is_unpowered());
         assert!(test_bed.ac_gnd_flt_service_bus_output().is_unpowered());
         assert!(test_bed
@@ -1868,7 +1867,7 @@ mod a380_electrical_circuit_tests {
             .is_single(PotentialOrigin::EngineGenerator(2)));
         assert!(test_bed
             .tr_2_input()
-            .is_single(PotentialOrigin::EngineGenerator(4)));
+            .is_single(PotentialOrigin::ApuGenerator(1)));
         assert!(test_bed
             .tr_ess_input()
             .is_single(PotentialOrigin::ApuGenerator(1)));
@@ -1887,7 +1886,8 @@ mod a380_electrical_circuit_tests {
         assert!(test_bed
             .dc_eha_bus_output()
             .is_single(PotentialOrigin::TransformerRectifier(2)));
-        assert!(test_bed.dc_apu_bus_output()
+        assert!(test_bed
+            .dc_apu_bus_output()
             .is_single(PotentialOrigin::TransformerRectifier(4)));
         assert!(test_bed
             .hot_bus_output(1)
@@ -1904,7 +1904,7 @@ mod a380_electrical_circuit_tests {
         assert!(test_bed
             .dc_gnd_flt_service_bus_output()
             .is_single(PotentialOrigin::TransformerRectifier(2)));
-    }*/
+    }
 
     /// # Source
     /// A380 FCOM


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
