### PR TITLE
fix: boarding rate and align time defaults

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -76,7 +76,8 @@
 1. [FLIGHTMODEL] Fixes some crosswind issues - @donstim (donbikes)
 1. [LIGHTS] Movement of landing lights now requires power and position is output into LVAR -  @Maximilian-Reuter
 1. [CDU] Fix auto weight and balance import on INIT B during GSX boarding not using the target values - @Maximilian-Reuter
-2. [FAC] Improve sideslip estimation - @lukecologne (luke)
+1. [FAC] Improve sideslip estimation - @lukecologne (luke)
+1. [EFB] Fix default value for boarding rate - @tracernz (Mike)
 
 ## 0.11.0
 

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/sync.ts
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/sync.ts
@@ -50,12 +50,12 @@ const settingsToSync: Map<string, SimVar> = new Map([
 
 const settingEnumToSync: Map<string, SimVarEnum> = new Map([
     ['CONFIG_BOARDING_RATE',
-        ['L:A32NX_BOARDING_RATE', 'number', '0',
+        ['L:A32NX_BOARDING_RATE', 'number', 'REAL',
             new Map([['REAL', 2], ['FAST', 1], ['INSTANT', 0]]),
         ],
     ],
     ['CONFIG_ALIGN_TIME',
-        ['L:A32NX_CONFIG_ADIRS_IR_ALIGN_TIME', 'number', '0',
+        ['L:A32NX_CONFIG_ADIRS_IR_ALIGN_TIME', 'number', 'REAL',
             new Map([['REAL', 0], ['FAST', 2], ['INSTANT', 1]]),
         ],
     ],


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes the default values for boarding rate and align time. Fixes a console error that resulted from the invalid defaults. There is a changelog for boarding rate as it was broken in 0.11, but the align time was only broken in https://github.com/flybywiresim/aircraft/pull/8530 which hasn't been in a stable release.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
None.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
