### PR TITLE
fix: Temporary fix for getAircraftType

### DIFF
--- a/fbw-common/src/systems/shared/src/aircraftTypeCheck.ts
+++ b/fbw-common/src/systems/shared/src/aircraftTypeCheck.ts
@@ -13,7 +13,8 @@ export function getAircraftType(): string {
     } else if (aircraftName.includes('A380')) {
         aircraft = 'a380x';
     } else {
-        aircraft = 'other';
+        // FIXME: temporary fix as this will be change via PF #8599 anyway
+        aircraft = 'a32nx';
     }
     return aircraft;
 }


### PR DESCRIPTION
## Summary of Changes
Temporary fix for getAircraftType - will be redone in PR #8500 or #8599 anyway.

Uses aircraft TITLE simvar which can be overwritten by liveries and is therefore not reliable. 

Discord username (if different from GitHub): cdr_maverick

## Testing instructions
not required

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
