### PR TITLE
fix(A380X): Show 3D Throttles at 0 when IDLE

### DIFF
--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
@@ -267,7 +267,7 @@ void FlyByWireInterface::loadConfiguration() {
   // create mapping for 3D animation position
   std::vector<std::pair<double, double>> mappingTable3d;
   mappingTable3d.emplace_back(-20.0, 0.0);
-  mappingTable3d.emplace_back(0.0, 25.0);
+  mappingTable3d.emplace_back(0.0, 0.0);
   mappingTable3d.emplace_back(25.0, 50.0);
   mappingTable3d.emplace_back(35.0, 75.0);
   mappingTable3d.emplace_back(45.0, 100.0);


### PR DESCRIPTION
## Summary of Changes
Fixes an issue where the 3d throttle were above 0 when in IDLE for the A380X.

With this change it is no longer visible on the levers that reversers are activated as the levers stay at 0 in the A380X. It is still visible in the EWD though - showing REV.

The reverser levers are not yet modelled in the XML (the 3d model has them). Once these are modelled then putting thrust to reverse will move these levers. 

Discord username (if different from GitHub): cdr_maverick

## Testing instructions
Check if the throttle levers work as before. Other than that IDLE is at 0 now there should be no other changes or effects. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
