### PR TITLE
fix: Fixed input parser for ICAO for weather widget

### DIFF
--- a/fbw-common/src/systems/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -122,7 +122,7 @@ export const WeatherWidget: FC<WeatherWidgetProps> = ({ name, simbriefIcao, user
     };
 
     async function getMetar(icao: string, source: string): Promise<void> {
-        if (icao.length !== 4 || icao === '----') {
+        if (icao.length !== 4 || !(/^[a-z]{4}$/i.test(icao))) {
             setErrorMetar(t('Dashboard.ImportantInformation.Weather.NoIcaoProvided'));
             dispatch(setMetar(MetarParserTypeProp));
             return Promise.resolve();


### PR DESCRIPTION
## Summary of Changes
The flyPad Weather Widget started requesting METAR information for invalid ICAOs which when for example entering "EDD," led the api to return ALL available metar and the flyPad to try to display these. This also caused the sim to freeze in some cases.

This PR improves the input validation to avoid this in the future. 

## Screenshots (if necessary)
![image](https://github.com/flybywiresim/aircraft/assets/16833201/77f0dfb0-b775-4d68-b509-9709393a9838)

Discord username (if different from GitHub): cdr_maverick

## Testing instructions
Try to enter valid and invalid ICAOs and make sure the Weather Widget behaves correctly. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
