### PR TITLE
fix(fms): fix crash when uplinking DCT route

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/new/uplink/CoRouteUplinkAdapter.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/new/uplink/CoRouteUplinkAdapter.ts
@@ -360,7 +360,8 @@ export class CoRouteUplinkAdapter {
   static generateRouteInstructionsFromNavlog(ofp: CoRoute): OfpRouteChunk[] {
     const instructions: OfpRouteChunk[] = [];
 
-    for (let i = 0; i < ofp.navlog.length; i++) {
+    // `navlog` is undefined when the route is DCT
+    for (let i = 0; i < ofp.navlog?.length ?? 0; i++) {
       const lastFix = ofp.navlog[i - 1];
       const fix = ofp.navlog[i];
 

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/new/uplink/SimBriefUplinkAdapter.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/new/uplink/SimBriefUplinkAdapter.ts
@@ -482,7 +482,8 @@ export class SimBriefUplinkAdapter {
   static generateRouteInstructionsFromNavlog(ofp: ISimbriefData): OfpRouteChunk[] {
     const instructions: OfpRouteChunk[] = [];
 
-    for (let i = 0; i < ofp.navlog.length; i++) {
+    // `navlog` is undefined when the route is DCT
+    for (let i = 0; i < ofp.navlog?.length ?? 0; i++) {
       const lastFix = ofp.navlog[i - 1];
       const fix = ofp.navlog[i];
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This fixes an FMS crash when the route uplinked from SimBrief is DCT without waypoints. A Discord user found this on a WMKK-WSSS routing.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Generate a route without any waypoints in between
- Uplink using INIT REQUEST
- Make sure the route is uplinked normally

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
