### PR TITLE
fix(fadec): fuel consumption at higher simrates

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -13,8 +13,8 @@
                 "${workspaceFolder}/fbw-common/src/wasm/extra-backend/**",
                 "${workspaceFolder}/fbw-a32nx/src/wasm/extra-backend-a32nx/src/**",
                 "${workspaceFolder}/fbw-a380x/src/wasm/extra-backend-a380x/src/**",
-                "${workspaceFolder}/fbw-a32nx/src/wasm/fadec_a320/src/**",
-                "${workspaceFolder}/fbw-a380x/src/wasm/fadec_a380/src/**"           ],
+                "${workspaceFolder}/fbw-common/src/wasm/fadec_common/src"
+            ],
             "defines": [
                 "_MSFS_WASM=1",
                 "__wasi__",
@@ -24,8 +24,8 @@
             ],
             "windowsSdkVersion": "10.0.18362.0",
             "compilerArgs": [
-              "--sysroot ${MSFS_SDK}/WASM/wasi-sysroot",
-              "-target wasm32-unknown-wasi"
+                "--sysroot ${MSFS_SDK}/WASM/wasi-sysroot",
+                "-target wasm32-unknown-wasi"
             ],
             "cStandard": "c17",
             "cppStandard": "c++20",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ add_definitions(
     -DNO_PROFILING
     # disable MSFS header min/max macros which clobber std::min/max
     -DNOMINMAX
+    # MSFS stdlib uses 64-bit off_t for lseek etc.
+    -D_FILE_OFFSET_BITS=64
 )
 
 # add the common components

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ add_definitions(
     -DNO_EXAMPLES
     #PROFILING | NO_PROFILING - for logging of profiling information of pre-, post-, update() calls
     -DNO_PROFILING
+    # disable MSFS header min/max macros which clobber std::min/max
+    -DNOMINMAX
 )
 
 # add the common components

--- a/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/EngineControlA32NX.h
+++ b/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/EngineControlA32NX.h
@@ -113,9 +113,8 @@ class EngineControl_A32NX {
 
   /**
    * @brief Updates the EngineControl_A32NX class once per frame.
-   * @param pData
    */
-  void update(sGaugeDrawData* pData);
+  void update();
 
   /**
    * @brief Shuts down the EngineControl_A32NX class once during the gauge shutdown.

--- a/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/Fadec_A32NX.cpp
+++ b/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/Fadec_A32NX.cpp
@@ -11,13 +11,13 @@ bool Fadec_A32NX::initialize() {
   return true;
 }
 
-bool Fadec_A32NX::update(sGaugeDrawData* pData) {
+bool Fadec_A32NX::update([[maybe_unused]] sGaugeDrawData* pData) {
   if (!_isInitialized) {
     std::cerr << "Fadec_A32NX::update() - not initialized" << std::endl;
     return false;
   }
 
-  engineControl.update(pData);
+  engineControl.update();
 
   return true;
 }

--- a/fbw-a380x/src/wasm/fadec_a380x/src/Fadec/EngineControl_A380X.cpp
+++ b/fbw-a380x/src/wasm/fadec_a380x/src/Fadec/EngineControl_A380X.cpp
@@ -13,6 +13,8 @@
 #include "Table1502_A380X.hpp"
 #include "ThrustLimits_A380X.hpp"
 
+#include <algorithm>
+
 void EngineControl_A380X::initialize(MsfsHandler* msfsHandler) {
   this->msfsHandlerPtr = msfsHandler;
   this->dataManagerPtr = &msfsHandler->getDataManager();
@@ -24,7 +26,7 @@ void EngineControl_A380X::shutdown() {
   LOG_INFO("Fadec::EngineControl_A380X::shutdown()");
 }
 
-void EngineControl_A380X::update(sGaugeDrawData* pData) {
+void EngineControl_A380X::update() {
 #ifdef PROFILING
   profilerUpdate.start();
 #endif
@@ -42,7 +44,7 @@ void EngineControl_A380X::update(sGaugeDrawData* pData) {
     return;
   }
 
-  const double deltaTime          = pData->dt;
+  const double deltaTime          = std::max(0.002, msfsHandlerPtr->getSimulationDeltaTime());
   const double mach               = simData.simVarsDataPtr->data().airSpeedMach;
   const double pressureAltitude   = simData.simVarsDataPtr->data().pressureAltitude;
   const double ambientTemperature = simData.simVarsDataPtr->data().ambientTemperature;
@@ -485,7 +487,7 @@ int EngineControl_A380X::updateFF(int    engine,
   // Checking Fuel Logic and final Fuel Flow
   double outFlow = 0;  // kg/hour
   if (correctedFuelFlow >= 1) {
-    outFlow = (std::max)(0.0,                                                                                  //
+    outFlow = std::max(0.0,                                                                                  //
                          (correctedFuelFlow * Fadec::LBS_TO_KGS * EngineRatios::delta2(mach, ambientPressure)  //
                           * (std::sqrt)(EngineRatios::theta2(mach, ambientTemperature))));
   }

--- a/fbw-a380x/src/wasm/fadec_a380x/src/Fadec/EngineControl_A380X.h
+++ b/fbw-a380x/src/wasm/fadec_a380x/src/Fadec/EngineControl_A380X.h
@@ -108,9 +108,8 @@ class EngineControl_A380X {
 
   /**
    * @brief Updates the EngineControl_A32NX class once per frame.
-   * @param pData
    */
-  void update(sGaugeDrawData* pData);
+  void update();
 
   /**
    * @brief Shuts down the EngineControl_A32NX class once during the gauge shutdown.

--- a/fbw-a380x/src/wasm/fadec_a380x/src/Fadec/Fadec_A380X.cpp
+++ b/fbw-a380x/src/wasm/fadec_a380x/src/Fadec/Fadec_A380X.cpp
@@ -17,7 +17,7 @@ bool Fadec_A380X::update([[maybe_unused]] sGaugeDrawData* pData) {
     return false;
   }
 
-  engineControl.update(pData);
+  engineControl.update();
 
   return true;
 }

--- a/fbw-common/src/wasm/cpp-msfs-framework/MsfsHandler/MsfsHandler.cpp
+++ b/fbw-common/src/wasm/cpp-msfs-framework/MsfsHandler/MsfsHandler.cpp
@@ -117,11 +117,14 @@ bool MsfsHandler::update(sGaugeDrawData* pData) {
   // active pause with just the aircraft not moving.
   // See the comments above for the different pause states.
   if (a32nxPauseDetected->getAsInt64() > 0 && a32nxPauseDetected->getAsInt64() != 4) {
+    simulationDeltaTime = 0.;
     return true;
   }
 
   // read and update base data from sim
+  FLOAT64 previousTimeStamp = timeStamp;
   timeStamp = baseSimData->data().simulationTime;
+  simulationDeltaTime = std::max(0., timeStamp - previousTimeStamp);
   tickCounter++;
 
   // Call preUpdate(), update() and postUpdate() for all modules

--- a/fbw-common/src/wasm/cpp-msfs-framework/MsfsHandler/MsfsHandler.h
+++ b/fbw-common/src/wasm/cpp-msfs-framework/MsfsHandler/MsfsHandler.h
@@ -90,6 +90,9 @@ class MsfsHandler {
    */
   FLOAT64 timeStamp{};
 
+  /** The difference in sim time (including sim rate) since the last update, in seconds. */
+  FLOAT64 simulationDeltaTime{};
+
   /**
    * Counts the number of ticks since start instance creation (calls to update). Used to
    * tick stamping the variable updates.
@@ -161,6 +164,12 @@ class MsfsHandler {
    * @return current simulation time in seconds
    */
   [[nodiscard]] FLOAT64 getSimulationTime() const { return baseSimData->data().simulationTime; }
+
+  /**
+   * @return The difference in sim time (accounting for sim rate) since the last update, in seconds.
+   * @note This can return 0, and will return 0 when paused.
+   */
+  [[nodiscard]] FLOAT64 getSimulationDeltaTime() const { return simulationDeltaTime; }
 
   /**
    * @return current simulation rate

--- a/scripts/build-cmake.sh
+++ b/scripts/build-cmake.sh
@@ -7,6 +7,9 @@
 # Use set +x and set +v to turn off the above settings
 #set -x
 
+# exit early with status if the script fails
+set -e
+
 # get directory of this script relative to root
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 pushd "${DIR}" || exit
@@ -53,8 +56,8 @@ wasm-ld --version
 echo ""
 
 echo "Building extra-backend with CMAKE..."
-cmake -DCMAKE_TOOLCHAIN_FILE=scripts/cmake/DockerToolchain.cmake -B${OUTPUT_DIR} -DCMAKE_BUILD_TYPE=${CONFIG} ../ || (echo "CMake config failed" && exit 1)
-cmake --build ${OUTPUT_DIR} --config ${CONFIG} ${CLEAN} -j ${PARALLEL} || (echo "CMake build failed" && exit 1)
+cmake -DCMAKE_TOOLCHAIN_FILE=scripts/cmake/DockerToolchain.cmake -B${OUTPUT_DIR} -DCMAKE_BUILD_TYPE=${CONFIG} ../ || (echo "CMake config failed"; exit 1)
+cmake --build ${OUTPUT_DIR} --config ${CONFIG} ${CLEAN} -j ${PARALLEL} || (echo "CMake build failed"; exit 1)
 echo ""
 
 echo "WASM module built successfully!"


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Makes some fixes to build env. and scripts, especially ensuring the igniter build fails when the cmake script or build fails.
- Adds a new simulation delta time to the C++ framework, which works similarly to the delta time in the old FADEC, accounting for simrate.
- Fixes the delta time used for FADEC calculations to use the sim-rate dependent simulation delta time.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Note: I recommend https://flightsim.to/file/45543/sim-rate-selector for controlling the sim rate if you don't already have a convenient means of doing so.

- Setup a flight at a cruise level in ISA weather (clear skies preset is okay), and achieve stable flight with the AP and ATHR ON.
- Use the chrono to time how long it takes to consume a given quantity of fuel with simrate at 1x (suggest 100 kg or more). The FOB on the EWD is good enough if you pick a fuel quantity of at least 100 kg.
- Increase the simrate to 4x
- Use the chrono to time how long it takes to consume the same quantity of fuel with simrate at 4x.
- The chrono time should be approximately the same, as the chrono will run at 4x wallclock time when the simrate is 4x.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
