### PR TITLE
fix(nd): fix active leg navaid color

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -92,6 +92,7 @@
 1. [EFCS] Fix ground spoiler retraction after increasing TLA slightly above 0 - @lukecologne (luke)
 1. [FWC] Improved LDG LT memo to take into account light position - @BravoMike99 (bruno_pt99)
 1. [PRESS] Add pressurization system failures - @mjuhe (Miquel Juhe)
+1. [ND] Fix color of navaids at the active leg termination - @BlueberryKing (BlueberryKing)
 
 ## 0.11.0
 

--- a/fbw-common/src/systems/instruments/src/ND/shared/map/WaypointLayer.ts
+++ b/fbw-common/src/systems/instruments/src/ND/shared/map/WaypointLayer.ts
@@ -116,17 +116,15 @@ export class WaypointLayer implements MapLayer<NdSymbol> {
     y: number,
     symbol: NdSymbol,
   ) {
-    let mainColor;
+    let mainColor = '#000';
     if (isColorLayer) {
-      if (symbol.type & NdSymbolTypeFlags.ActiveLegTermination) {
-        mainColor = '#fff';
-      } else if (symbol.type & NdSymbolTypeFlags.Tuned) {
+      if (symbol.type & NdSymbolTypeFlags.Tuned) {
         mainColor = '#0ff';
+      } else if (symbol.type & NdSymbolTypeFlags.ActiveLegTermination) {
+        mainColor = '#fff';
       } else {
         mainColor = '#ff94ff';
       }
-    } else {
-      mainColor = '#000';
     }
 
     if (symbol.type & NdSymbolTypeFlags.VorDme) {

--- a/fbw-common/src/systems/instruments/src/ND/shared/map/WaypointLayer.ts
+++ b/fbw-common/src/systems/instruments/src/ND/shared/map/WaypointLayer.ts
@@ -120,8 +120,6 @@ export class WaypointLayer implements MapLayer<NdSymbol> {
     if (isColorLayer) {
       if (symbol.type & NdSymbolTypeFlags.Tuned) {
         mainColor = '#0ff';
-      } else if (symbol.type & NdSymbolTypeFlags.ActiveLegTermination) {
-        mainColor = '#fff';
       } else {
         mainColor = '#ff94ff';
       }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8691

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Previously, when the active leg termination was a tuned navaid, the symbol appeared in white. This is incorrect, tuned navaids should appear in cyan. This PR fixes it.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://github.com/flybywiresim/aircraft/assets/22713769/38bf68ec-1d2b-4ac3-8f6f-c741d24b2e25)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
see issue #8691 

## Additional context
<!-- Add any other context about the pull request here. -->
There are more errors in the ND symbology. For example, symbols from the EFIS overlay should be behind flightplan symbols. I don't have the capacity to fix these issues at the moment, so I will restrict the PR to this small fix.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Load up on the runway, tune navaids on the RAD NAV page, make sure they appear in cyan.
- Make tuned navaids the active leg by using a DIR TO for example, check that the navaid is still cyan.
- Check different combinations of EFIS filters, active waypoints and tuned navaids.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
