### PR TITLE
feat(nws): add better NWS hacks

### DIFF
--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/flight_model.cfg
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/flight_model.cfg
@@ -46,6 +46,7 @@ tailwheel_lock = 0 ; Is tailwheel lock available TRUE/FALSE
 max_number_of_points = 9 ; Number of contact points
 gear_locked_on_ground = 0 ; Defines whether or not the landing gear handle is locked to down when the plane is on the ground.
 gear_locked_above_speed = -1 ; Defines the speed at which the landing gear handle becomes locked in the up position. (-1 = Disabled)==> Disabled is kept in favor of an XML-based solution
+allow_stopped_steering = 1 ; This can be used to enable (TRUE, 1) steering when the aircraft is stopped or not (FALSE, 0).
 max_speed_full_steering = 300 ; Defines the speed under which the full angle of steering is available (in feet/second).==> 20 kts or 33.7 ft/sec (was 8)
 max_speed_decreasing_steering = 350 ; Defines the speed above which the angle of steering stops decreasing (in feet/second). ==> 40 kts or 67.5 ft/sec (was 50)
 min_available_steering_angle_pct = 0.0 ; Defines the percentage of steering which will always be available even above max_speed_decreasing_steering (in percent over 100) ===> 6 degrees or 0.08% of 75 degrees max deflection (was 0.2 or 15 degrees)

--- a/fbw-a32nx/src/wasm/systems/a320_systems_wasm/src/nose_wheel_steering.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems_wasm/src/nose_wheel_steering.rs
@@ -132,14 +132,28 @@ pub(super) fn nose_wheel_steering(builder: &mut MsfsAspectBuilder) -> Result<(),
 
             steering_demand_to_msfs_from_steering_angle(nose_wheel_position, rudder_position)
         },
-        Variable::aspect("STEERING_ANGLE"),
+        Variable::aspect("STEERING_ANGLE_COMMAND"),
+    );
+
+    builder.map(
+        ExecuteOn::PostTick,
+        Variable::aspect("NOSE_WHEEL_POSITION_RATIO"),
+        steering_max_demand_to_msfs_from_steering_angle,
+        Variable::aspect("STEERING_ANGLE_MAX_COMMAND"),
     );
 
     builder.variable_to_event(
-        Variable::aspect("STEERING_ANGLE"),
+        Variable::aspect("STEERING_ANGLE_COMMAND"),
         VariableToEventMapping::EventData32kPosition,
         VariableToEventWriteOn::EveryTick,
         "STEERING_SET",
+    )?;
+
+    builder.variable_to_event(
+        Variable::aspect("STEERING_ANGLE_MAX_COMMAND"),
+        VariableToEventMapping::EventData32kPosition,
+        VariableToEventWriteOn::EveryTick,
+        "NOSE_WHEEL_STEERING_LIMIT_SET",
     )?;
 
     Ok(())
@@ -180,4 +194,14 @@ fn steering_demand_to_msfs_from_steering_angle(
     // Then we hack msfs by adding the rudder value that it will always substract internally
     // This way we end up with actual angle we required
     (1. - steering_ratio_converted) + (rudder_position - 0.5)
+}
+
+fn steering_max_demand_to_msfs_from_steering_angle(nose_wheel_position: f64) -> f64 {
+    const MAX_MSFS_STEERING_ANGLE_DEGREES: f64 = 180.;
+
+    // Steering in msfs is the max we want rescaled to the max in msfs
+    nose_wheel_position.abs() * MAX_CONTROLLABLE_STEERING_ANGLE_DEGREES
+        / MAX_MSFS_STEERING_ANGLE_DEGREES
+        / 2.
+        + 0.5
 }

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/flight_model.cfg
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/flight_model.cfg
@@ -74,6 +74,7 @@ tailwheel_lock = 0 ; Is tailwheel lock available TRUE/FALSE
 max_number_of_points = 11 ; Number of contact points
 gear_locked_on_ground = 0 ; Defines whether or not the landing gear handle is locked to down when the plane is on the ground.
 gear_locked_above_speed = -1 ; Defines the speed at which the landing gear handle becomes locked in the up position. (-1 = Disabled)==> Disabled is kept in favor of an XML-based solution
+allow_stopped_steering = 1 ; This can be used to enable (TRUE, 1) steering when the aircraft is stopped or not (FALSE, 0).
 max_speed_full_steering = 300 ; Defines the speed under which the full angle of steering is available (in feet/second).==> 20 kts or 33.7 ft/sec (was 8)
 max_speed_decreasing_steering = 350 ; Defines the speed above which the angle of steering stops decreasing (in feet/second). ==> 40 kts or 67.5 ft/sec (was 50)
 min_available_steering_angle_pct = 0.0 ; Defines the percentage of steering which will always be available even above max_speed_decreasing_steering (in percent over 100) ===> 6 degrees or 0.08% of 75 degrees max deflection (was 0.2 or 15 degrees)

--- a/fbw-a380x/src/wasm/systems/a380_systems_wasm/src/nose_wheel_steering.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems_wasm/src/nose_wheel_steering.rs
@@ -132,14 +132,28 @@ pub(super) fn nose_wheel_steering(builder: &mut MsfsAspectBuilder) -> Result<(),
 
             steering_demand_to_msfs_from_steering_angle(nose_wheel_position, rudder_position)
         },
-        Variable::aspect("STEERING_ANGLE"),
+        Variable::aspect("STEERING_ANGLE_COMMAND"),
+    );
+
+    builder.map(
+        ExecuteOn::PostTick,
+        Variable::aspect("NOSE_WHEEL_POSITION_RATIO"),
+        steering_max_demand_to_msfs_from_steering_angle,
+        Variable::aspect("STEERING_ANGLE_MAX_COMMAND"),
     );
 
     builder.variable_to_event(
-        Variable::aspect("STEERING_ANGLE"),
+        Variable::aspect("STEERING_ANGLE_COMMAND"),
         VariableToEventMapping::EventData32kPosition,
         VariableToEventWriteOn::EveryTick,
         "STEERING_SET",
+    )?;
+
+    builder.variable_to_event(
+        Variable::aspect("STEERING_ANGLE_MAX_COMMAND"),
+        VariableToEventMapping::EventData32kPosition,
+        VariableToEventWriteOn::EveryTick,
+        "NOSE_WHEEL_STEERING_LIMIT_SET",
     )?;
 
     // Adds rotational speed to nose wheel based on steering angle
@@ -205,6 +219,16 @@ fn steering_demand_to_msfs_from_steering_angle(
     // Then we hack msfs by adding the rudder value that it will always substract internally
     // This way we end up with actual angle we required
     (1. - steering_ratio_converted) + (rudder_position - 0.5)
+}
+
+fn steering_max_demand_to_msfs_from_steering_angle(nose_wheel_position: f64) -> f64 {
+    const MAX_MSFS_STEERING_ANGLE_DEGREES: f64 = 180.;
+
+    // Steering in msfs is the max we want rescaled to the max in msfs
+    nose_wheel_position.abs() * MAX_CONTROLLABLE_STEERING_ANGLE_DEGREES
+        / MAX_MSFS_STEERING_ANGLE_DEGREES
+        / 2.
+        + 0.5
 }
 
 fn normalise_angle(angle: f64) -> f64 {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR fixes two things related to the NWS:
* Enables the sim NWS to move when standing still (was previously only possible visually, but not functionally)
* Enhance the previous hack required to cancel out the rudder effect on the NWS, by limiting the NWS amplitude to the commanded value. This removes jittering that happens when the rudder is moved.

NOTE: There is still the issue that when giving opposite rudder and tiller orders, the sim's NWS command due to the rudder deflection can only be cancelled, but the NWS doesn't steer in the tiller direction as it should. AFAIK. there is nothing we can do about that.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Confirm that
* There is no more slight oscillation in the taxi path when using the rudder (very noticeable when using pedal disc, but also happens when using the rudder pedals to command the NWS)
* The NWS turns at a standstill (not only visually, which it did before, but also functionally)
* The NWS otherwise works correctly (except the note above)

This was changed both on the 380 and the 320.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
