### PR TITLE
build: fixed igniter cache config for cpp wasm

### DIFF
--- a/fbw-common/src/wasm/cpp-msfs-framework/cmake/TargetDefinition.cmake
+++ b/fbw-common/src/wasm/cpp-msfs-framework/cmake/TargetDefinition.cmake
@@ -23,7 +23,6 @@ macro(add_wasm_library)
         # we use `cp` to copy the unoptimized wasm file to the output directory
         set(WASM_OPT_FULL_CMD cp ${CMAKE_CURRENT_BINARY_DIR}/${ADD_WASM_LIBRARY_NAME}.wasm ${OUTPUT_DIRECTORY}/)
     else()
-        # FIXME: 20231111 setting optimization to other than -o0 causes the wasm to crash
         set(WASM_LD_ARGS -O2 --lto-O2 --strip-debug)
         set(WASM_OPT_FLAGS -O1 --signext-lowering)
         set(WASM_OPT_FULL_CMD ${CMAKE_WASM_OPTIMIZER} ${WASM_OPT_FLAGS} -o ${OUTPUT_DIRECTORY}/${ADD_WASM_LIBRARY_NAME}.wasm ${CMAKE_CURRENT_BINARY_DIR}/${ADD_WASM_LIBRARY_NAME}.wasm)

--- a/igniter.config.mjs
+++ b/igniter.config.mjs
@@ -130,7 +130,7 @@ export default new TaskOfTasks("all", [
                 [
                     'fbw-common/src/wasm/cpp-msfs-framework',
                     'fbw-common/src/wasm/extra-backend',
-                    'fbw-common/src/wasm/fadec_common_v2',
+                    'fbw-common/src/wasm/fadec_common',
                     'fbw-a32nx/src/wasm/extra-backend-a32nx',
                     'fbw-a32nx/src/wasm/fadec_a32nx',
                     'fbw-a32nx/out/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/panel/extra-backend-a32nx.wasm',
@@ -209,11 +209,11 @@ export default new TaskOfTasks("all", [
                 [
                     'fbw-common/src/wasm/cpp-msfs-framework',
                     'fbw-common/src/wasm/extra-backend',
-                    'fbw-common/src/wasm/fadec_common_v2',
+                    'fbw-common/src/wasm/fadec_common',
                     'fbw-a380x/src/wasm/extra-backend-a380x',
                     'fbw-a380x/src/wasm/fadec_a380x',
                     'fbw-a380x/out/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/panel/extra-backend-a380x.wasm',
-                    'fbw-a32nx/out/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/panel/fadec-a380x.wasm'
+                    'fbw-a380x/out/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/panel/fadec-a380x.wasm'
                 ]),
         ], true),
 


### PR DESCRIPTION
## Summary of Changes
cpp-wasm-cmake task was running every time due to a config mistake. 
This PR fixes it.

Still the A380X PFD build is triggered every time - haven't found a cause yet.

Discord username (if different from GitHub): cdr_maverick

## Testing instructions
n/a - build only 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
