### PR TITLE
feat(fwc): non-cancellable warnings

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -78,6 +78,7 @@
 1. [CDU] Fix auto weight and balance import on INIT B during GSX boarding not using the target values - @Maximilian-Reuter
 1. [FAC] Improve sideslip estimation - @lukecologne (luke)
 1. [FWC] Implement overspeed VMO/MMO warning - @tracernz (Mike)
+1. [FWC] Implement non-cancellable master warning for overspeed and gear not down - @tracernz (Mike)
 
 ## 0.11.0
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -5016,7 +5016,6 @@
                 <NODE_ID>A32NX_PUSH_WARN_L</NODE_ID>
                 <PART_ID>A32NX_PUSH_WARN_L</PART_ID>
                 <LEFT_SINGLE_CODE>
-                    0 (&gt;L:A32NX_MASTER_WARNING)
                     1 (&gt;L:PUSH_AUTOPILOT_MASTERAWARN_L)
                 </LEFT_SINGLE_CODE>
                 <LEFT_LEAVE_CODE>
@@ -5040,7 +5039,6 @@
                 <NODE_ID>A32NX_PUSH_CAUTION_L</NODE_ID>
                 <PART_ID>A32NX_PUSH_CAUTION_L</PART_ID>
                 <LEFT_SINGLE_CODE>
-                    0 (&gt;L:A32NX_MASTER_CAUTION)
                     1 (&gt;L:PUSH_AUTOPILOT_MASTERCAUT_L)
                 </LEFT_SINGLE_CODE>
                 <LEFT_LEAVE_CODE>
@@ -5064,7 +5062,6 @@
                 <NODE_ID>A32NX_PUSH_WARN_R</NODE_ID>
                 <PART_ID>A32NX_PUSH_WARN_R</PART_ID>
                 <LEFT_SINGLE_CODE>
-                    0 (&gt;L:A32NX_MASTER_WARNING)
                     1 (&gt;L:PUSH_AUTOPILOT_MASTERAWARN_L)
                 </LEFT_SINGLE_CODE>
                 <LEFT_LEAVE_CODE>
@@ -5088,7 +5085,6 @@
                 <NODE_ID>A32NX_PUSH_CAUTION_R</NODE_ID>
                 <PART_ID>A32NX_PUSH_CAUTION_R</PART_ID>
                 <LEFT_SINGLE_CODE>
-                    0 (&gt;L:A32NX_MASTER_CAUTION)
                     1 (&gt;L:PUSH_AUTOPILOT_MASTERCAUT_L)
                 </LEFT_SINGLE_CODE>
                 <LEFT_LEAVE_CODE>

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_FWC.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_FWC.js
@@ -53,10 +53,6 @@ class A32NX_FWC {
         // ESDL 1. 0.320
         this.memoLdgInhibit_conf01 = new NXLogic_ConfirmNode(3, true); // CONF 01
 
-        // master warning & caution buttons
-        this.warningPressed = false;
-        this.cautionPressed = false;
-
         // altitude warning
         this.previousTargetAltitude = NaN;
         this._wasBellowThreshold = false;
@@ -75,17 +71,6 @@ class A32NX_FWC {
 
     _updateButtons(_deltaTime) {
         this.toConfigTest = SimVar.GetSimVarValue('L:A32NX_FWS_TO_CONFIG_TEST', 'boolean');
-
-        if (SimVar.GetSimVarValue("L:PUSH_AUTOPILOT_MASTERAWARN_L", "Bool") || SimVar.GetSimVarValue("L:PUSH_AUTOPILOT_MASTERAWARN_R", "Bool")) {
-            this.warningPressed = true;
-        } else {
-            this.warningPressed = false;
-        }
-        if (SimVar.GetSimVarValue("L:PUSH_AUTOPILOT_MASTERCAUT_L", "Bool") || SimVar.GetSimVarValue("L:PUSH_AUTOPILOT_MASTERCAUT_R", "Bool")) {
-            this.cautionPressed = true;
-        } else {
-            this.cautionPressed = false;
-        }
     }
 
     _updateFlightPhase(_deltaTime) {
@@ -302,7 +287,8 @@ class A32NX_FWC {
             SimVar.SetSimVarValue("L:A32NX_ALT_DEVIATION_SHORT", "Bool", false);
         }
 
-        if (this.warningPressed === true) {
+        const warningPressed = SimVar.GetSimVarValue("L:PUSH_AUTOPILOT_MASTERAWARN_L", "Bool") || SimVar.GetSimVarValue("L:PUSH_AUTOPILOT_MASTERAWARN_R", "Bool");
+        if (warningPressed) {
             this._wasBellowThreshold = false;
             this._wasAboveThreshold = false;
             this._wasInRange = false;

--- a/fbw-a32nx/src/systems/instruments/src/EWD/PseudoFWC.ts
+++ b/fbw-a32nx/src/systems/instruments/src/EWD/PseudoFWC.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-import { Subject, Subscribable, MappedSubject, DebounceTimer, ConsumerValue, EventBus, ConsumerSubject, SimVarValueType } from '@microsoft/msfs-sdk';
+import { Subject, Subscribable, MappedSubject, DebounceTimer, ConsumerValue, EventBus, ConsumerSubject, SimVarValueType, SubscribableMapFunctions } from '@microsoft/msfs-sdk';
 
 import { Arinc429Register, Arinc429Word, NXDataStore, NXLogicClockNode, NXLogicConfirmNode, NXLogicMemoryNode, NXLogicPulseNode, NXLogicTriggeredMonostableNode } from '@flybywiresim/fbw-sdk';
 import { VerticalMode } from '@shared/autopilot';
@@ -25,7 +25,7 @@ interface EWDItem {
     failure: number,
     sysPage: number,
     side: string,
-    /** Cancel flag (only emergency cancel can cancel if false), defaults to true. */
+    /** Cancel flag for level 3 warning audio (only emergency cancel can cancel if false), defaults to true. */
     cancel?: boolean,
 }
 
@@ -86,8 +86,10 @@ export class PseudoFWC {
 
     private readonly fireActive = Subject.create(false);
 
+    private nonCancellableWarningCount = 0;
+
     private readonly masterWarningOutput = MappedSubject.create(
-        ([masterWarning, fireActive]) => masterWarning || fireActive,
+        SubscribableMapFunctions.or(),
         this.masterWarning,
         this.fireActive,
     );
@@ -1573,7 +1575,7 @@ export class PseudoFWC {
             this.masterCaution.set(false);
             this.auralSingleChimePending = false;
         }
-        if (masterWarningButtonLeft || masterWarningButtonRight) {
+        if ((masterWarningButtonLeft || masterWarningButtonRight) && this.nonCancellableWarningCount === 0) {
             this.masterWarning.set(false);
             this.auralCrcActive.set(false);
         }
@@ -1603,15 +1605,8 @@ export class PseudoFWC {
 
         /* CLEAR AND RECALL */
         if (this.clrTriggerRisingEdge) {
-            // delete the first cancellable failure
-            for (const [index, failure] of this.failuresLeft.entries()) {
-                const cancellable = this.ewdMessageFailures[failure]?.cancel;
-                if (cancellable === false) {
-                    continue;
-                }
-                this.failuresLeft.splice(index, 1);
-                break;
-            }
+            // delete the first failure
+            this.failuresLeft.splice(0, 1);
             this.recallFailures = this.allCurrentFailures.filter((item) => !this.failuresLeft.includes(item));
         }
 
@@ -1665,6 +1660,7 @@ export class PseudoFWC {
 
         this.recallFailures.length = 0;
         this.recallFailures.push(...recallFailureKeys);
+        this.nonCancellableWarningCount = 0;
 
         // Failures first
         for (const [key, value] of Object.entries(this.ewdMessageFailures)) {
@@ -1689,6 +1685,10 @@ export class PseudoFWC {
                     if (value.failure === 2) {
                         this.masterCaution.set(true);
                     }
+                }
+
+                if (value.cancel === false && value.failure === 3) {
+                    this.nonCancellableWarningCount++;
                 }
 
                 // if the warning is the same as the aural
@@ -1833,7 +1833,9 @@ export class PseudoFWC {
 
             if (orderedFailureArrayRight.length === 0) {
                 this.masterCaution.set(false);
-                this.masterWarning.set(false);
+                if (this.nonCancellableWarningCount === 0) {
+                    this.masterWarning.set(false);
+                }
             }
         }
 

--- a/fbw-a32nx/src/systems/instruments/src/EWD/PseudoFWC.ts
+++ b/fbw-a32nx/src/systems/instruments/src/EWD/PseudoFWC.ts
@@ -1923,6 +1923,7 @@ export class PseudoFWC {
             failure: 3,
             sysPage: -1,
             side: 'LEFT',
+            cancel: false,
         },
         3400220: { // OVERSPEED FLAPS 3
             flightPhaseInhib: [2, 3, 4, 8, 9, 10],
@@ -1934,6 +1935,7 @@ export class PseudoFWC {
             failure: 3,
             sysPage: -1,
             side: 'LEFT',
+            cancel: false,
         },
         3400230: { // OVERSPEED FLAPS 2
             flightPhaseInhib: [2, 3, 4, 8, 9, 10],
@@ -1946,6 +1948,7 @@ export class PseudoFWC {
             failure: 3,
             sysPage: -1,
             side: 'LEFT',
+            cancel: false,
         },
         3400235: { // OVERSPEED FLAPS 1+F
             flightPhaseInhib: [2, 3, 4, 8, 9, 10],
@@ -1958,6 +1961,7 @@ export class PseudoFWC {
             failure: 3,
             sysPage: -1,
             side: 'LEFT',
+            cancel: false,
         },
         3400240: { // OVERSPEED FLAPS 1
             flightPhaseInhib: [2, 3, 4, 8, 9, 10],
@@ -1970,6 +1974,7 @@ export class PseudoFWC {
             failure: 3,
             sysPage: -1,
             side: 'LEFT',
+            cancel: false,
         },
         7700027: { // DUAL ENGINE FAILURE
             flightPhaseInhib: [],


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Correctly implements non-cancellable warnings (overspeed and one of the gear not down cases) so they **can** be cleared from the ECAM, but the master warning light and CRC **cannot** be cleared. The overspeed Vfe warnings are also marked as non-cancellable as they were not before.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
A32NX:
- Overspeed the plane to trigger the overspeed warning. Press the master warning button and make sure the light + CRC audio stays on. Press CLR on the ECAM control panel and make sure the overspeed warning clears, but the master warning + CRC remains. Press the master warning button again to ensure it still can't cancel the audio + light.
- Trigger a cancellable red warning... I suggest FLAPS NOT ZERO by extending flaps above FL200. Press master warning button and ensure the CRC audio + master warning light are cleared.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
