### PR TITLE
fix: Fixed bug in checklist to not display previous checklists as completed

### DIFF
--- a/fbw-common/src/systems/instruments/src/EFB/Checklists/Checklists.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Checklists/Checklists.tsx
@@ -42,8 +42,8 @@ export const getRelevantChecklistIndices = () => {
 
     // iterate over all checklists and check if they are relevant for the current flight phase
     aircraftChecklists.forEach((cl, clIndex) => {
-        // check if the checklist is relevant for the current flight phase
-        if (cl.flightphase && cl.flightphase === flightPhase) {
+        // check if the checklist is relevant for the previous or the current flight phase
+        if (cl.flightphase && cl.flightphase <= flightPhase) {
             relevantChecklistIndices.push(clIndex);
         }
     });


### PR DESCRIPTION
## Summary of Changes
Fixed a small bug that completed checklist in previous flight phases were no longer shown as completed in later flight phases. 

Discord username (if different from GitHub): cdr_maverick

## Testing instructions
Very simple fix - might not require a test.

If tested then check that checklists stay completed when in later flight phases and that checklist still become "relevant" when flight phases change - good example is after touchdown - this checklist is not relevant while still in the air and it is not checked for completeness (when autocomplete is on) before touchdown. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
