### PR TITLE
fix: Removed debug output from Pushback code

### DIFF
--- a/fbw-common/src/wasm/extra-backend/Pushback/Pushback.cpp
+++ b/fbw-common/src/wasm/extra-backend/Pushback/Pushback.cpp
@@ -139,7 +139,6 @@ bool Pushback::update(sGaugeDrawData* pData) {
       parkingBrakeEngaged ? (aircraftTurnSpeedFactor->get() / aircraftParkingBrakeFactor->get()) : aircraftTurnSpeedFactor->get();
   const FLOAT64 computedRotationVelocity = turnDampener.updateSpeed(
       (inertiaSpeed / aircraftSpeedFactor->get()) * tugCommandedHeadingFactor->get() * turnSpeedHdgFactor);
-  std::cout << "computedRotationVelocity: " << computedRotationVelocity << std::endl;
 
   // The heading of the tug is calculated based on the aircraft heading and the user input (0.0-1.0).
   const FLOAT64 computedTugHdg =
@@ -201,6 +200,6 @@ bool Pushback::postUpdate([[maybe_unused]] sGaugeDrawData* pData) {
 
 bool Pushback::shutdown() {
   _isInitialized = false;
-  std::cout << "Pushback::shutdown()" << std::endl;
+  LOG_INFO("Pushback::shutdown()");
   return true;
 }


### PR DESCRIPTION
## Summary of Changes
Removed debug output accidentally left in.

Discord username (if different from GitHub): cdr_maverick

## Testing instructions
not required

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
