### PR TITLE
fix: Add missing localization in efb

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## 0.12.0
 
+1. [EFB] Added missing localization for SimBridge related settings in SimOptions page - @implasmatbh (Plasma)
 1. [EFB/ATSU] Added NOAA (aviationweather.gov) as a METAR source - @tracernz (Mike)
 1. [EFB] Fixed the main page and landing calculator to use the selected METAR source - @tracernz (Mike)
 1. [FMS] Improve layout of PERF CLB, PERF CRZ and PERF DES pages according to H3 - @BlueberryKing (BlueberryKing)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,7 +7,6 @@
 
 ## 0.12.0
 
-1. [EFB] Added missing localization for SimBridge related settings in SimOptions page - @implasmatbh (Plasma)
 1. [EFB/ATSU] Added NOAA (aviationweather.gov) as a METAR source - @tracernz (Mike)
 1. [EFB] Fixed the main page and landing calculator to use the selected METAR source - @tracernz (Mike)
 1. [FMS] Improve layout of PERF CLB, PERF CRZ and PERF DES pages according to H3 - @BlueberryKing (BlueberryKing)
@@ -78,6 +77,7 @@
 1. [LIGHTS] Movement of landing lights now requires power and position is output into LVAR -  @Maximilian-Reuter
 1. [CDU] Fix auto weight and balance import on INIT B during GSX boarding not using the target values - @Maximilian-Reuter
 2. [FAC] Improve sideslip estimation - @lukecologne (luke)
+1. [EFB] Added missing localization for SimBridge related settings in SimOptions page - @implasmatbh (Plasma)
 
 ## 0.11.0
 

--- a/fbw-common/src/systems/instruments/src/EFB/Localization/data/en.json
+++ b/fbw-common/src/systems/instruments/src/EFB/Localization/data/en.json
@@ -587,7 +587,11 @@
       "Title": "Sim Options",
       "UseCalculatedIlsSignals": "Use Calculated ILS Signals",
       "WheelChocksEnabled": "Wheel Chocks",
-      "inHg": "inHg"
+      "inHg": "inHg",
+      "SimbridgeMachine": "Simbridge Host Machine",
+      "SimbridgeLocal": "This PC",
+      "SimbridgeRemote": "Remote PC",
+      "SimbridgeEmptyAddress": "SimBridge Remote IP Address cannot be empty!"
     },
     "ThirdPartyOptions": {
       "TT": {

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
@@ -97,7 +97,7 @@ export const SimOptionsPage = () => {
                         </div>
                     </SettingItem>
 
-                    <SettingItem name="SimBridge Host Machine">
+                    <SettingItem name={t('Settings.SimOptions.SimbridgeMachine')}>
                         <SelectGroup>
                             <SelectItem
                                 className="color-red text-center"
@@ -108,7 +108,7 @@ export const SimOptionsPage = () => {
                                 }
                                 selected={simbridgeRemote === 'local'}
                             >
-                                This PC
+                                {t('Settings.SimOptions.SimbridgeLocal')}
                             </SelectItem>
                             <SelectItem
                                 onSelect={
@@ -118,7 +118,7 @@ export const SimOptionsPage = () => {
                                 }
                                 selected={simbridgeRemote === 'remote'}
                             >
-                                Remote PC
+                                {t('Settings.SimOptions.SimbridgeRemote')}
                             </SelectItem>
                         </SelectGroup>
                         {simbridgeRemote === 'remote'
@@ -130,7 +130,7 @@ export const SimOptionsPage = () => {
                                     onChange={(event) => {
                                         // Error on empty string
                                         if (event === '') {
-                                            toast.error('SimBridge Remote IP Address cannot be empty!');
+                                            toast.error(t('Settings.SimOptions.SimbridgeEmptyAddress));
                                             // Reset to previous value
                                             setSimbridgeIp(simbridgeIp);
                                             return;

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
@@ -130,7 +130,7 @@ export const SimOptionsPage = () => {
                                     onChange={(event) => {
                                         // Error on empty string
                                         if (event === '') {
-                                            toast.error(t('Settings.SimOptions.SimbridgeEmptyAddress));
+                                            toast.error(t('Settings.SimOptions.SimbridgeEmptyAddress'));
                                             // Reset to previous value
                                             setSimbridgeIp(simbridgeIp);
                                             return;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #7815 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Updated the SimOptions page to now use loc for values for text under SimBridge connection related settings in EFB.
Updated en.json localization page to include keys that will be used as text in SimOptions setting in EFB

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): implasma#0

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Turn on FlyPad
Navigate to Settings, then Sim Options page
Scroll down till you get to SimBridge settings where you can see simbridge related settings.
Text should show properly in English (you should be able to see SimBridge Host Machine, This PC, Remote PC etc. in English properly)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
