### PR TITLE
fix(fms): fix vnav crash on steep approaches

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -106,8 +106,9 @@
 1. [EFB] Added a takeoff performance calculator - @donstim (donbikes), @tracernz (Mike)
 1. [MCDU] Removed V-speed auto-fill function - @tracernz (Mike)
 1. [PFD] Implement alerts within artificial horizon (ROP, ROW, OANS, stall, windshear) @flogross89 (Flo)
-1. [MCDU] Fixed ZFW Autofill with lbs during boarding @ShreyasKallingal 
+1. [MCDU] Fixed ZFW Autofill with lbs during boarding @ShreyasKallingal
 1. [FWC] Fix NW STRG DISC turning amber too soon - @adoggman (Andrew)
+1. [FMS] Fix VNAV crash for steep approaches - @BlueberryKing (BlueberryKing)
 
 ## 0.11.0
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Previously, the FMS would produce nonsensical predictions if an approach with a steeper-than-normal (>3.5°) final approach was selected. This PR fixes this behavior. Note that the TOO STEEP PATH message is not implemented in this PR, this is merely meant to be an improvement over the current behavior.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://github.com/user-attachments/assets/aadf6634-f2b8-4657-bb73-9e179cc45df8)
![image](https://github.com/user-attachments/assets/ac584201-e3bd-4b84-9a07-b419901204ff)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Perform a full flight to ending in an approach with final approach gradient >3.5°. Ensure predictions in the FMS and on the ND are reasonable throughout the flight and managed descent can be used.

Some example destination airports are LOWI, LFML, EGLC, ENTC.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
