### PR TITLE
fix(a380x): disable lower ISIS temporarily

### DIFF
--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/panel/panel.cfg
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/panel/panel.cfg
@@ -92,7 +92,8 @@ size_mm=512,512
 pixel_size=512,512
 texture=$ISIS2
 
-htmlgauge00=A32NX/ISIS/isis.html, 0,0,512,512
+;htmlgauge00=A32NX/ISIS/isis.html, 0,0,512,512
+; FIXME re-enable second ISIS when A380X ISIS implementation is in place
 
 [VCockpit12]
 size_mm=256,256


### PR DESCRIPTION
**A380X only, no QA needed.**

## Summary of Changes
Disable lower ISIS, until implementation of A380X ISIS is in place.
(to avoid two identical ISIS being shown)

## Screenshots (if necessary)
n/a

## References
none

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
