### PR TITLE
fix: Changing A380X LVar units used in fadec to Number

### DIFF
--- a/fbw-a32nx/src/behavior/src/A32NX_Exterior.xml
+++ b/fbw-a32nx/src/behavior/src/A32NX_Exterior.xml
@@ -89,7 +89,7 @@
     <Template Name="A32NX_ENGINE_Turbine_Rotation_Template">
         <UseTemplate Name="ASOBO_GT_Anim">
             <!-- 3856 is the rated 100% N1 of the LEAP, times 6 is from RPM to deg/s, times 0.01 because percentages -->
-            <ANIM_CODE>0.01 6 3856 (L:A32NX_ENGINE_N1:#ID#, Percent) (A:ANIMATION DELTA TIME, seconds) * * * *</ANIM_CODE>
+            <ANIM_CODE>0.01 6 3856 (L:A32NX_ENGINE_N1:#ID#, Number) (A:ANIMATION DELTA TIME, seconds) * * * *</ANIM_CODE>
             <ANIM_LENGTH>360</ANIM_LENGTH>
             <ANIM_WRAP>1</ANIM_WRAP>
             <ANIM_DELTA>1</ANIM_DELTA>
@@ -97,20 +97,20 @@
     </Template>
     <Template Name="A32NX_ENGINE_Turbine_Still_Visibility_Template">
         <UseTemplate Name="ASOBO_GT_Visibility">
-            <VISIBILITY_CODE>(L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_SLOW# &lt;</VISIBILITY_CODE>
+            <VISIBILITY_CODE>(L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_SLOW# &lt;</VISIBILITY_CODE>
         </UseTemplate>
     </Template>
     <Template Name="A32NX_ENGINE_Turbine_Slow_Visibility_Template">
         <UseTemplate Name="ASOBO_GT_Visibility">
             <VISIBILITY_CODE>
-                (L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_SLOW# &gt;
-                (L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_BLUR# &lt; and
+                (L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_SLOW# &gt;
+                (L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_BLUR# &lt; and
             </VISIBILITY_CODE>
         </UseTemplate>
     </Template>
     <Template Name="A32NX_ENGINE_Turbine_Blurred_Visibility_Template">
         <UseTemplate Name="ASOBO_GT_Visibility">
-            <VISIBILITY_CODE>(L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_BLUR# &gt;</VISIBILITY_CODE>
+            <VISIBILITY_CODE>(L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_BLUR# &gt;</VISIBILITY_CODE>
         </UseTemplate>
     </Template>
     <!-- Base visibility template for turbines -->

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/engines.xml
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/engines.xml
@@ -40,7 +40,7 @@
         </DefaultTemplateParameters>
         <UseTemplate Name="ASOBO_GT_Anim">
             <!-- 385 is used for best visual appearance of the engine blur -->
-            <ANIM_CODE>0.01 385 (L:A32NX_ENGINE_N1:#ID#, Percent) * *</ANIM_CODE>
+            <ANIM_CODE>0.01 385 (L:A32NX_ENGINE_N1:#ID#, Number) * *</ANIM_CODE>
 			<ANIM_LENGTH>360</ANIM_LENGTH>
 			<ANIM_LAG>0</ANIM_LAG>
             <ANIM_WRAP>True</ANIM_WRAP>
@@ -83,36 +83,36 @@
 
     <Template Name="A380X_ENGINE_Turbine_Still_Visibility_Template">
         <UseTemplate Name="ASOBO_GT_Visibility">
-            <VISIBILITY_CODE>(L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_BLUR1# &lt;</VISIBILITY_CODE>
+            <VISIBILITY_CODE>(L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_BLUR1# &lt;</VISIBILITY_CODE>
         </UseTemplate>
     </Template>
     <Template Name="A380X_ENGINE_Turbine_Blurred1_Visibility_Template">
         <UseTemplate Name="ASOBO_GT_Visibility">
             <VISIBILITY_CODE>
-                (L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_BLUR1# &gt;=
-                (L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_BLUR2# &lt; and
+                (L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_BLUR1# &gt;=
+                (L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_BLUR2# &lt; and
             </VISIBILITY_CODE>
         </UseTemplate>
     </Template>
     <Template Name="A380X_ENGINE_Turbine_Blurred2_Visibility_Template">
         <UseTemplate Name="ASOBO_GT_Visibility">
             <VISIBILITY_CODE>
-                (L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_BLUR2# &gt;=
-                (L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_BLUR3# &lt; and
+                (L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_BLUR2# &gt;=
+                (L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_BLUR3# &lt; and
             </VISIBILITY_CODE>
         </UseTemplate>
     </Template>
     <Template Name="A380X_ENGINE_Turbine_Blurred3_Visibility_Template">
         <UseTemplate Name="ASOBO_GT_Visibility">
             <VISIBILITY_CODE>
-                (L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_BLUR3# &gt;=
-                (L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_BLUR4# &lt; and
+                (L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_BLUR3# &gt;=
+                (L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_BLUR4# &lt; and
             </VISIBILITY_CODE>
         </UseTemplate>
     </Template>
     <Template Name="A380X_ENGINE_Turbine_Blurred4_Visibility_Template">
         <UseTemplate Name="ASOBO_GT_Visibility">
-            <VISIBILITY_CODE>(L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_BLUR4# &gt;=</VISIBILITY_CODE>
+            <VISIBILITY_CODE>(L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_BLUR4# &gt;=</VISIBILITY_CODE>
         </UseTemplate>
     </Template>
     <!-- Base visibility template for turbines -->

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/legacy/generated/A32NX_Exterior.xml
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/legacy/generated/A32NX_Exterior.xml
@@ -60,7 +60,7 @@
     <Template Name="A32NX_ENGINE_Turbine_Rotation_Template">
         <UseTemplate Name="ASOBO_GT_Anim">
             <!-- 3856 is the rated 100% N1 of the LEAP, times 6 is from RPM to deg/s, times 0.01 because percentages -->
-            <ANIM_CODE>0.01 6 3856 (L:A32NX_ENGINE_N1:#ID#, Percent) (A:ANIMATION DELTA TIME, seconds) * * * *</ANIM_CODE>
+            <ANIM_CODE>0.01 6 3856 (L:A32NX_ENGINE_N1:#ID#, Number) (A:ANIMATION DELTA TIME, seconds) * * * *</ANIM_CODE>
             <ANIM_LENGTH>360</ANIM_LENGTH>
             <ANIM_WRAP>1</ANIM_WRAP>
             <ANIM_DELTA>1</ANIM_DELTA>
@@ -68,20 +68,20 @@
     </Template>
     <Template Name="A32NX_ENGINE_Turbine_Still_Visibility_Template">
         <UseTemplate Name="ASOBO_GT_Visibility">
-            <VISIBILITY_CODE>(L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_SLOW# &lt;</VISIBILITY_CODE>
+            <VISIBILITY_CODE>(L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_SLOW# &lt;</VISIBILITY_CODE>
         </UseTemplate>
     </Template>
     <Template Name="A32NX_ENGINE_Turbine_Slow_Visibility_Template">
         <UseTemplate Name="ASOBO_GT_Visibility">
             <VISIBILITY_CODE>
-                (L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_SLOW# &gt;
-                (L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_BLUR# &lt; and
+                (L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_SLOW# &gt;
+                (L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_BLUR# &lt; and
             </VISIBILITY_CODE>
         </UseTemplate>
     </Template>
     <Template Name="A32NX_ENGINE_Turbine_Blurred_Visibility_Template">
         <UseTemplate Name="ASOBO_GT_Visibility">
-            <VISIBILITY_CODE>(L:A32NX_ENGINE_N1:#ID#, Percent) #MIN_N1_PCT_FOR_BLUR# &gt;</VISIBILITY_CODE>
+            <VISIBILITY_CODE>(L:A32NX_ENGINE_N1:#ID#, Number) #MIN_N1_PCT_FOR_BLUR# &gt;</VISIBILITY_CODE>
         </UseTemplate>
     </Template>
     <!-- Base visibility template for turbines -->

--- a/fbw-a380x/src/systems/instruments/src/EWD/elements/EGT.tsx
+++ b/fbw-a380x/src/systems/instruments/src/EWD/elements/EGT.tsx
@@ -33,7 +33,7 @@ const warningEGTColor = (EGTemperature: number) => {
 };
 
 const EGT: React.FC<EGTProps> = ({ x, y, engine, active }) => {
-    const [EGTemperature] = useSimVar(`L:A32NX_ENGINE_EGT:${engine}`, 'celsius');
+    const [EGTemperature] = useSimVar(`L:A32NX_ENGINE_EGT:${engine}`, 'number');
     const radius = 68;
     const startAngle = 270;
     const endAngle = 90;

--- a/fbw-a380x/src/systems/instruments/src/EWD/elements/IgnitionBorder.tsx
+++ b/fbw-a380x/src/systems/instruments/src/EWD/elements/IgnitionBorder.tsx
@@ -3,9 +3,9 @@ import { Position, EngineNumber, FadecActive } from '@instruments/common/types';
 import React from 'react';
 
 const IgnitionBorder: React.FC<Position & EngineNumber & FadecActive> = ({ x, y, engine, active }) => {
-    const [engineState] = useSimVar(`L:A32NX_ENGINE_STATE:${engine}`, 'enum', 500);
-    const [N1Percent] = useSimVar(`L:A32NX_ENGINE_N1:${engine}`, 'percent', 100);
-    const [N1Idle] = useSimVar('L:A32NX_ENGINE_IDLE_N1', 'percent', 1000);
+    const [engineState] = useSimVar(`L:A32NX_ENGINE_STATE:${engine}`, 'number', 500);
+    const [N1Percent] = useSimVar(`L:A32NX_ENGINE_N1:${engine}`, 'number', 100);
+    const [N1Idle] = useSimVar('L:A32NX_ENGINE_IDLE_N1', 'number', 1000);
     const showBorder = !!((N1Percent < Math.floor(N1Idle) - 1) && (engineState === 2));
     // const showBorder = true;
 

--- a/fbw-a380x/src/systems/instruments/src/EWD/elements/N1.tsx
+++ b/fbw-a380x/src/systems/instruments/src/EWD/elements/N1.tsx
@@ -4,9 +4,9 @@ import { Position, EngineNumber, FadecActive, n1Degraded } from '@instruments/co
 import React from 'react';
 
 const N1: React.FC<Position & EngineNumber & FadecActive & n1Degraded> = ({ x, y, engine, active, n1Degraded }) => {
-    const [N1Percent] = useSimVar(`L:A32NX_ENGINE_N1:${engine}`, 'percent', 100);
+    const [N1Percent] = useSimVar(`L:A32NX_ENGINE_N1:${engine}`, 'number', 100);
     const N1PercentSplit = splitDecimals(N1Percent);
-    const [N1Idle] = useSimVar('L:A32NX_ENGINE_IDLE_N1', 'percent', 1000);
+    const [N1Idle] = useSimVar('L:A32NX_ENGINE_IDLE_N1', 'number', 1000);
     const [throttlePosition] = useSimVar(`L:A32NX_AUTOTHRUST_TLA_N1:${engine}`, 'number', 100);
 
     const radius = 64;

--- a/fbw-a380x/src/systems/instruments/src/EWD/elements/ThrustGauge.tsx
+++ b/fbw-a380x/src/systems/instruments/src/EWD/elements/ThrustGauge.tsx
@@ -7,8 +7,8 @@ import { Position, EngineNumber, FadecActive, n1Degraded } from '@instruments/co
 import React from 'react';
 
 const ThrustGauge: React.FC<Position & EngineNumber & FadecActive & n1Degraded> = ({ x, y, engine, active, n1Degraded }) => {
-    const [N1Percent] = useSimVar(`L:A32NX_ENGINE_N1:${engine}`, 'percent', 100);
-    const [N1Idle] = useSimVar('L:A32NX_ENGINE_IDLE_N1', 'percent', 1000);
+    const [N1Percent] = useSimVar(`L:A32NX_ENGINE_N1:${engine}`, 'number', 100);
+    const [N1Idle] = useSimVar('L:A32NX_ENGINE_IDLE_N1', 'number', 1000);
     const [Thrust] = useSimVar(`TURB ENG JET THRUST:${engine}`, 'pounds');
     const ThrustPercent = Math.round(((Thrust / 30000) * 100) * 2.8125 * 10) / 100; // Hack for now until real thrust values available
     const ThrustPercentSplit = splitDecimals(ThrustPercent);

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Engine/elements/EngineColumn.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Engine/elements/EngineColumn.tsx
@@ -14,9 +14,9 @@ interface EngineColumnProps {
 }
 
 const EngineColumn: FC<Position & EngineNumber & IgnitionActive & EngineColumnProps> = ({ x, y, engine, ignition, anyEngineRunning }) => {
-    const [N2] = useSimVar(`L:A32NX_ENGINE_N2:${engine}`, 'percent', 100); // TODO: Update with correct SimVars
-    const [N3] = useSimVar(`L:A32NX_ENGINE_N3:${engine}`, 'percent', 100); // TODO: Update with correct SimVars
-    const [starterValveOpen] = useSimVar(`L:A32NX_PNEU_ENG_${engine}_STARTER_VALVE_OPEN`, 'percent', 500); // TODO: Update with correct SimVars
+    const [N2] = useSimVar(`L:A32NX_ENGINE_N2:${engine}`, 'number', 100); // TODO: Update with correct SimVars
+    const [N3] = useSimVar(`L:A32NX_ENGINE_N3:${engine}`, 'number', 100); // TODO: Update with correct SimVars
+    const [starterValveOpen] = useSimVar(`L:A32NX_PNEU_ENG_${engine}_STARTER_VALVE_OPEN`, 'number', 500); // TODO: Update with correct SimVars
     const starting = !!(N2 < 58.5 && ignition && starterValveOpen); // TODO Should be N3
 
     const engineRunningOrIgnitionOn = ignition || anyEngineRunning;

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Engine/elements/IgnitionBorder.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Engine/elements/IgnitionBorder.tsx
@@ -3,9 +3,9 @@ import { Position, EngineNumber, IgnitionActive } from '@instruments/common/type
 import React from 'react';
 
 const IgnitionBorder: React.FC<Position & EngineNumber & IgnitionActive> = ({ x, y, engine, ignition }) => {
-    const [engineState] = useSimVar(`L:A32NX_ENGINE_STATE:${engine}`, 'bool', 500);
-    const [N1Percent] = useSimVar(`L:A32NX_ENGINE_N1:${engine}`, 'percent', 100);
-    const [N1Idle] = useSimVar('L:A32NX_ENGINE_IDLE_N1', 'percent', 1000);
+    const [engineState] = useSimVar(`L:A32NX_ENGINE_STATE:${engine}`, 'number', 500);
+    const [N1Percent] = useSimVar(`L:A32NX_ENGINE_N1:${engine}`, 'number', 100);
+    const [N1Idle] = useSimVar('L:A32NX_ENGINE_IDLE_N1', 'number', 1000);
     const showBorder = !!(N1Percent < Math.floor(N1Idle) - 1 && engineState === 2);
 
     return (

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Engine/elements/StartValve.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Engine/elements/StartValve.tsx
@@ -7,7 +7,7 @@ const StartValve: React.FC<Position & EngineNumber> = ({ x, y, engine }) => {
     const [startValveOpen] = useSimVar(`L:A32NX_PNEU_ENG_${engine}_STARTER_VALVE_OPEN`, 'boolean', 500);
     const [starterInletPressure] = useSimVar(`L:A32NX_PNEU_ENG_${engine}_STARTER_CONTAINER_PRESSURE`, 'psi', 100);
 
-    const [N2] = useSimVar(`L:A32NX_ENGINE_N2:${engine}`, 'percent', 100);
+    const [N2] = useSimVar(`L:A32NX_ENGINE_N2:${engine}`, 'number', 100);
     const showIgniter = !!(N2 > 9 && N2 < 25); // TODO Use SimVars for igniter once available
 
     return (

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Hyd/HydPage.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Hyd/HydPage.tsx
@@ -7,10 +7,10 @@ import '../../../index.scss';
 
 
 export const HydPage = () => {
-    const [engine1N3] = useSimVar('L:A32NX_ENGINE_N3:1', 'percent', 500);
-    const [engine2N3] = useSimVar('L:A32NX_ENGINE_N3:2', 'percent', 500);
-    const [engine3N3] = useSimVar('L:A32NX_ENGINE_N3:3', 'percent', 500);
-    const [engine4N3] = useSimVar('L:A32NX_ENGINE_N3:4', 'percent', 500);
+    const [engine1N3] = useSimVar('L:A32NX_ENGINE_N3:1', 'number', 500);
+    const [engine2N3] = useSimVar('L:A32NX_ENGINE_N3:2', 'number', 500);
+    const [engine3N3] = useSimVar('L:A32NX_ENGINE_N3:3', 'number', 500);
+    const [engine4N3] = useSimVar('L:A32NX_ENGINE_N3:4', 'number', 500);
     const anyEngineIsRunning = engine1N3 > 50 || engine2N3 > 50 || engine3N3 > 50 || engine4N3 > 50;
 
     return (

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Hyd/elements/Engine.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Hyd/elements/Engine.tsx
@@ -12,7 +12,7 @@ export const Engine = ({ x, y, engineNumber }: EngineProps) => {
     const hydSystem = engineNumber <= 2 ? 'GREEN' : 'YELLOW';
     const pumpIndex = (engineNumber - 1) * 2 + 1 - (engineNumber <= 2 ? 0 : 4)
 
-    const [engineState] = useSimVar(`L:A32NX_ENGINE_N3:${engineNumber}`, 'percent', 500);
+    const [engineState] = useSimVar(`L:A32NX_ENGINE_N3:${engineNumber}`, 'number', 500);
     const isRunning = engineState > 50;
 
     const [reservoirLowLevel] = useSimVar(`L:A32NX_HYD_${engineNumber <= 2 ? 'GREEN' : 'YELLOW'}_RESERVOIR_LEVEL_IS_LOW`, 'boolean', 500);

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Hyd/elements/HydraulicSystem.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Hyd/elements/HydraulicSystem.tsx
@@ -71,10 +71,10 @@ type ElecPumpProps = {
 const ElecPump = ({ x, y, label, side, systemPressureSwitch }: ElecPumpProps) => {
     const isGreen = side === 'GREEN';
 
-    const [engine1N3] = useSimVar('L:A32NX_ENGINE_N3:1', 'percent', 500);
-    const [engine2N3] = useSimVar('L:A32NX_ENGINE_N3:2', 'percent', 500);
-    const [engine3N3] = useSimVar('L:A32NX_ENGINE_N3:3', 'percent', 500);
-    const [engine4N3] = useSimVar('L:A32NX_ENGINE_N3:4', 'percent', 500);
+    const [engine1N3] = useSimVar('L:A32NX_ENGINE_N3:1', 'number', 500);
+    const [engine2N3] = useSimVar('L:A32NX_ENGINE_N3:2', 'number', 500);
+    const [engine3N3] = useSimVar('L:A32NX_ENGINE_N3:3', 'number', 500);
+    const [engine4N3] = useSimVar('L:A32NX_ENGINE_N3:4', 'number', 500);
     const anyEngineIsRunning = engine1N3 > 50 || engine2N3 > 50 || engine3N3 > 50 || engine4N3 > 50;
 
     const [isElecPumpActive] = useSimVar(`L:A32NX_HYD_${side[0]}${label}_EPUMP_ACTIVE`, 'boolean', 1000);

--- a/fbw-a380x/src/wasm/fadec_a380x/src/Fadec/FadecSimData_A380X.hpp
+++ b/fbw-a380x/src/wasm/fadec_a380x/src/Fadec/FadecSimData_A380X.hpp
@@ -125,18 +125,18 @@ class FadecSimData_A380X {
 
   // SimVars Data in one Data Definition as they are read together and never updated
   struct SimVarsData {
-    FLOAT64 animationDeltaTime;      // in Seconds
-    FLOAT64 airSpeedMach;            // in Mach
-    FLOAT64 ambientPressure;         // in Millibars
-    FLOAT64 ambientTemperature;      // in Celsius
-    FLOAT64 pressureAltitude;        // in Feet
-    FLOAT64 fuelWeightLbsPerGallon;  // in Pounds
-    FLOAT64 engineAntiIce[4];        // 0 or 1
-    FLOAT64 engineIgniter[4];        // 0 or 1
-    FLOAT64 engineStarter[4];        // 0 or 1
-    FLOAT64 simEngineCorrectedN1[4];    // in Percent
-    FLOAT64 simEngineN1[4];          // in Percent
-    FLOAT64 simEngineN2[4];          // in Percent
+    FLOAT64 animationDeltaTime;       // in Seconds
+    FLOAT64 airSpeedMach;             // in Mach
+    FLOAT64 ambientPressure;          // in Millibars
+    FLOAT64 ambientTemperature;       // in Celsius
+    FLOAT64 pressureAltitude;         // in Feet
+    FLOAT64 fuelWeightLbsPerGallon;   // in Pounds
+    FLOAT64 engineAntiIce[4];         // 0 or 1
+    FLOAT64 engineIgniter[4];         // 0 or 1
+    FLOAT64 engineStarter[4];         // 0 or 1
+    FLOAT64 simEngineCorrectedN1[4];  // in Percent
+    FLOAT64 simEngineN1[4];           // in Percent
+    FLOAT64 simEngineN2[4];           // in Percent
   };
   DataDefinitionVector simVarsDataDef = {
       {"ANIMATION DELTA TIME",         0, UNITS.Seconds  }, //
@@ -314,35 +314,35 @@ class FadecSimData_A380X {
     // TODO: consider DataDefinition for the groups tha are read/write each tick
     startState = dm->make_named_var("A32NX_START_STATE", UNITS.Number, NO_AUTO_UPDATE);
 
-    engineIdleN1  = dm->make_named_var("A32NX_ENGINE_IDLE_N1", UNITS.Percent, AUTO_READ_WRITE);
-    engineIdleN3  = dm->make_named_var("A32NX_ENGINE_IDLE_N3", UNITS.Percent, AUTO_READ_WRITE);
+    engineIdleN1  = dm->make_named_var("A32NX_ENGINE_IDLE_N1", UNITS.Number, AUTO_READ_WRITE);
+    engineIdleN3  = dm->make_named_var("A32NX_ENGINE_IDLE_N3", UNITS.Number, AUTO_READ_WRITE);
     engineIdleEGT = dm->make_named_var("A32NX_ENGINE_IDLE_EGT", UNITS.Number, AUTO_READ_WRITE);
     engineIdleFF  = dm->make_named_var("A32NX_ENGINE_IDLE_FF", UNITS.Number, AUTO_READ_WRITE);
 
-    engineState[E1] = dm->make_named_var("A32NX_ENGINE_STATE:1", UNITS.Enum, AUTO_READ_WRITE);
-    engineState[E2] = dm->make_named_var("A32NX_ENGINE_STATE:2", UNITS.Enum, AUTO_READ_WRITE);
-    engineState[E3] = dm->make_named_var("A32NX_ENGINE_STATE:3", UNITS.Enum, AUTO_READ_WRITE);
-    engineState[E4] = dm->make_named_var("A32NX_ENGINE_STATE:4", UNITS.Enum, AUTO_READ_WRITE);
+    engineState[E1] = dm->make_named_var("A32NX_ENGINE_STATE:1", UNITS.Number, AUTO_READ_WRITE);
+    engineState[E2] = dm->make_named_var("A32NX_ENGINE_STATE:2", UNITS.Number, AUTO_READ_WRITE);
+    engineState[E3] = dm->make_named_var("A32NX_ENGINE_STATE:3", UNITS.Number, AUTO_READ_WRITE);
+    engineState[E4] = dm->make_named_var("A32NX_ENGINE_STATE:4", UNITS.Number, AUTO_READ_WRITE);
 
-    engineN1[E1] = dm->make_named_var("A32NX_ENGINE_N1:1", UNITS.Percent, AUTO_READ_WRITE);
-    engineN1[E2] = dm->make_named_var("A32NX_ENGINE_N1:2", UNITS.Percent, AUTO_READ_WRITE);
-    engineN1[E3] = dm->make_named_var("A32NX_ENGINE_N1:3", UNITS.Percent, AUTO_READ_WRITE);
-    engineN1[E4] = dm->make_named_var("A32NX_ENGINE_N1:4", UNITS.Percent, AUTO_READ_WRITE);
+    engineN1[E1] = dm->make_named_var("A32NX_ENGINE_N1:1", UNITS.Number, AUTO_READ_WRITE);
+    engineN1[E2] = dm->make_named_var("A32NX_ENGINE_N1:2", UNITS.Number, AUTO_READ_WRITE);
+    engineN1[E3] = dm->make_named_var("A32NX_ENGINE_N1:3", UNITS.Number, AUTO_READ_WRITE);
+    engineN1[E4] = dm->make_named_var("A32NX_ENGINE_N1:4", UNITS.Number, AUTO_READ_WRITE);
 
-    engineN2[E1] = dm->make_named_var("A32NX_ENGINE_N2:1", UNITS.Percent, AUTO_READ_WRITE);
-    engineN2[E2] = dm->make_named_var("A32NX_ENGINE_N2:2", UNITS.Percent, AUTO_READ_WRITE);
-    engineN2[E3] = dm->make_named_var("A32NX_ENGINE_N2:3", UNITS.Percent, AUTO_READ_WRITE);
-    engineN2[E4] = dm->make_named_var("A32NX_ENGINE_N2:4", UNITS.Percent, AUTO_READ_WRITE);
+    engineN2[E1] = dm->make_named_var("A32NX_ENGINE_N2:1", UNITS.Number, AUTO_READ_WRITE);
+    engineN2[E2] = dm->make_named_var("A32NX_ENGINE_N2:2", UNITS.Number, AUTO_READ_WRITE);
+    engineN2[E3] = dm->make_named_var("A32NX_ENGINE_N2:3", UNITS.Number, AUTO_READ_WRITE);
+    engineN2[E4] = dm->make_named_var("A32NX_ENGINE_N2:4", UNITS.Number, AUTO_READ_WRITE);
 
-    engineN3[E1] = dm->make_named_var("A32NX_ENGINE_N3:1", UNITS.Percent, AUTO_READ_WRITE);
-    engineN3[E2] = dm->make_named_var("A32NX_ENGINE_N3:2", UNITS.Percent, AUTO_READ_WRITE);
-    engineN3[E3] = dm->make_named_var("A32NX_ENGINE_N3:3", UNITS.Percent, AUTO_READ_WRITE);
-    engineN3[E4] = dm->make_named_var("A32NX_ENGINE_N3:4", UNITS.Percent, AUTO_READ_WRITE);
+    engineN3[E1] = dm->make_named_var("A32NX_ENGINE_N3:1", UNITS.Number, AUTO_READ_WRITE);
+    engineN3[E2] = dm->make_named_var("A32NX_ENGINE_N3:2", UNITS.Number, AUTO_READ_WRITE);
+    engineN3[E3] = dm->make_named_var("A32NX_ENGINE_N3:3", UNITS.Number, AUTO_READ_WRITE);
+    engineN3[E4] = dm->make_named_var("A32NX_ENGINE_N3:4", UNITS.Number, AUTO_READ_WRITE);
 
-    engineEgt[E1] = dm->make_named_var("A32NX_ENGINE_EGT:1", UNITS.Celsius, AUTO_READ_WRITE);
-    engineEgt[E2] = dm->make_named_var("A32NX_ENGINE_EGT:2", UNITS.Celsius, AUTO_READ_WRITE);
-    engineEgt[E3] = dm->make_named_var("A32NX_ENGINE_EGT:3", UNITS.Celsius, AUTO_READ_WRITE);
-    engineEgt[E4] = dm->make_named_var("A32NX_ENGINE_EGT:4", UNITS.Celsius, AUTO_READ_WRITE);
+    engineEgt[E1] = dm->make_named_var("A32NX_ENGINE_EGT:1", UNITS.Number, AUTO_READ_WRITE);
+    engineEgt[E2] = dm->make_named_var("A32NX_ENGINE_EGT:2", UNITS.Number, AUTO_READ_WRITE);
+    engineEgt[E3] = dm->make_named_var("A32NX_ENGINE_EGT:3", UNITS.Number, AUTO_READ_WRITE);
+    engineEgt[E4] = dm->make_named_var("A32NX_ENGINE_EGT:4", UNITS.Number, AUTO_READ_WRITE);
 
     engineFF[E1] = dm->make_named_var("A32NX_ENGINE_FF:1", UNITS.Number, AUTO_READ_WRITE);
     engineFF[E2] = dm->make_named_var("A32NX_ENGINE_FF:2", UNITS.Number, AUTO_READ_WRITE);
@@ -374,17 +374,17 @@ class FadecSimData_A380X {
     engineTimer[E3] = dm->make_named_var("A32NX_ENGINE_TIMER:3", UNITS.Number, AUTO_READ_WRITE);
     engineTimer[E4] = dm->make_named_var("A32NX_ENGINE_TIMER:4", UNITS.Number, AUTO_READ_WRITE);
 
-    fuelLeftOuterPre  = dm->make_named_var("A32NX_FUEL_LEFTOUTER_PRE", UNITS.Pounds, AUTO_READ_WRITE);
-    fuelFeedOnePre    = dm->make_named_var("A32NX_FUEL_FEED1_PRE", UNITS.Pounds, AUTO_READ_WRITE);
-    fuelLeftMidPre    = dm->make_named_var("A32NX_FUEL_LEFTMID_PRE", UNITS.Pounds, AUTO_READ_WRITE);
-    fuelLeftInnerPre  = dm->make_named_var("A32NX_FUEL_LEFTINNER_PRE", UNITS.Pounds, AUTO_READ_WRITE);
-    fuelFeedTwoPre    = dm->make_named_var("A32NX_FUEL_FEED2_PRE", UNITS.Pounds, AUTO_READ_WRITE);
-    fuelFeedThreePre  = dm->make_named_var("A32NX_FUEL_FEED3_PRE", UNITS.Pounds, AUTO_READ_WRITE);
-    fuelRightInnerPre = dm->make_named_var("A32NX_FUEL_RIGHTINNER_PRE", UNITS.Pounds, AUTO_READ_WRITE);
-    fuelRightMidPre   = dm->make_named_var("A32NX_FUEL_RIGHTMID_PRE", UNITS.Pounds, AUTO_READ_WRITE);
-    fuelFeedFourPre   = dm->make_named_var("A32NX_FUEL_FEED4_PRE", UNITS.Pounds, AUTO_READ_WRITE);
-    fuelRightOuterPre = dm->make_named_var("A32NX_FUEL_RIGHTOUTER_PRE", UNITS.Pounds, AUTO_READ_WRITE);
-    fuelTrimPre       = dm->make_named_var("A32NX_FUEL_TRIM_PRE", UNITS.Pounds, AUTO_READ_WRITE);
+    fuelLeftOuterPre  = dm->make_named_var("A32NX_FUEL_LEFTOUTER_PRE", UNITS.Number, AUTO_READ_WRITE);
+    fuelFeedOnePre    = dm->make_named_var("A32NX_FUEL_FEED1_PRE", UNITS.Number, AUTO_READ_WRITE);
+    fuelLeftMidPre    = dm->make_named_var("A32NX_FUEL_LEFTMID_PRE", UNITS.Number, AUTO_READ_WRITE);
+    fuelLeftInnerPre  = dm->make_named_var("A32NX_FUEL_LEFTINNER_PRE", UNITS.Number, AUTO_READ_WRITE);
+    fuelFeedTwoPre    = dm->make_named_var("A32NX_FUEL_FEED2_PRE", UNITS.Number, AUTO_READ_WRITE);
+    fuelFeedThreePre  = dm->make_named_var("A32NX_FUEL_FEED3_PRE", UNITS.Number, AUTO_READ_WRITE);
+    fuelRightInnerPre = dm->make_named_var("A32NX_FUEL_RIGHTINNER_PRE", UNITS.Number, AUTO_READ_WRITE);
+    fuelRightMidPre   = dm->make_named_var("A32NX_FUEL_RIGHTMID_PRE", UNITS.Number, AUTO_READ_WRITE);
+    fuelFeedFourPre   = dm->make_named_var("A32NX_FUEL_FEED4_PRE", UNITS.Number, AUTO_READ_WRITE);
+    fuelRightOuterPre = dm->make_named_var("A32NX_FUEL_RIGHTOUTER_PRE", UNITS.Number, AUTO_READ_WRITE);
+    fuelTrimPre       = dm->make_named_var("A32NX_FUEL_TRIM_PRE", UNITS.Number, AUTO_READ_WRITE);
 
     fuelPumpState[E1] = dm->make_named_var("A32NX_PUMP_STATE:1", UNITS.Number, AUTO_READ_WRITE);
     fuelPumpState[E2] = dm->make_named_var("A32NX_PUMP_STATE:2", UNITS.Number, AUTO_READ_WRITE);


### PR DESCRIPTION
## Summary of Changes
Changes the units for LVars used in the fadec rewrite to "Number" and fixing all related usages of these vars. 

Also changes A32NX and A380X turbine rotation animation behavior XML to use unit Number.

In general the team has decided to only use "Number" for LVars going forward and refactor existing non-number LVars at a later point in time. 

Discord username (if different from GitHub): cdr_maverick

## Video
before:
https://github.com/flybywiresim/aircraft/assets/16833201/f7fa29b0-9e2e-4010-8147-4650afcb95e4

after:
https://github.com/flybywiresim/aircraft/assets/16833201/d9cb1153-32c6-4577-9977-4a34f29654f7

## Testing instructions
A32NX:
Check turbine rotation animation for different N1 - best visible when starting or shutting down. 
Compare to current master to see if improved 

A380X
Check the Fadec related systems:
* EWD / SD
  * Thrust Limits
  * N1-3 values
  * FF values
  * Oil qty
  * ...
* other systems depending on these values - e.g. VNAV might use thrust limits, etc. 

Check turbine rotation animation for different N1 - best visible when starting or shutting down. 

This best tested together with other current PRs in the exp branch (@flogross89)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
