### PR TITLE
fix: simbrief auto-import spam

### DIFF
--- a/fbw-common/src/systems/instruments/src/EFB/Apis/Navigraph/Components/Authentication.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Apis/Navigraph/Components/Authentication.tsx
@@ -28,10 +28,12 @@ export type NavigraphAuthInfo =
     };
 
 export const useNavigraphAuthInfo = (): NavigraphAuthInfo => {
+  const [info, setInfo] = useState<NavigraphAuthInfo>({ loggedIn: false });
+
   const navigraphAuth = useNavigraphAuth();
 
-  if (navigraphAuth.user) {
-    return {
+  if (navigraphAuth.user && info.loggedIn === false) {
+    setInfo({
       loggedIn: true,
       username: navigraphAuth.user.preferred_username,
       subscriptionStatus: [NAVIGRAPH_SUBSCRIPTION_CHARTS, NAVIGRAPH_SUBSCRIPTION_FMSDATA].every((it) =>
@@ -39,10 +41,12 @@ export const useNavigraphAuthInfo = (): NavigraphAuthInfo => {
       )
         ? NavigraphSubscriptionStatus.Unlimited
         : NavigraphSubscriptionStatus.Unknown,
-    };
+    });
+  } else if (!navigraphAuth.user && info.loggedIn === true) {
+    setInfo({ loggedIn: false });
   }
 
-  return { loggedIn: false };
+  return info;
 };
 
 interface LoadingProps {

--- a/fbw-common/src/systems/instruments/src/EFB/Dashboard/Widgets/FlightWidget.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Dashboard/Widgets/FlightWidget.tsx
@@ -151,7 +151,7 @@ export const FlightWidget = () => {
     ) {
       fetchData();
     }
-  }, [navigraphAuthInfo]);
+  }, [navigraphAuthInfo.loggedIn]);
 
   const simbriefDataLoaded = isSimbriefDataLoaded();
 


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

- Corrects the `useNavigraphAuthInfo` hook to not create a new auth info object instance every render
- Corretcs the `useEffect` handling simbrief auto-import to only fire when the auth state changes

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

- Ensure SimBrief auto-import works correctly when the associated SimBrief account (both navigraph login and override ID) has no active OFP (no notification spam)
- Ensure SimBrief manual import works correctly

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
