### PR TITLE
feat(a380x): true/mag button

### DIFF
--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/fcu.xml
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/fcu.xml
@@ -60,6 +60,16 @@
             <TOOLTIPID>%((A:AUTOPILOT MANAGED SPEED IN MACH, Bool))%{if}TT:COCKPIT.TOOLTIPS.AUTOPILOT_PANEL_SPD_MACH%{else}TT:COCKPIT.TOOLTIPS.AUTOPILOT_PANEL_SPD_KNOT%{end}</TOOLTIPID>
         </UseTemplate>
 
+        <UseTemplate Name="FBW_AUTOPILOT_Push_Template">
+            <NODE_ID>PUSH_FCU_TRUEMAG</NODE_ID>
+            <TOOLTIPID>%((L:A32NX_PUSH_TRUE_REF, bool))%{if}TT:COCKPIT.TOOLTIPS.AUTOPILOT_PANEL_AP_ON%{else}TT:COCKPIT.TOOLTIPS.AUTOPILOT_PANEL_AP_OFF%{end}</TOOLTIPID>
+
+            <NO_INDICATOR>True</NO_INDICATOR>
+            <NO_TEXT_EMISSIVE>True</NO_TEXT_EMISSIVE>
+
+            <LEFT_SINGLE_CODE>(&gt;H:A320_Neo_FCU_TRUEMAG_PUSH)</LEFT_SINGLE_CODE>
+        </UseTemplate>
+
         <!-- LOC pb -->
         <UseTemplate Name="FBW_A380X_BacklightIndicator_Button_Template">
             <NODE_ID>PUSH_FCU_LOC</NODE_ID>

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/html_ui/Pages/VCockpit/Instruments/LegacyA380X/FCU/A380_FCU.js
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/html_ui/Pages/VCockpit/Instruments/LegacyA380X/FCU/A380_FCU.js
@@ -532,6 +532,8 @@ class A320_Neo_FCU_Autopilot extends A320_Neo_FCU_Component {
             SimVar.SetSimVarValue('K:A32NX.FCU_APPR_PUSH', 'number', 0);
         } else if (_event === 'EXPED_PUSH') {
             SimVar.SetSimVarValue('K:A32NX.FCU_EXPED_PUSH', 'number', 0);
+        } else if (_event === 'TRUEMAG_PUSH') {
+          SimVar.SetSimVarValue('L:A32NX_PUSH_TRUE_REF', 'bool', !SimVar.GetSimVarValue('L:A32NX_PUSH_TRUE_REF', 'bool'));
         }
     }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Clear out the git stash... Adds the TRUE/MAG button on the FCU.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Spawn in a region at lower latitude (so the magnetic database is available). Press the true/mag button and ensure the PFD and ND switch to true ref mode. Press it again and make sure they switch back.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
