### PR TITLE
fix(lights): Landing Light movement now only possible with power + position LVAR

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -74,6 +74,7 @@
 1. [FUEL] Lowered starting fuel on C/D spawn, will only load last saved fuel on C/D spawn, center tank refuel now happens simultaneous with wing refuel - @Maximilian-Reuter
 1. [EFB/SIMBRIEF] Option to import SimBrief Fuel & Payload when SimBrief Data is imported - @Fragtality (Fragtality) + @Maximilian-Reuter
 1. [FLIGHTMODEL] Fixes some crosswind issues - @donstim (donbikes)
+1. [LIGHTS] Movement of landing lights now requires power and position is output into LVAR -  @Maximilian-Reuter
 
 ## 0.11.0
 

--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -1255,6 +1255,13 @@
       | 13    | Ten                       |
       | 14    | Five                      |
 
+- A32NX_LANDING_{ID}_POSITION
+    - Percent
+    - Current position of the landing light animation
+    - {ID}
+        - 2 | LEFT
+        - 3 | RIGHT
+
 ## Model/XML Interface
 
 These variables are the interface between the 3D model and the systems/code.

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO.xml
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO.xml
@@ -54,18 +54,24 @@
         <Include ModelBehaviorFile="Asobo\Generic\FX.xml"/>
         <Include Path="A32NX\generated\A32NX_Exterior.xml"/>
         <Component ID="LIGHTING">
-            <UseTemplate Name="ASOBO_LIGHTING_Exterior_Retractable_Light_Template">
-                <LIGHT_TYPE>LANDING</LIGHT_TYPE>
-                <ID>2</ID>
-                <ANIM_NAME>l_opening_landing_light</ANIM_NAME>
-                <ANIM_LAG>12</ANIM_LAG>
-            </UseTemplate>
-            <UseTemplate Name="ASOBO_LIGHTING_Exterior_Retractable_Light_Template">
-                <LIGHT_TYPE>LANDING</LIGHT_TYPE>
-                <ID>3</ID>
-                <ANIM_NAME>r_opening_landing_light</ANIM_NAME>
-                <ANIM_LAG>12</ANIM_LAG>
-            </UseTemplate>
+            <Component ID="LANDING_LIGHT_LEFT">
+                <UseTemplate Name="FBW_LIGHTING_Exterior_Retractable_Light_Template">
+                    <LIGHT_TYPE>LANDING</LIGHT_TYPE>
+                    <ID>2</ID>
+                    <ANIM_NAME>l_opening_landing_light</ANIM_NAME>
+                    <ANIM_LAG>12</ANIM_LAG>
+                    <FAILURE>(L:A32NX_ELEC_AC_1_BUS_IS_POWERED)</FAILURE>
+                </UseTemplate>
+            </Component>
+            <Component ID="LANDING_LIGHT_RIGHT">
+                <UseTemplate Name="FBW_LIGHTING_Exterior_Retractable_Light_Template">
+                    <LIGHT_TYPE>LANDING</LIGHT_TYPE>
+                    <ID>3</ID>
+                    <ANIM_NAME>r_opening_landing_light</ANIM_NAME>
+                    <ANIM_LAG>12</ANIM_LAG>
+                    <FAILURE>(L:A32NX_ELEC_AC_2_BUS_IS_POWERED)</FAILURE>
+                </UseTemplate>
+            </Component>
         </Component>
         <Component ID="HANDLING">
             <UseTemplate Name="FBW_HANDLING_Elevator_Template">

--- a/fbw-a32nx/src/behavior/src/A32NX_Exterior.xml
+++ b/fbw-a32nx/src/behavior/src/A32NX_Exterior.xml
@@ -2,6 +2,35 @@
 <!-- SPDX-License-Identifier: GPL-3.0 -->
 
 <ModelBehaviors>
+    <Template Name="FBW_LIGHTING_Exterior_Retractable_Light_Template">
+        <DefaultTemplateParameters>
+            <ANIM_NAME>LIGHTING_Retractable_#LIGHT_TYPE#_Light_#ID#</ANIM_NAME>
+            <ANIM_LAG>100</ANIM_LAG>
+            <ANIM_FRAMES>100</ANIM_FRAMES>
+        </DefaultTemplateParameters>
+        <UseTemplate Name="ASOBO_GT_Anim_Code">
+            <ANIM_CODE type="rnp" return="number" >
+                alias currentPosition = (O:AnimCode, number);
+                alias publishedPosition = (L:A32NX_#LIGHT_TYPE#_#ID#_POSITION, number);
+                let animSpeed = #ANIM_FRAMES, number# / #ANIM_LAG, number#;
+                let animProgress = animSpeed * (A:ANIMATION DELTA TIME, seconds);
+                let requestedPosition = if (L:#LIGHT_TYPE#_#ID#_Retracted, boolean) {0} else {100};
+
+                if currentPosition != requestedPosition {
+                    let newPosition = 0;
+                    if requestedPosition > 0 {
+                       newPosition = (currentPosition + animProgress).min(requestedPosition);
+                    } else {
+                       newPosition = (currentPosition - animProgress).max(requestedPosition);
+                    }
+                    publishedPosition = newPosition;
+                } else {
+                    publishedPosition = currentPosition;
+                }
+                publishedPosition
+            </ANIM_CODE>
+        </UseTemplate>
+    </Template>
     <Template Name="A32NX_ENGINE_Turbine_Template">
         <DefaultTemplateParameters>
             <ID>1</ID>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

This fixes the landing lights being able to retract or extend without any AC power. Now they need AC power to move and should that power be lost during movement, they will stop in position and only continue moving once power is restored.

Additionally I also created a LVAR for the current position of the landing lights since it can now be anywhere between 0 and 100 percent extended.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):\_chaoz_

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Start C/D
2. move either Landing light switch into the OFF position
3. Check externally that no movement has occured
4. Activate ground power
5. Check externally that the lights move to extend
6. move either landing light switch into the retract position
7. wait a few seconds (less than 8)
8. cut ground power
9. check externally that the lights have moved partially to the retracted position
10. reapply groundpower
11. check externally that the lights have fully retracted.
12. Open EFB failure page
13. Go to electrical failures
14. Fail AC bus 1
15. Try to move landing lights.
16. only right landing light should move
17. unfail AC bus 1 and fail AC bus 2
18. try to move landing lights
19. only left landing light should move

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
