### PR TITLE
fix(GSX): Fix GSX Integration not disabling the a/c provided cones 

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -73,7 +73,7 @@
 1. [FCU] Fix the QFE indicator not illuminating - @BenJuan26 (BenJuan26)
 1. [FCU] Disabled QFE mode - @tracernz (Mike)
 1. [FUEL] Lowered starting fuel on C/D spawn, will only load last saved fuel on C/D spawn, center tank refuel now happens simultaneous with wing refuel - @Maximilian-Reuter
-1. [GSX] Fix GSX Integration not disabling wheel chocks and cones
+1. [GSX] Fix GSX Integration not disabling the a/c provided cones
 
 ## 0.11.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -73,6 +73,7 @@
 1. [FCU] Fix the QFE indicator not illuminating - @BenJuan26 (BenJuan26)
 1. [FCU] Disabled QFE mode - @tracernz (Mike)
 1. [FUEL] Lowered starting fuel on C/D spawn, will only load last saved fuel on C/D spawn, center tank refuel now happens simultaneous with wing refuel - @Maximilian-Reuter
+1. [GSX] Fix GSX Integration not disabling wheel chocks and cones
 
 ## 0.11.0
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO.xml
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO.xml
@@ -500,15 +500,15 @@
             <!-- GND CHOCKS -->
             <UseTemplate Name="FBW_Gnd_Equipment">
                 <NODE_ID>CHOCKS_NOSE_GEAR</NODE_ID>
-                <GND_ENABLE_OVRD>(L:A32NX_MODEL_WHEELCHOCKS_ENABLED) (L:A32NX_GSX_PAYLOAD_SYNC_ENABLED) ! &&</GND_ENABLE_OVRD>
+                <GND_ENABLE_OVRD>(L:A32NX_MODEL_WHEELCHOCKS_ENABLED)</GND_ENABLE_OVRD>
             </UseTemplate>
             <UseTemplate Name="FBW_Gnd_Equipment">
                 <NODE_ID>CHOCKS_MAIN_GEAR_RIGHT</NODE_ID>
-                <GND_ENABLE_OVRD>(L:A32NX_MODEL_WHEELCHOCKS_ENABLED) (L:A32NX_GSX_PAYLOAD_SYNC_ENABLED) ! &&</GND_ENABLE_OVRD>
+                <GND_ENABLE_OVRD>(L:A32NX_MODEL_WHEELCHOCKS_ENABLED)</GND_ENABLE_OVRD>
             </UseTemplate>
             <UseTemplate Name="FBW_Gnd_Equipment">
                 <NODE_ID>CHOCKS_MAIN_GEAR_LEFT</NODE_ID>
-                <GND_ENABLE_OVRD>(L:A32NX_MODEL_WHEELCHOCKS_ENABLED) (L:A32NX_GSX_PAYLOAD_SYNC_ENABLED) ! &&</GND_ENABLE_OVRD>
+                <GND_ENABLE_OVRD>(L:A32NX_MODEL_WHEELCHOCKS_ENABLED)</GND_ENABLE_OVRD>
             </UseTemplate>
 
             <!-- GND CONES -->

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO.xml
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO.xml
@@ -500,37 +500,37 @@
             <!-- GND CHOCKS -->
             <UseTemplate Name="FBW_Gnd_Equipment">
                 <NODE_ID>CHOCKS_NOSE_GEAR</NODE_ID>
-                <GND_ENABLE_OVRD>(L:A32NX_MODEL_WHEELCHOCKS_ENABLED)</GND_ENABLE_OVRD>
+                <GND_ENABLE_OVRD>(L:A32NX_MODEL_WHEELCHOCKS_ENABLED) (L:A32NX_GSX_PAYLOAD_SYNC_ENABLED) ! &&</GND_ENABLE_OVRD>
             </UseTemplate>
             <UseTemplate Name="FBW_Gnd_Equipment">
                 <NODE_ID>CHOCKS_MAIN_GEAR_RIGHT</NODE_ID>
-                <GND_ENABLE_OVRD>(L:A32NX_MODEL_WHEELCHOCKS_ENABLED)</GND_ENABLE_OVRD>
+                <GND_ENABLE_OVRD>(L:A32NX_MODEL_WHEELCHOCKS_ENABLED) (L:A32NX_GSX_PAYLOAD_SYNC_ENABLED) ! &&</GND_ENABLE_OVRD>
             </UseTemplate>
             <UseTemplate Name="FBW_Gnd_Equipment">
                 <NODE_ID>CHOCKS_MAIN_GEAR_LEFT</NODE_ID>
-                <GND_ENABLE_OVRD>(L:A32NX_MODEL_WHEELCHOCKS_ENABLED)</GND_ENABLE_OVRD>
+                <GND_ENABLE_OVRD>(L:A32NX_MODEL_WHEELCHOCKS_ENABLED) (L:A32NX_GSX_PAYLOAD_SYNC_ENABLED) ! &&</GND_ENABLE_OVRD>
             </UseTemplate>
 
             <!-- GND CONES -->
             <UseTemplate Name="FBW_Gnd_Equipment">
                 <NODE_ID>CONE_B</NODE_ID>
-                <GND_ENABLE_OVRD>(L:A32NX_MODEL_CONES_ENABLED) (L:A32NX_IS_STATIONARY, bool) and</GND_ENABLE_OVRD>
+                <GND_ENABLE_OVRD>(L:A32NX_MODEL_CONES_ENABLED) (L:A32NX_IS_STATIONARY, bool) && (L:A32NX_GSX_PAYLOAD_SYNC_ENABLED) ! &&</GND_ENABLE_OVRD>
             </UseTemplate>
             <UseTemplate Name="FBW_Gnd_Equipment">
                 <NODE_ID>CONE_R</NODE_ID>
-                <GND_ENABLE_OVRD>(L:A32NX_MODEL_CONES_ENABLED) (L:A32NX_IS_STATIONARY, bool) and</GND_ENABLE_OVRD>
+                <GND_ENABLE_OVRD>(L:A32NX_MODEL_CONES_ENABLED) (L:A32NX_IS_STATIONARY, bool) && (L:A32NX_GSX_PAYLOAD_SYNC_ENABLED) ! &&</GND_ENABLE_OVRD>
             </UseTemplate>
             <UseTemplate Name="FBW_Gnd_Equipment">
                 <NODE_ID>CONE_L</NODE_ID>
-                <GND_ENABLE_OVRD>(L:A32NX_MODEL_CONES_ENABLED) (L:A32NX_IS_STATIONARY, bool) and</GND_ENABLE_OVRD>
+                <GND_ENABLE_OVRD>(L:A32NX_MODEL_CONES_ENABLED) (L:A32NX_IS_STATIONARY, bool) && (L:A32NX_GSX_PAYLOAD_SYNC_ENABLED) ! &&</GND_ENABLE_OVRD>
             </UseTemplate>
             <UseTemplate Name="FBW_Gnd_Equipment">
                 <NODE_ID>CONE_ENG_L</NODE_ID>
-                <GND_ENABLE_OVRD>(L:A32NX_MODEL_CONES_ENABLED) (L:A32NX_IS_STATIONARY, bool) and</GND_ENABLE_OVRD>
+                <GND_ENABLE_OVRD>(L:A32NX_MODEL_CONES_ENABLED) (L:A32NX_IS_STATIONARY, bool) && (L:A32NX_GSX_PAYLOAD_SYNC_ENABLED) ! &&</GND_ENABLE_OVRD>
             </UseTemplate>
             <UseTemplate Name="FBW_Gnd_Equipment">
                 <NODE_ID>CONE_ENG_R</NODE_ID>
-                <GND_ENABLE_OVRD>(L:A32NX_MODEL_CONES_ENABLED) (L:A32NX_IS_STATIONARY, bool) and</GND_ENABLE_OVRD>
+                <GND_ENABLE_OVRD>(L:A32NX_MODEL_CONES_ENABLED) (L:A32NX_IS_STATIONARY, bool) && (L:A32NX_GSX_PAYLOAD_SYNC_ENABLED) ! &&</GND_ENABLE_OVRD>
             </UseTemplate>
 
             <!-- Utility function for creating the A32NX_IS_STATIONARY and A32NX_GND_EQP_IS_VISIBLE L-vars. -->

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
@@ -169,17 +169,12 @@ export const SimOptionsPage = () => {
                     </SettingItem>
 
                     <SettingItem name={t('Settings.SimOptions.WheelChocksEnabled')}>
-                        {gsxPayloadSyncEnabled === 0 && (
-                            <Toggle
-                                value={wheelChocksEnabled === 1}
-                                onToggle={(value) => {
-                                    setWheelChocksEnabled(value ? 1 : 0);
-                                }}
-                            />
-                        )}
-                        {gsxPayloadSyncEnabled === 1 && (
-                            t('Ground.Payload.GSXPayloadSyncEnabled')
-                        )}
+                        <Toggle
+                            value={wheelChocksEnabled === 1}
+                            onToggle={(value) => {
+                                setWheelChocksEnabled(value ? 1 : 0);
+                            }}
+                        />
                     </SettingItem>
 
                     <SettingItem name={t('Settings.SimOptions.ConesEnabled')}>

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
@@ -194,8 +194,8 @@ export const SimOptionsPage = () => {
                     <SettingItem name={t('Settings.SimOptions.ThrottleDetents')}>
                         <button
                             type="button"
-                            className="border-theme-highlight bg-theme-highlight text-theme-body hover:bg-theme-body hover:text-theme-highlight
-                                       rounded-md border-2 px-5 py-2.5 transition duration-100"
+                            className="rounded-md border-2 border-theme-highlight bg-theme-highlight px-5
+                                       py-2.5 text-theme-body transition duration-100 hover:bg-theme-body hover:text-theme-highlight"
                             onClick={() => setShowThrottleSettings(true)}
                         >
                             {t('Settings.SimOptions.Calibrate')}

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
@@ -29,6 +29,7 @@ export const SimOptionsPage = () => {
     const [, setRadioReceiverUsageSimVar] = useSimVar('L:A32NX_RADIO_RECEIVER_USAGE_ENABLED', 'number', 0);
     const [wheelChocksEnabled, setWheelChocksEnabled] = usePersistentNumberProperty('MODEL_WHEELCHOCKS_ENABLED', 1);
     const [conesEnabled, setConesEnabled] = usePersistentNumberProperty('MODEL_CONES_ENABLED', 1);
+    const [gsxPayloadSyncEnabled] = usePersistentNumberProperty('GSX_PAYLOAD_SYNC', 0);
 
     const defaultBaroButtons: ButtonType[] = [
         { name: t('Settings.SimOptions.Auto'), setting: 'AUTO' },
@@ -168,28 +169,38 @@ export const SimOptionsPage = () => {
                     </SettingItem>
 
                     <SettingItem name={t('Settings.SimOptions.WheelChocksEnabled')}>
-                        <Toggle
-                            value={wheelChocksEnabled === 1}
-                            onToggle={(value) => {
-                                setWheelChocksEnabled(value ? 1 : 0);
-                            }}
-                        />
+                        {gsxPayloadSyncEnabled === 0 && (
+                            <Toggle
+                                value={wheelChocksEnabled === 1}
+                                onToggle={(value) => {
+                                    setWheelChocksEnabled(value ? 1 : 0);
+                                }}
+                            />
+                        )}
+                        {gsxPayloadSyncEnabled === 1 && (
+                            t('Ground.Payload.GSXPayloadSyncEnabled')
+                        )}
                     </SettingItem>
 
                     <SettingItem name={t('Settings.SimOptions.ConesEnabled')}>
-                        <Toggle
-                            value={conesEnabled === 1}
-                            onToggle={(value) => {
-                                setConesEnabled(value ? 1 : 0);
-                            }}
-                        />
+                        {gsxPayloadSyncEnabled === 0 && (
+                            <Toggle
+                                value={conesEnabled === 1}
+                                onToggle={(value) => {
+                                    setConesEnabled(value ? 1 : 0);
+                                }}
+                            />
+                        )}
+                        {gsxPayloadSyncEnabled === 1 && (
+                            t('Ground.Payload.GSXPayloadSyncEnabled')
+                        )}
                     </SettingItem>
 
                     <SettingItem name={t('Settings.SimOptions.ThrottleDetents')}>
                         <button
                             type="button"
-                            className="rounded-md border-2 border-theme-highlight bg-theme-highlight px-5
-                                       py-2.5 text-theme-body transition duration-100 hover:bg-theme-body hover:text-theme-highlight"
+                            className="border-theme-highlight bg-theme-highlight text-theme-body hover:bg-theme-body hover:text-theme-highlight
+                                       rounded-md border-2 px-5 py-2.5 transition duration-100"
                             onClick={() => setShowThrottleSettings(true)}
                         >
                             {t('Settings.SimOptions.Calibrate')}


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8241

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

GSX has the ability to show its own cones if enabled by the aircraft configuration. Currently in the A320 GSX config this feature isn't enabled (unknown why). The A380 GSX Config has this enabled. 

This PR fixes the GSX Integration not disabling the aircraft(s) cones and also allowing the aircraft cones from being toggled in the EFB. If the integration is disabled, based on previous user setting, the cones will re-enable (or stay off). 

Note for localization: This is reusing the string from the payload page, so new strings are not required. 

A380 Note: Due to lack of the XML for the cones, there is no change to be done there. A new PR will be required once those are added. 

**Thoughts**: ~~Do we want to listen for the GSX cones Lvars to toggle this setting on/off instead of relying on the user enabling the GSX integration?~~ (EDIT: GSX does not currently have Lvars for the cones - automatic on/off not possible 😦 )
~~In addition, do we want to perhaps force the GSX cones state on via the EFB GSX integration (so payload will also turn on the aircraft configuration for cones)?~~ (EDIT: We can do that via the default configuration - addition not needed) 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![FlightSimulator_NNA4QL6pzb](https://github.com/flybywiresim/aircraft/assets/98479040/dd106e35-2692-4c11-8213-cd20726d42be)

https://github.com/flybywiresim/aircraft/assets/98479040/48831317-a257-4063-956f-99e8962d9c51


## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

**Requires GSX**
1. Spawn on a gate 
2. Ensure GSX custom cones are disabled (via GSX Aircraft Settings)
3. Disable the GSX Payload integration from EFB Settings > 3rd Party
4. Ensure you can enable/disable the cones via EFB Settings 
5. Enable the GSX Payload integration 
6. Check you do not see a switch on cones setting
7. [Optionally] Confirm via Behaviors tool that `A32NX_GSX_PAYLOAD_SYNC_ENABLED` is 1.0. Cones  `A32NX_MODEL_CONES_ENABLED` ) should be 0.0. 
8. Enable GSX custom cones (via GSX Aircraft Settings)
9. Repeat steps 3 to 7, ensure the aircraft cones visually disappear when the GSX integration is enabled and only GSX cones are visible

**Does not require GSX**
- Check for any issues with the GSX Integration being disabled and check if the cones can be toggled on/off. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
