### PR TITLE
ci: Rename workflows from 'PR' to more descriptive names 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,5 +34,5 @@ Every new commit to this PR will cause new A32NX and A380X artifacts to be creat
 
 1. Make sure you are signed in to GitHub
 1. Click on the **Checks** tab on the PR
-1. On the left side, click on the bottom **PR** tab
+1. On the left side, find and click on the **PR Build** tab
 1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,4 +1,4 @@
-name: PR Build
+name: PR Tests & Build
 on:
   pull_request:
     types:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,4 +1,4 @@
-name: PR
+name: PR Build
 on:
   pull_request:
     types:

--- a/.github/workflows/pr-semantics.yml
+++ b/.github/workflows/pr-semantics.yml
@@ -1,4 +1,4 @@
-name: PR
+name: PR Semantics
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

1. Renames the PR action for building the aircraft from 'PR' to 'PR Build' (as well as the file name) so that it is more easily locatable as some PRs may have multiple actions run under the 'PR' label, making it slightly frustrating to find the right build, especially for the QA team. This also improves visibility for working with the repository. 
This PR also updates the 'PR template text' for the new label. 

2. Renames the PR semantic titles action from 'PR' to 'PR Semantics' (as well as the file name) so that it is more identifiable in the checks tab and when working with the repository. 

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

No QA needed. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
