### PR TITLE
fix(fma): V/S not properly aligned when value is 0

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/PFD/FMA.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/FMA.tsx
@@ -812,7 +812,7 @@ class B1Cell extends ShowForSecondsComponent<CellProps> {
             break;
         }
         case VerticalMode.VS: {
-            const VSText = `${(this.selectedVS > 0 ? '+' : '')}${Math.round(this.selectedVS).toString()}`.padStart(5, ' ');
+            const VSText = `${(this.selectedVS > 0 ? '+' : '')}${Math.round(this.selectedVS).toString()}`.padStart(5, '\xa0');
 
             text = 'V/S';
 
@@ -1536,9 +1536,9 @@ class D3Cell extends DisplayComponent<{bus: ArincEventBus}> {
         ([mdaMode, dh, mda]) => {
             switch (mdaMode) {
             case MdaMode.Baro:
-                return Math.round(mda.value).toString().padStart(6, ' ');
+                return Math.round(mda.value).toString().padStart(6, '\xa0');
             case MdaMode.Radio:
-                return Math.round(dh.value).toString().padStart(4, ' ');
+                return Math.round(dh.value).toString().padStart(4, '\xa0');
             default:
                 return '';
             }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes a FMA regression where white spaces are not applied to the vertical speed FMA when the selected value is zero.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
(left side = after, right side = before)
![VS](https://github.com/flybywiresim/aircraft/assets/119708186/5d0afdec-731e-4dbb-b88d-e2e25907c524)
## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
Using \xa0 instead of " " in the padStart function seems to fix the spacing issue, as a result, I changed all the padStart calls in the FMA to \xa0 just for consistency.
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
bruno_pt99
## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Pull the V/S knob on the FCU and select a value of 0, make sure the vertical fma looks as the left side picture.
Insert a BARO or RADIO minima in the PERF APPR page and make sure it shows on the PFD.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
