### PR TITLE
fix: Fixed FLX-CLB thrust limit transition

### DIFF
--- a/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/EngineControlA32NX.cpp
+++ b/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/EngineControlA32NX.cpp
@@ -1003,25 +1003,26 @@ void EngineControl_A32NX::updateThrustLimits(double                  simulationT
   flex                 = flex_to + (flex_ga - flex_to) * machFactorLow;
 
   // adaption of CLB due to FLX limit if necessary ------------------------------------------------------------------
-  bool         isFlexActive    = false;
   const double thrustLimitType = simData.thrustLimitType->get();
   if ((prevThrustLimitType != 3 && thrustLimitType == 3) || (prevFlexTemperature == 0 && flexTemp > 0)) {
     isFlexActive = true;
+    std::cout << "Flex Active" << std::endl;
   } else if ((flexTemp == 0) || (thrustLimitType == 4)) {
     isFlexActive = false;
+    std::cout << "Flex Inactive" << std::endl;
   }
 
-  double transitionStartTime = 0;
-  double transitionFactor    = 0;
   if (isFlexActive && !isTransitionActive && thrustLimitType == 1) {
     isTransitionActive  = true;
     transitionStartTime = simulationTime;
     transitionFactor    = 0.2;
+    std::cout << "Transition Active" << std::endl;
     // transitionFactor = (clb - flex) / transitionTime;
   } else if (!isFlexActive) {
     isTransitionActive  = false;
     transitionStartTime = 0;
     transitionFactor    = 0;
+    std::cout << "Transition Inactive" << std::endl;
   }
 
   double deltaThrust = 0;

--- a/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/EngineControlA32NX.cpp
+++ b/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/EngineControlA32NX.cpp
@@ -1006,23 +1006,19 @@ void EngineControl_A32NX::updateThrustLimits(double                  simulationT
   const double thrustLimitType = simData.thrustLimitType->get();
   if ((prevThrustLimitType != 3 && thrustLimitType == 3) || (prevFlexTemperature == 0 && flexTemp > 0)) {
     isFlexActive = true;
-    std::cout << "Flex Active" << std::endl;
   } else if ((flexTemp == 0) || (thrustLimitType == 4)) {
     isFlexActive = false;
-    std::cout << "Flex Inactive" << std::endl;
   }
 
   if (isFlexActive && !isTransitionActive && thrustLimitType == 1) {
     isTransitionActive  = true;
     transitionStartTime = simulationTime;
     transitionFactor    = 0.2;
-    std::cout << "Transition Active" << std::endl;
     // transitionFactor = (clb - flex) / transitionTime;
   } else if (!isFlexActive) {
     isTransitionActive  = false;
     transitionStartTime = 0;
     transitionFactor    = 0;
-    std::cout << "Transition Inactive" << std::endl;
   }
 
   double deltaThrust = 0;

--- a/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/EngineControlA32NX.h
+++ b/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/EngineControlA32NX.h
@@ -57,6 +57,11 @@ class EngineControl_A32NX {
   double prevEngineMasterPos[2] = {0, 0};
   bool prevEngineStarterState[2] = {false, false};
 
+  // FLX->CLB thrust limit transition
+  double transitionStartTime;
+  double transitionFactor;
+  bool isFlexActive = false;
+
   // additional constants
   static constexpr int MAX_OIL = 200;
   static constexpr int MIN_OIL = 140;

--- a/fbw-a380x/src/wasm/fadec_a380x/src/Fadec/EngineControl_A380X.cpp
+++ b/fbw-a380x/src/wasm/fadec_a380x/src/Fadec/EngineControl_A380X.cpp
@@ -896,7 +896,6 @@ void EngineControl_A380X::updateThrustLimits(double simulationTime,
   double       toga          = to + (ga - to) * machFactorLow;
 
   // adaption of CLB due to FLX limit if necessary ------------------------------------------------------------------
-  bool         isFlexActive    = false;
   const double thrustLimitType = simData.thrustLimitType->get();
   if ((prevThrustLimitType != 3 && thrustLimitType == 3) || (prevFlexTemperature == 0 && flexTemp > 0)) {
     isFlexActive = true;
@@ -904,8 +903,6 @@ void EngineControl_A380X::updateThrustLimits(double simulationTime,
     isFlexActive = false;
   }
 
-  double transitionStartTime = 0;
-  double transitionFactor    = 0;
   if (isFlexActive && !isTransitionActive && thrustLimitType == 1) {
     isTransitionActive  = true;
     transitionStartTime = simulationTime;

--- a/fbw-a380x/src/wasm/fadec_a380x/src/Fadec/EngineControl_A380X.h
+++ b/fbw-a380x/src/wasm/fadec_a380x/src/Fadec/EngineControl_A380X.h
@@ -51,6 +51,11 @@ class EngineControl_A380X {
   double prevFlexTemperature = 0.0;
   double prevThrustLimitType = 0.0;
 
+  // FLX->CLB thrust limit transition
+  bool isFlexActive;
+  double transitionStartTime;
+  double transitionFactor;
+
   // TODO - might not be required - feeds into stateMachine but really relevant
   double prevSimEngineN3[4] = {0.0, 0.0, 0.0, 0.0};
 


### PR DESCRIPTION
## Summary of Changes
Fixes the FLX-CLB transition which was happening instantly but should be very gradual. 

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): cdr_maverick

## Testing instructions
Check if FLX-CLB transition after a FLX takeoff when reducing to the CLB detent is slow and gradual - first there is a several seconds phase where FLX and CLB limit are still identical then CLB limit raises slowly.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
