### PR TITLE
fix: lvar for brightness offset of ISIS for it support light presets

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/ISIS/AutoBrightness.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/ISIS/AutoBrightness.tsx
@@ -18,7 +18,6 @@ export const AutoBrightness: React.FC<AutoBrightnessProps> = ({ bugsActive, chil
 
     const [rawAutoBrightness] = useSimVar('GLASSCOCKPIT AUTOMATIC BRIGHTNESS', 'number', 1000);
     const [autoBrightness, setAutoBrightness] = useState(0.5);
-    // const [manualOffset, setManualOffset] = useState(0);
     const [manualOffset, setManualOffset] = useSimVar('L:A32NX_ISIS_MANUAL_BRIGHTNESS_OFFSET', 'number', 200);
     const [targetBrightness, setTargetBrightness] = useState(0.5);
 

--- a/fbw-a32nx/src/systems/instruments/src/ISIS/AutoBrightness.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/ISIS/AutoBrightness.tsx
@@ -18,7 +18,8 @@ export const AutoBrightness: React.FC<AutoBrightnessProps> = ({ bugsActive, chil
 
     const [rawAutoBrightness] = useSimVar('GLASSCOCKPIT AUTOMATIC BRIGHTNESS', 'number', 1000);
     const [autoBrightness, setAutoBrightness] = useState(0.5);
-    const [manualOffset, setManualOffset] = useState(0);
+    // const [manualOffset, setManualOffset] = useState(0);
+    const [manualOffset, setManualOffset] = useSimVar('L:A32NX_ISIS_MANUAL_BRIGHTNESS_OFFSET', 'number', 200);
     const [targetBrightness, setTargetBrightness] = useState(0.5);
 
     const [plusHeld, setPlusHeld] = useState(false);

--- a/fbw-a32nx/src/wasm/extra-backend-a32nx/src/LightingPresets/LightingPresets_A32NX.cpp
+++ b/fbw-a32nx/src/wasm/extra-backend-a32nx/src/LightingPresets/LightingPresets_A32NX.cpp
@@ -34,36 +34,37 @@ bool LightingPresets_A32NX::initialize_aircraft() {
 
   // Events for setting the aircraft variables
   lightPotentiometerSetEvent = dataManager->make_sim_event("LIGHT_POTENTIOMETER_SET", NOTIFICATION_GROUP_1);
-  cabinLightSetEvent = dataManager->make_sim_event("CABIN_LIGHTS_SET", NOTIFICATION_GROUP_1);
+  cabinLightSetEvent         = dataManager->make_sim_event("CABIN_LIGHTS_SET", NOTIFICATION_GROUP_1);
 
   // Lighting LVARs - manual update and write when load/saving is requested
-  efbBrightness = dataManager->make_named_var("EFB_BRIGHTNESS");
-  dcduLeftLightLevel = dataManager->make_named_var("PANEL_DCDU_L_BRIGHTNESS");
-  dcduRightLightLevel = dataManager->make_named_var("PANEL_DCDU_R_BRIGHTNESS");
-  mcduLeftLightLevel = dataManager->make_named_var("MCDU_L_BRIGHTNESS");
-  mcduRightLightLevel = dataManager->make_named_var("MCDU_R_BRIGHTNESS");
+  efbBrightness         = dataManager->make_named_var("EFB_BRIGHTNESS");
+  isisManualOffsetLevel = dataManager->make_named_var("ISIS_MANUAL_BRIGHTNESS_OFFSET");
+  dcduLeftLightLevel    = dataManager->make_named_var("PANEL_DCDU_L_BRIGHTNESS");
+  dcduRightLightLevel   = dataManager->make_named_var("PANEL_DCDU_R_BRIGHTNESS");
+  mcduLeftLightLevel    = dataManager->make_named_var("MCDU_L_BRIGHTNESS");
+  mcduRightLightLevel   = dataManager->make_named_var("MCDU_R_BRIGHTNESS");
 
   // Light Potentiometers - manual update and write when load/saving is requested
-  lightCabin = dataManager->make_aircraft_var("LIGHT CABIN", 0, "", cabinLightSetEvent, UNITS.Percent);
-  lightCabinLevel = createLightPotentiometerVar(7);
-  ovhdIntegralLightLevel = createLightPotentiometerVar(86);
+  lightCabin                    = dataManager->make_aircraft_var("LIGHT CABIN", 0, "", cabinLightSetEvent, UNITS.Percent);
+  lightCabinLevel               = createLightPotentiometerVar(7);
+  ovhdIntegralLightLevel        = createLightPotentiometerVar(86);
   glareshieldIntegralLightLevel = createLightPotentiometerVar(84);
-  glareshieldLcdLightLevel = createLightPotentiometerVar(87);
-  tableLightCptLevel = createLightPotentiometerVar(10);
-  tableLightFoLevel = createLightPotentiometerVar(11);
-  pfdBrtCptLevel = createLightPotentiometerVar(88);
-  ndBrtCptLevel = createLightPotentiometerVar(89);
-  wxTerrainBrtCptLevel = createLightPotentiometerVar(94);
-  consoleLightCptLevel = createLightPotentiometerVar(8);
-  pfdBrtFoLevel = createLightPotentiometerVar(90);
-  ndBrtFoLevel = createLightPotentiometerVar(91);
-  wxTerrainBrtFoLevel = createLightPotentiometerVar(95);
-  consoleLightFoLevel = createLightPotentiometerVar(9);
-  ecamUpperLightLevel = createLightPotentiometerVar(92);
-  ecamLowerLightLevel = createLightPotentiometerVar(93);
-  floodPnlLightLevel = createLightPotentiometerVar(83);
-  pedestalIntegralLightLevel = createLightPotentiometerVar(85);
-  floodPedLightLevel = createLightPotentiometerVar(76);
+  glareshieldLcdLightLevel      = createLightPotentiometerVar(87);
+  tableLightCptLevel            = createLightPotentiometerVar(10);
+  tableLightFoLevel             = createLightPotentiometerVar(11);
+  pfdBrtCptLevel                = createLightPotentiometerVar(88);
+  ndBrtCptLevel                 = createLightPotentiometerVar(89);
+  wxTerrainBrtCptLevel          = createLightPotentiometerVar(94);
+  consoleLightCptLevel          = createLightPotentiometerVar(8);
+  pfdBrtFoLevel                 = createLightPotentiometerVar(90);
+  ndBrtFoLevel                  = createLightPotentiometerVar(91);
+  wxTerrainBrtFoLevel           = createLightPotentiometerVar(95);
+  consoleLightFoLevel           = createLightPotentiometerVar(9);
+  ecamUpperLightLevel           = createLightPotentiometerVar(92);
+  ecamLowerLightLevel           = createLightPotentiometerVar(93);
+  floodPnlLightLevel            = createLightPotentiometerVar(83);
+  pedestalIntegralLightLevel    = createLightPotentiometerVar(85);
+  floodPedLightLevel            = createLightPotentiometerVar(76);
 
   loadLightingPresetRequest->setAsInt64(0);
   saveLightingPresetRequest->setAsInt64(0);
@@ -78,32 +79,33 @@ bool LightingPresets_A32NX::initialize_aircraft() {
 // =================================================================================================
 
 void LightingPresets_A32NX::readFromAircraft() {
-  currentLightValues.efbBrightness = efbBrightness->readFromSim();
-  currentLightValues.cabinLightLevel = lightCabinLevel->readFromSim();
-  currentLightValues.ovhdIntegralLightLevel = ovhdIntegralLightLevel->readFromSim();
+  currentLightValues.efbBrightness                 = efbBrightness->readFromSim();
+  currentLightValues.cabinLightLevel               = lightCabinLevel->readFromSim();
+  currentLightValues.ovhdIntegralLightLevel        = ovhdIntegralLightLevel->readFromSim();
   currentLightValues.glareshieldIntegralLightLevel = glareshieldIntegralLightLevel->readFromSim();
-  currentLightValues.glareshieldLcdLightLevel = glareshieldLcdLightLevel->readFromSim();
-  currentLightValues.tableLightCptLevel = tableLightCptLevel->readFromSim();
-  currentLightValues.tableLightFoLevel = tableLightFoLevel->readFromSim();
-  currentLightValues.pfdBrtCptLevel = pfdBrtCptLevel->readFromSim();
-  currentLightValues.ndBrtCptLevel = ndBrtCptLevel->readFromSim();
-  currentLightValues.wxTerrainBrtCptLevel = wxTerrainBrtCptLevel->readFromSim();
-  currentLightValues.consoleLightCptLevel = consoleLightCptLevel->readFromSim();
-  currentLightValues.pfdBrtFoLevel = pfdBrtFoLevel->readFromSim();
-  currentLightValues.ndBrtFoLevel = ndBrtFoLevel->readFromSim();
-  currentLightValues.wxTerrainBrtFoLevel = wxTerrainBrtFoLevel->readFromSim();
-  currentLightValues.consoleLightFoLevel = consoleLightFoLevel->readFromSim();
-  currentLightValues.ecamUpperLightLevel = ecamUpperLightLevel->readFromSim();
-  currentLightValues.ecamLowerLightLevel = ecamLowerLightLevel->readFromSim();
-  currentLightValues.floodPnlLightLevel = floodPnlLightLevel->readFromSim();
-  currentLightValues.pedestalIntegralLightLevel = pedestalIntegralLightLevel->readFromSim();
-  currentLightValues.floodPedLightLevel = floodPedLightLevel->readFromSim();
+  currentLightValues.glareshieldLcdLightLevel      = glareshieldLcdLightLevel->readFromSim();
+  currentLightValues.tableLightCptLevel            = tableLightCptLevel->readFromSim();
+  currentLightValues.tableLightFoLevel             = tableLightFoLevel->readFromSim();
+  currentLightValues.pfdBrtCptLevel                = pfdBrtCptLevel->readFromSim();
+  currentLightValues.ndBrtCptLevel                 = ndBrtCptLevel->readFromSim();
+  currentLightValues.wxTerrainBrtCptLevel          = wxTerrainBrtCptLevel->readFromSim();
+  currentLightValues.consoleLightCptLevel          = consoleLightCptLevel->readFromSim();
+  currentLightValues.pfdBrtFoLevel                 = pfdBrtFoLevel->readFromSim();
+  currentLightValues.ndBrtFoLevel                  = ndBrtFoLevel->readFromSim();
+  currentLightValues.wxTerrainBrtFoLevel           = wxTerrainBrtFoLevel->readFromSim();
+  currentLightValues.consoleLightFoLevel           = consoleLightFoLevel->readFromSim();
+  currentLightValues.ecamUpperLightLevel           = ecamUpperLightLevel->readFromSim();
+  currentLightValues.ecamLowerLightLevel           = ecamLowerLightLevel->readFromSim();
+  currentLightValues.floodPnlLightLevel            = floodPnlLightLevel->readFromSim();
+  currentLightValues.pedestalIntegralLightLevel    = pedestalIntegralLightLevel->readFromSim();
+  currentLightValues.floodPedLightLevel            = floodPedLightLevel->readFromSim();
   // these are not using standard 0..100 range
   // so we need to convert them to 0..100
-  currentLightValues.dcduLeftLightLevel = dcduLeftLightLevel->readFromSim() * 100;   // 0.0..1.0
-  currentLightValues.dcduRightLightLevel = dcduRightLightLevel->readFromSim() * 100; // 0.0..1.0
-  currentLightValues.mcduLeftLightLevel = mcduLeftLightLevel->readFromSim() * 12.5;   // 0.5..8.0
-  currentLightValues.mcduRightLightLevel = mcduRightLightLevel->readFromSim() * 12.5; // 0.5..8.0
+  currentLightValues.isisManualOffsetLevel = isisManualOffsetLevel->readFromSim() * 100;  // -1.0..1.0
+  currentLightValues.dcduLeftLightLevel    = dcduLeftLightLevel->readFromSim() * 100;     // 0.0..1.0
+  currentLightValues.dcduRightLightLevel   = dcduRightLightLevel->readFromSim() * 100;    // 0.0..1.0
+  currentLightValues.mcduLeftLightLevel    = mcduLeftLightLevel->readFromSim() * 12.5;    // 0.5..8.0
+  currentLightValues.mcduRightLightLevel   = mcduRightLightLevel->readFromSim() * 12.5;   // 0.5..8.0
 }
 
 void LightingPresets_A32NX::applyToAircraft() {
@@ -129,14 +131,14 @@ void LightingPresets_A32NX::applyToAircraft() {
   floodPedLightLevel->setAndWriteToSim(intermediateLightValues.floodPedLightLevel);
   // These are not using standard 0..100 range
   // So we need to convert them back
-  dcduLeftLightLevel->setAndWriteToSim(intermediateLightValues.dcduLeftLightLevel / 100);     // 0.0..1.0
-  dcduRightLightLevel->setAndWriteToSim(intermediateLightValues.dcduRightLightLevel / 100);   // 0.0..1.0
-  mcduLeftLightLevel->setAndWriteToSim(intermediateLightValues.mcduLeftLightLevel / 12.5);     // 0.5..8.0
-  mcduRightLightLevel->setAndWriteToSim(intermediateLightValues.mcduRightLightLevel / 12.5) ;   // 0.5..8.0
+  isisManualOffsetLevel->setAndWriteToSim(intermediateLightValues.isisManualOffsetLevel / 100);  // -1.0..1.0
+  dcduLeftLightLevel->setAndWriteToSim(intermediateLightValues.dcduLeftLightLevel / 100);        // 0.0..1.0
+  dcduRightLightLevel->setAndWriteToSim(intermediateLightValues.dcduRightLightLevel / 100);      // 0.0..1.0
+  mcduLeftLightLevel->setAndWriteToSim(intermediateLightValues.mcduLeftLightLevel / 12.5);       // 0.5..8.0
+  mcduRightLightLevel->setAndWriteToSim(intermediateLightValues.mcduRightLightLevel / 12.5);     // 0.5..8.0
 }
 
-void LightingPresets_A32NX::loadFromIni(const mINI::INIStructure& ini,
-                                          const std::string& iniSectionName) {
+void LightingPresets_A32NX::loadFromIni(const mINI::INIStructure& ini, const std::string& iniSectionName) {
   // check if iniSectionName is available
   // if not use a 50% default iniSectionName
   if (!ini.has(iniSectionName)) {
@@ -145,57 +147,59 @@ void LightingPresets_A32NX::loadFromIni(const mINI::INIStructure& ini,
   }
 
   // reading data structure from ini
-  loadedLightValues.efbBrightness = iniGetOrDefault(ini, iniSectionName, "efb_brightness", 80.0);
-  loadedLightValues.cabinLightLevel = iniGetOrDefault(ini, iniSectionName, "cabin_light", 50.0);
-  loadedLightValues.ovhdIntegralLightLevel = iniGetOrDefault(ini, iniSectionName, "ovhd_int_lt", 50.0);
+  loadedLightValues.efbBrightness                 = iniGetOrDefault(ini, iniSectionName, "efb_brightness", 80.0);
+  loadedLightValues.cabinLightLevel               = iniGetOrDefault(ini, iniSectionName, "cabin_light", 50.0);
+  loadedLightValues.ovhdIntegralLightLevel        = iniGetOrDefault(ini, iniSectionName, "ovhd_int_lt", 50.0);
   loadedLightValues.glareshieldIntegralLightLevel = iniGetOrDefault(ini, iniSectionName, "glareshield_int_lt", 50.0);
-  loadedLightValues.glareshieldLcdLightLevel = iniGetOrDefault(ini, iniSectionName, "glareshield_lcd_lt", 50.0);
-  loadedLightValues.tableLightCptLevel = iniGetOrDefault(ini, iniSectionName, "table_cpt_lt", 50.0);
-  loadedLightValues.tableLightFoLevel = iniGetOrDefault(ini, iniSectionName, "table_fo_lt", 50.0);
-  loadedLightValues.pfdBrtCptLevel = iniGetOrDefault(ini, iniSectionName, "pfd_cpt_lvl", 50.0);
-  loadedLightValues.ndBrtCptLevel = iniGetOrDefault(ini, iniSectionName, "nd_cpt_lvl", 50.0);
-  loadedLightValues.wxTerrainBrtCptLevel = iniGetOrDefault(ini, iniSectionName, "wx_cpt_lvl", 50.0);
-  loadedLightValues.consoleLightCptLevel = iniGetOrDefault(ini, iniSectionName, "console_cpt_lt", 50.0);
-  loadedLightValues.pfdBrtFoLevel = iniGetOrDefault(ini, iniSectionName, "pfd_fo_lvl", 50.0);
-  loadedLightValues.ndBrtFoLevel = iniGetOrDefault(ini, iniSectionName, "nd_fo_lvl", 50.0);
-  loadedLightValues.wxTerrainBrtFoLevel = iniGetOrDefault(ini, iniSectionName, "wx_fo_lvl", 50.0);
-  loadedLightValues.consoleLightFoLevel = iniGetOrDefault(ini, iniSectionName, "console_fo_lt", 50.0);
-  loadedLightValues.dcduLeftLightLevel = iniGetOrDefault(ini, iniSectionName, "dcdu_left_lvl", 50.0);
-  loadedLightValues.dcduRightLightLevel = iniGetOrDefault(ini, iniSectionName, "dcdu_right_lvl", 50.0);
-  loadedLightValues.mcduLeftLightLevel = iniGetOrDefault(ini, iniSectionName, "mcdu_left_lvl", 50.0);
-  loadedLightValues.mcduRightLightLevel = iniGetOrDefault(ini, iniSectionName, "mcdu_right_lvl", 50.0);
-  loadedLightValues.ecamUpperLightLevel = iniGetOrDefault(ini, iniSectionName, "ecam_upper_lvl", 50.0);
-  loadedLightValues.ecamLowerLightLevel = iniGetOrDefault(ini, iniSectionName, "ecam_lower_lvl", 50.0);
-  loadedLightValues.floodPnlLightLevel = iniGetOrDefault(ini, iniSectionName, "flood_pnl_lt", 50.0);
-  loadedLightValues.pedestalIntegralLightLevel = iniGetOrDefault(ini, iniSectionName, "pedestal_int_lt", 50.0);
-  loadedLightValues.floodPedLightLevel = iniGetOrDefault(ini, iniSectionName, "flood_ped_lvl", 50.0);
+  loadedLightValues.glareshieldLcdLightLevel      = iniGetOrDefault(ini, iniSectionName, "glareshield_lcd_lt", 50.0);
+  loadedLightValues.tableLightCptLevel            = iniGetOrDefault(ini, iniSectionName, "table_cpt_lt", 50.0);
+  loadedLightValues.tableLightFoLevel             = iniGetOrDefault(ini, iniSectionName, "table_fo_lt", 50.0);
+  loadedLightValues.pfdBrtCptLevel                = iniGetOrDefault(ini, iniSectionName, "pfd_cpt_lvl", 50.0);
+  loadedLightValues.ndBrtCptLevel                 = iniGetOrDefault(ini, iniSectionName, "nd_cpt_lvl", 50.0);
+  loadedLightValues.wxTerrainBrtCptLevel          = iniGetOrDefault(ini, iniSectionName, "wx_cpt_lvl", 50.0);
+  loadedLightValues.consoleLightCptLevel          = iniGetOrDefault(ini, iniSectionName, "console_cpt_lt", 50.0);
+  loadedLightValues.pfdBrtFoLevel                 = iniGetOrDefault(ini, iniSectionName, "pfd_fo_lvl", 50.0);
+  loadedLightValues.ndBrtFoLevel                  = iniGetOrDefault(ini, iniSectionName, "nd_fo_lvl", 50.0);
+  loadedLightValues.wxTerrainBrtFoLevel           = iniGetOrDefault(ini, iniSectionName, "wx_fo_lvl", 50.0);
+  loadedLightValues.consoleLightFoLevel           = iniGetOrDefault(ini, iniSectionName, "console_fo_lt", 50.0);
+  loadedLightValues.isisManualOffsetLevel         = iniGetOrDefault(ini, iniSectionName, "isis_manual_offset_lvl", 0.0);
+  loadedLightValues.dcduLeftLightLevel            = iniGetOrDefault(ini, iniSectionName, "dcdu_left_lvl", 50.0);
+  loadedLightValues.dcduRightLightLevel           = iniGetOrDefault(ini, iniSectionName, "dcdu_right_lvl", 50.0);
+  loadedLightValues.mcduLeftLightLevel            = iniGetOrDefault(ini, iniSectionName, "mcdu_left_lvl", 50.0);
+  loadedLightValues.mcduRightLightLevel           = iniGetOrDefault(ini, iniSectionName, "mcdu_right_lvl", 50.0);
+  loadedLightValues.ecamUpperLightLevel           = iniGetOrDefault(ini, iniSectionName, "ecam_upper_lvl", 50.0);
+  loadedLightValues.ecamLowerLightLevel           = iniGetOrDefault(ini, iniSectionName, "ecam_lower_lvl", 50.0);
+  loadedLightValues.floodPnlLightLevel            = iniGetOrDefault(ini, iniSectionName, "flood_pnl_lt", 50.0);
+  loadedLightValues.pedestalIntegralLightLevel    = iniGetOrDefault(ini, iniSectionName, "pedestal_int_lt", 50.0);
+  loadedLightValues.floodPedLightLevel            = iniGetOrDefault(ini, iniSectionName, "flood_ped_lvl", 50.0);
 }
 
 void LightingPresets_A32NX::saveToIni(mINI::INIStructure& ini, const std::string& iniSectionName) const {
-  ini[iniSectionName]["efb_brightness"] = std::to_string(currentLightValues.efbBrightness);
-  ini[iniSectionName]["cabin_light"] = std::to_string(currentLightValues.cabinLightLevel);
-  ini[iniSectionName]["ovhd_int_lt"] = std::to_string(currentLightValues.ovhdIntegralLightLevel);
-  ini[iniSectionName]["glareshield_int_lt"] = std::to_string(currentLightValues.glareshieldIntegralLightLevel);
-  ini[iniSectionName]["glareshield_lcd_lt"] = std::to_string(currentLightValues.glareshieldLcdLightLevel);
-  ini[iniSectionName]["table_cpt_lt"] = std::to_string(currentLightValues.tableLightCptLevel);
-  ini[iniSectionName]["table_fo_lt"] = std::to_string(currentLightValues.tableLightFoLevel);
-  ini[iniSectionName]["pfd_cpt_lvl"] = std::to_string(currentLightValues.pfdBrtCptLevel);
-  ini[iniSectionName]["nd_cpt_lvl"] = std::to_string(currentLightValues.ndBrtCptLevel);
-  ini[iniSectionName]["wx_cpt_lvl"] = std::to_string(currentLightValues.wxTerrainBrtCptLevel);
-  ini[iniSectionName]["console_cpt_lt"] = std::to_string(currentLightValues.consoleLightCptLevel);
-  ini[iniSectionName]["pfd_fo_lvl"] = std::to_string(currentLightValues.pfdBrtFoLevel);
-  ini[iniSectionName]["nd_fo_lvl"] = std::to_string(currentLightValues.ndBrtFoLevel);
-  ini[iniSectionName]["wx_fo_lvl"] = std::to_string(currentLightValues.wxTerrainBrtFoLevel);
-  ini[iniSectionName]["console_fo_lt"] = std::to_string(currentLightValues.consoleLightFoLevel);
-  ini[iniSectionName]["dcdu_left_lvl"] = std::to_string(currentLightValues.dcduLeftLightLevel);
-  ini[iniSectionName]["dcdu_right_lvl"] = std::to_string(currentLightValues.dcduRightLightLevel);
-  ini[iniSectionName]["mcdu_left_lvl"] = std::to_string(currentLightValues.mcduLeftLightLevel);
-  ini[iniSectionName]["mcdu_right_lvl"] = std::to_string(currentLightValues.mcduRightLightLevel);
-  ini[iniSectionName]["ecam_upper_lvl"] = std::to_string(currentLightValues.ecamUpperLightLevel);
-  ini[iniSectionName]["ecam_lower_lvl"] = std::to_string(currentLightValues.ecamLowerLightLevel);
-  ini[iniSectionName]["flood_pnl_lt"] = std::to_string(currentLightValues.floodPnlLightLevel);
-  ini[iniSectionName]["pedestal_int_lt"] = std::to_string(currentLightValues.pedestalIntegralLightLevel);
-  ini[iniSectionName]["flood_ped_lvl"] = std::to_string(currentLightValues.floodPedLightLevel);
+  ini[iniSectionName]["efb_brightness"]         = std::to_string(currentLightValues.efbBrightness);
+  ini[iniSectionName]["cabin_light"]            = std::to_string(currentLightValues.cabinLightLevel);
+  ini[iniSectionName]["ovhd_int_lt"]            = std::to_string(currentLightValues.ovhdIntegralLightLevel);
+  ini[iniSectionName]["glareshield_int_lt"]     = std::to_string(currentLightValues.glareshieldIntegralLightLevel);
+  ini[iniSectionName]["glareshield_lcd_lt"]     = std::to_string(currentLightValues.glareshieldLcdLightLevel);
+  ini[iniSectionName]["table_cpt_lt"]           = std::to_string(currentLightValues.tableLightCptLevel);
+  ini[iniSectionName]["table_fo_lt"]            = std::to_string(currentLightValues.tableLightFoLevel);
+  ini[iniSectionName]["pfd_cpt_lvl"]            = std::to_string(currentLightValues.pfdBrtCptLevel);
+  ini[iniSectionName]["nd_cpt_lvl"]             = std::to_string(currentLightValues.ndBrtCptLevel);
+  ini[iniSectionName]["wx_cpt_lvl"]             = std::to_string(currentLightValues.wxTerrainBrtCptLevel);
+  ini[iniSectionName]["console_cpt_lt"]         = std::to_string(currentLightValues.consoleLightCptLevel);
+  ini[iniSectionName]["pfd_fo_lvl"]             = std::to_string(currentLightValues.pfdBrtFoLevel);
+  ini[iniSectionName]["nd_fo_lvl"]              = std::to_string(currentLightValues.ndBrtFoLevel);
+  ini[iniSectionName]["wx_fo_lvl"]              = std::to_string(currentLightValues.wxTerrainBrtFoLevel);
+  ini[iniSectionName]["console_fo_lt"]          = std::to_string(currentLightValues.consoleLightFoLevel);
+  ini[iniSectionName]["isis_manual_offset_lvl"] = std::to_string(currentLightValues.isisManualOffsetLevel);
+  ini[iniSectionName]["dcdu_left_lvl"]          = std::to_string(currentLightValues.dcduLeftLightLevel);
+  ini[iniSectionName]["dcdu_right_lvl"]         = std::to_string(currentLightValues.dcduRightLightLevel);
+  ini[iniSectionName]["mcdu_left_lvl"]          = std::to_string(currentLightValues.mcduLeftLightLevel);
+  ini[iniSectionName]["mcdu_right_lvl"]         = std::to_string(currentLightValues.mcduRightLightLevel);
+  ini[iniSectionName]["ecam_upper_lvl"]         = std::to_string(currentLightValues.ecamUpperLightLevel);
+  ini[iniSectionName]["ecam_lower_lvl"]         = std::to_string(currentLightValues.ecamLowerLightLevel);
+  ini[iniSectionName]["flood_pnl_lt"]           = std::to_string(currentLightValues.floodPnlLightLevel);
+  ini[iniSectionName]["pedestal_int_lt"]        = std::to_string(currentLightValues.pedestalIntegralLightLevel);
+  ini[iniSectionName]["flood_ped_lvl"]          = std::to_string(currentLightValues.floodPedLightLevel);
 }
 
 [[maybe_unused]] std::string LightingPresets_A32NX::str() const {
@@ -215,6 +219,7 @@ void LightingPresets_A32NX::saveToIni(mINI::INIStructure& ini, const std::string
   os << "ND FO Lvl: " << intermediateLightValues.ndBrtFoLevel << std::endl;
   os << "WX FO Lvl: " << intermediateLightValues.wxTerrainBrtFoLevel << std::endl;
   os << "Console Fo Lt: " << intermediateLightValues.consoleLightFoLevel << std::endl;
+  os << "ISIS Manual Offset Lvl: " << intermediateLightValues.isisManualOffsetLevel << std::endl;
   os << "DCDU Left Lvl: " << intermediateLightValues.dcduLeftLightLevel << std::endl;
   os << "DCDU Right Lvl: " << intermediateLightValues.dcduRightLightLevel << std::endl;
   os << "MCDU Left Lvl: " << intermediateLightValues.mcduLeftLightLevel << std::endl;
@@ -260,6 +265,7 @@ bool LightingPresets_A32NX::calculateIntermediateValues(FLOAT64 stepSize) {
   intermediateLightValues.ndBrtFoLevel = convergeValue( currentLightValues.ndBrtFoLevel,loadedLightValues.ndBrtFoLevel, stepSize);
   intermediateLightValues.wxTerrainBrtFoLevel = convergeValue( currentLightValues.wxTerrainBrtFoLevel,loadedLightValues.wxTerrainBrtFoLevel, stepSize);
   intermediateLightValues.consoleLightFoLevel = convergeValue( currentLightValues.consoleLightFoLevel,loadedLightValues.consoleLightFoLevel, stepSize);
+  intermediateLightValues.isisManualOffsetLevel = convergeValue( currentLightValues.isisManualOffsetLevel,loadedLightValues.isisManualOffsetLevel, stepSize);
   intermediateLightValues.dcduLeftLightLevel = convergeValue( currentLightValues.dcduLeftLightLevel,loadedLightValues.dcduLeftLightLevel, stepSize);
   intermediateLightValues.dcduRightLightLevel = convergeValue( currentLightValues.dcduRightLightLevel,loadedLightValues.dcduRightLightLevel, stepSize);
   intermediateLightValues.mcduLeftLightLevel = convergeValue( currentLightValues.mcduLeftLightLevel,loadedLightValues.mcduLeftLightLevel, stepSize);

--- a/fbw-a32nx/src/wasm/extra-backend-a32nx/src/LightingPresets/LightingPresets_A32NX.h
+++ b/fbw-a32nx/src/wasm/extra-backend-a32nx/src/LightingPresets/LightingPresets_A32NX.h
@@ -30,11 +30,12 @@ struct LightingValues_A32NX {
   FLOAT64 ndBrtFoLevel;          // 91
   FLOAT64 wxTerrainBrtFoLevel;   // 95
   FLOAT64 consoleLightFoLevel;   // 9 (0, 50, 100)
-  // ISIS display has automatic brightness adjustment.
-  FLOAT64 dcduLeftLightLevel;   // A32NX_PANEL_DCDU_L_BRIGHTNESS  0..100
-  FLOAT64 dcduRightLightLevel;  // A32NX_PANEL_DCDU_R_BRIGHTNESS  0..100
-  FLOAT64 mcduLeftLightLevel;   // A32NX_MCDU_L_BRIGHTNESS        0.5..8.0
-  FLOAT64 mcduRightLightLevel;  // A32NX_MCDU_R_BRIGHTNESS        0.5..8.0
+  // ISIS display has automatic brightness adjustment - this is just a manual offset
+  FLOAT64 isisManualOffsetLevel;  // A32NX_ISIS_MANUAL_BRIGHTNESS_OFFSET -1.0..1.0 but limited by min/max total brightness
+  FLOAT64 dcduLeftLightLevel;     // A32NX_PANEL_DCDU_L_BRIGHTNESS  0.0..1.0
+  FLOAT64 dcduRightLightLevel;    // A32NX_PANEL_DCDU_R_BRIGHTNESS  0.0..1.0
+  FLOAT64 mcduLeftLightLevel;     // A32NX_MCDU_L_BRIGHTNESS        0.5..8.0
+  FLOAT64 mcduRightLightLevel;    // A32NX_MCDU_R_BRIGHTNESS        0.5..8.0
   // Pedestal
   FLOAT64 ecamUpperLightLevel;         // 92
   FLOAT64 ecamLowerLightLevel;         // 93
@@ -59,6 +60,7 @@ class LightingPresets_A32NX : public LightingPresets {
  private:
   // Lighting LVARs
   NamedVariablePtr efbBrightness;
+  NamedVariablePtr isisManualOffsetLevel;
   NamedVariablePtr dcduLeftLightLevel;
   NamedVariablePtr dcduRightLightLevel;
   NamedVariablePtr mcduLeftLightLevel;
@@ -130,8 +132,33 @@ class LightingPresets_A32NX : public LightingPresets {
    */
   void setValidCabinLightValue(FLOAT64 level);
 
-  const LightingValues_A32NX DEFAULT_50 = {50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0,
-                                     50.0, 50.0, 50.0, 0.5,  0.5,  0.5,  0.5,  50.0, 50.0, 50.0, 50.0, 50.0};
+  const LightingValues_A32NX DEFAULT_50 = {
+      50.0,  // efbBrightness
+      50.0,  // cabinLightLevel
+      50.0,  // ovhdIntegralLightLevel
+      50.0,  // glareshieldIntegralLightLevel
+      50.0,  // glareshieldLcdLightLevel
+      50.0,  // tableLightCptLevel
+      50.0,  // tableLightFoLevel
+      50.0,  // pfdBrtCptLevel
+      50.0,  // ndBrtCptLevel
+      50.0,  // wxTerrainBrtCptLevel
+      50.0,  // consoleLightCptLevel
+      50.0,  // pfdBrtFoLevel
+      50.0,  // ndBrtFoLevel
+      50.0,  // wxTerrainBrtFoLevel
+      50.0,  // consoleLightFoLevel
+      0.0,   // isisManualOffsetLevel
+      0.5,   // dcduLeftLightLevel
+      0.5,   // dcduRightLightLevel
+      0.5,   // mcduLeftLightLevel
+      0.5,   // mcduRightLightLevel
+      50.0,  // ecamUpperLightLevel
+      50.0,  // ecamLowerLightLevel
+      50.0,  // floodPnlLightLevel
+      50.0,  // pedestalIntegralLightLevel
+      50.0   // floodPedLightLevel
+  };
 };
 
 inline bool operator==(const LightingValues_A32NX& p1, const LightingValues_A32NX& p2) {
@@ -151,6 +178,7 @@ inline bool operator==(const LightingValues_A32NX& p1, const LightingValues_A32N
          helper::Math::almostEqual(p1.ndBrtFoLevel, p2.ndBrtFoLevel, epsilon) &&
          helper::Math::almostEqual(p1.wxTerrainBrtFoLevel, p2.wxTerrainBrtFoLevel, epsilon) &&
          helper::Math::almostEqual(p1.consoleLightFoLevel, p2.consoleLightFoLevel, epsilon) &&
+         helper::Math::almostEqual(p1.isisManualOffsetLevel, p2.isisManualOffsetLevel, epsilon) &&
          helper::Math::almostEqual(p1.dcduLeftLightLevel, p2.dcduLeftLightLevel, epsilon) &&
          helper::Math::almostEqual(p1.dcduRightLightLevel, p2.dcduRightLightLevel, epsilon) &&
          helper::Math::almostEqual(p1.mcduLeftLightLevel, p2.mcduLeftLightLevel, epsilon) &&


### PR DESCRIPTION
## Summary of Changes
Adds an LVar to the offset value of the ISIS brightness which is otherwise automatic. 
This PR makes it possible to store/load this value with Lighting Presets.

Discord username (if different from GitHub): cdr_maverick

## Testing instructions
Test if the ISIS offset brightness is now stored and loaded via the Lighting Presets. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
