### PR TITLE
fix(a380): various W/B fixes

### DIFF
--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/flight_model.cfg
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/flight_model.cfg
@@ -15,7 +15,7 @@
 
 ; 19 Jul 2024 - Adjust CG, wheels and fuel tanks to correct model origin to Airbus reference datum offset
 ; The position of the nose in the model coord. system is 35.1927m. The Airbus reference datum distance from the nose is 7.33m.
-; So, the conversion from HArm value to model coordinates in m is: model_coord = (35.1927 + 7.33) - harm_value
+; So, the conversion from HArm value to model coordinates in m is: model_coord = (35.1927m + 7.33m) - harm_value
 
 [VERSION]
 major = 1

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/flight_model.cfg
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/flight_model.cfg
@@ -24,9 +24,9 @@ minor = 0
 ; Maximum Landing Weight (MLW) 395,000 kg, 870,826 lb
 ; Maximum Zero Fuel Weight (MZFW) 373,000 kg, 822,324 lb (360,000 kg/793,663 lb at fwd CG)
 max_gross_weight = 1124355 ; Max takeoff weight, (LBS)
-empty_weight = 629023; Empty weight, (LBS)
+empty_weight = 661403; Empty weight, (LBS)
 reference_datum_position = 0, 0, 0 ; Position of reference datum relative to FS(0,0,0) (FEET), z, x, y
-empty_weight_CG_position = 5.52, 0, 2.8 ; Position of airplane empty weight CG relative to reference datum (FEET), z, x, y Should give empty weight cg of 36.2%RC
+empty_weight_CG_position = 6.47, 0, 2.8 ; Position of airplane empty weight CG relative to reference datum (FEET), z, x, y Should give empty weight cg of 36.2%RC
 CG_forward_limit = 0.28 ; Gravity center forward limit (longitudinal offset) for longitudinal stability
 CG_aft_limit = 0.44 ; Gravity center after limit (longitudinal offset z) w.r.t reference datum for longitudinal stability (FEET)
 empty_weight_pitch_MOI = 79112140 ; Empty pitch moment of inertia, Jxx (SLUG SQ FEET)
@@ -102,11 +102,13 @@ spring_exponential_fix = 1; Activates MSFS new spring formula
 ;14 The airspeed limit for gears retraction, in kias.
 ;15 Airspeed above which gear is damaged, in kias.
 ;16 The exponential constant for springs
-point.0 = 1, 100.0, 0, -15.15, 800, 0, 2.239, 70, 1.2947673642672, 1.20481927710843, 0.5, 17, 15, 0, 0, 0, 4
-point.1 = 1, -6, -8.5, -15.4, 1200, 1, 2.356, 8, 1.3790921701152, 1.25, 0.5, 21.1, 19.9, 2, 0, 0, 4
-point.2 = 1, -6, 8.5, -15.4, 1200, 2, 2.356, 8, 1.3790921701152, 1.25, 0.5, 21.1, 19.9, 3, 0, 0, 4
-point.3 = 1, 3.84, -20.5, -15.25, 1200, 1, 2.356, 0, 1.3146370499424, 1.25, 0.5, 21.1, 19.9, 2, 0, 0, 4
-point.4 = 1, 3.84, 20.5, -15.25, 1200, 2, 2.356, 0, 1.3146370499424, 1.25, 0.5, 21.1, 19.9, 3, 0, 0, 4
+
+; WLG, BLG z-positions should be 5.3ft, -5.45ft according to the WBM, but this is slightly adjusted to visually match the model.
+point.0 = 1, 99.15, 0, -15.15, 800, 0, 2.239, 70, 1.2947673642672, 1.20481927710843, 0.5, 17, 15, 0, 0, 0, 4
+point.1 = 1, -5.7, -8.5, -15.4, 1200, 1, 2.356, 8, 1.3790921701152, 1.25, 0.5, 21.1, 19.9, 2, 0, 0, 4
+point.2 = 1, -5.7, 8.5, -15.4, 1200, 2, 2.356, 8, 1.3790921701152, 1.25, 0.5, 21.1, 19.9, 3, 0, 0, 4
+point.3 = 1, 5.7, -20.5, -15.18, 1200, 1, 2.356, 0, 1.3146370499424, 1.25, 0.5, 21.1, 19.9, 2, 0, 0, 4
+point.4 = 1, 5.7, 20.5, -15.18, 1200, 2, 2.356, 0, 1.3146370499424, 1.25, 0.5, 21.1, 19.9, 3, 0, 0, 4
 point.5 = 2, -26, -60, 6, 100, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 1
 point.6 = 2, -26, 60, 6, 100, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 1
 point.7 = 2, -79.2, 0, 8, 100, 0, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 1
@@ -124,17 +126,17 @@ Engine.1 = Name:LeftOuterEngine#Index:1
 Engine.2 = Name:LeftInnerEngine#Index:2
 Engine.3 = Name:RightInnerEngine#Index:3
 Engine.4 = Name:RightOuterEngine#Index:4
-Tank.1 = Name:LeftOuter#Title:TT:MENU.FUEL.LEFT_OUTER#Capacity:2731.5#UnusableCapacity:0#Position:-25.7,-100.0,8.5#Priority:2#OutputOnlyLines:LeftOuterTankToLeftOuterTankPump,LeftOuterTankToLeftOuterEmerXferValve
-Tank.2 = Name:Feed1#Title:TT:MENU.FUEL.FEED_ONE#Capacity:7299.6#UnusableCapacity:0#Position:-8.2,-71.0,7.3#Priority:5#InputOnlyLines:FeedTank1FwdXferValve1ToFeedTank1,FeedTank1FwdXferValve2ToFeedTank1,FeedTank1AftXferValve2ToFeedTank1#OutputOnlyLines:FeedTank1ToFeed1TankPump1,FeedTank1ToFeed1TankPump2
-Tank.3 = Name:LeftMid#Title:TT:MENU.FUEL.LEFT_MID#Capacity:9632#UnusableCapacity:0#Position:6.3,-46.4,5.9#Priority:3#OutputOnlyLines:LeftMidTankToLeftMidTankPumpFwd,LeftMidTankToLeftMidTankPumpAft
-Tank.4 = Name:LeftInner#Title:TT:MENU.FUEL.LEFT_INNER#Capacity:12189.4#UnusableCapacity:0#Position:15.8,-24.7,3.2#Priority:4#OutputOnlyLines:LeftInnerTankToLeftInnerTankPumpFwd,LeftInnerTankToLeftInnerTankPumpAft
-Tank.5 = Name:Feed2#Title:TT:MENU.FUEL.FEED_TWO#Capacity:7753.2.#UnusableCapacity:0#Position:26.6,-18.4,1.0#Priority:5#InputOnlyLines:FeedTank2FwdXferValve1_1ToFeedTank2,FeedTank2FwdXferValve1_2ToFeedTank2,FeedTank2FwdXferValve2_1ToFeedTank2,FeedTank2FwdXferValve2_2ToFeedTank2,FeedTank2AftXferValve2ToFeedTank2#OutputOnlyLines:FeedTank2ToFeed2TankPump1,FeedTank2ToFeed2TankPump2
-Tank.6 = Name:Feed3#Title:TT:MENU.FUEL.FEED_THREE#Capacity:7753.2#UnusableCapacity:0#Position:26.6,18.4,1.0#Priority:5#InputOnlyLines:FeedTank3FwdXferValve1_1ToFeedTank3,FeedTank3FwdXferValve1_2ToFeedTank3,FeedTank3FwdXferValve2_1ToFeedTank3,FeedTank3FwdXferValve2_2ToFeedTank3,FeedTank3AftXferValve2ToFeedTank3#OutputOnlyLines:FeedTank3ToFeed3TankPump1,FeedTank3ToFeed3TankPump2
-Tank.7 = Name:RightInner#Title:TT:MENU.FUEL.RIGHT_INNER#Capacity:12189.4#UnusableCapacity:0#Position:15.8,24.7,3.2#Priority:4#OutputOnlyLines:RightInnerTankToRightInnerTankPumpFwd,RightInnerTankToRightInnerTankPumpAft
-Tank.8 = Name:RightMid#Title:TT:MENU.FUEL.RIGHT_MID#Capacity:9632#UnusableCapacity:0#Position:6.3,46.4,5.9#Priority:3#OutputOnlyLines:RightMidTankToRightMidTankPumpFwd,RightMidTankToRightMidTankPumpAft
-Tank.9 = Name:Feed4#Title:TT:MENU.FUEL.FEED_FOUR#Capacity:7299.6#UnusableCapacity:0#Position:-8.2,71,7.3#Priority:5#InputOnlyLines:FeedTank4FwdXferValve1ToFeedTank4,FeedTank4FwdXferValve2ToFeedTank4,FeedTank4AftXferValve2ToFeedTank4#OutputOnlyLines:FeedTank4ToFeed4TankPump1,FeedTank4ToFeed4TankPump2
-Tank.10 = Name:RightOuter#Title:TT:MENU.FUEL.RIGHT_OUTER#Capacity:2731.5#UnusableCapacity:0#Position:-25.7,100,8.5#Priority:2#OutputOnlyLines:RightOuterTankToRightOuterTankPump,RightOuterTankToRightOuterEmerXferValve
-Tank.11 = Name:Trim#Title:TT:MENU.FUEL.TRIM#Capacity:6260.3#UnusableCapacity:0#Position:-87.9,0,12.1#Priority:1#OutputOnlyLines:TrimTankToTrimTankPumpLeft,TrimTankToTrimTankPumpRight
+Tank.1 = Name:LeftOuter#Title:TT:MENU.FUEL.LEFT_OUTER#Capacity:2731.5#UnusableCapacity:0#Position:-25.0,-100.0,8.5#Priority:2#OutputOnlyLines:LeftOuterTankToLeftOuterTankPump,LeftOuterTankToLeftOuterEmerXferValve
+Tank.2 = Name:Feed1#Title:TT:MENU.FUEL.FEED_ONE#Capacity:7299.6#UnusableCapacity:0#Position:-7.45,-71.0,7.3#Priority:5#InputOnlyLines:FeedTank1FwdXferValve1ToFeedTank1,FeedTank1FwdXferValve2ToFeedTank1,FeedTank1AftXferValve2ToFeedTank1#OutputOnlyLines:FeedTank1ToFeed1TankPump1,FeedTank1ToFeed1TankPump2
+Tank.3 = Name:LeftMid#Title:TT:MENU.FUEL.LEFT_MID#Capacity:9632#UnusableCapacity:0#Position:7.1,-45.9,5.9#Priority:3#OutputOnlyLines:LeftMidTankToLeftMidTankPumpFwd,LeftMidTankToLeftMidTankPumpAft
+Tank.4 = Name:LeftInner#Title:TT:MENU.FUEL.LEFT_INNER#Capacity:12189.4#UnusableCapacity:0#Position:16.5,-24.7,3.2#Priority:4#OutputOnlyLines:LeftInnerTankToLeftInnerTankPumpFwd,LeftInnerTankToLeftInnerTankPumpAft
+Tank.5 = Name:Feed2#Title:TT:MENU.FUEL.FEED_TWO#Capacity:7753.2.#UnusableCapacity:0#Position:27.3,-18.4,1.0#Priority:5#InputOnlyLines:FeedTank2FwdXferValve1_1ToFeedTank2,FeedTank2FwdXferValve1_2ToFeedTank2,FeedTank2FwdXferValve2_1ToFeedTank2,FeedTank2FwdXferValve2_2ToFeedTank2,FeedTank2AftXferValve2ToFeedTank2#OutputOnlyLines:FeedTank2ToFeed2TankPump1,FeedTank2ToFeed2TankPump2
+Tank.6 = Name:Feed3#Title:TT:MENU.FUEL.FEED_THREE#Capacity:7753.2#UnusableCapacity:0#Position:27.3,18.4,1.0#Priority:5#InputOnlyLines:FeedTank3FwdXferValve1_1ToFeedTank3,FeedTank3FwdXferValve1_2ToFeedTank3,FeedTank3FwdXferValve2_1ToFeedTank3,FeedTank3FwdXferValve2_2ToFeedTank3,FeedTank3AftXferValve2ToFeedTank3#OutputOnlyLines:FeedTank3ToFeed3TankPump1,FeedTank3ToFeed3TankPump2
+Tank.7 = Name:RightInner#Title:TT:MENU.FUEL.RIGHT_INNER#Capacity:12189.4#UnusableCapacity:0#Position:16.5,24.7,3.2#Priority:4#OutputOnlyLines:RightInnerTankToRightInnerTankPumpFwd,RightInnerTankToRightInnerTankPumpAft
+Tank.8 = Name:RightMid#Title:TT:MENU.FUEL.RIGHT_MID#Capacity:9632#UnusableCapacity:0#Position:7.1,45.9,5.9#Priority:3#OutputOnlyLines:RightMidTankToRightMidTankPumpFwd,RightMidTankToRightMidTankPumpAft
+Tank.9 = Name:Feed4#Title:TT:MENU.FUEL.FEED_FOUR#Capacity:7299.6#UnusableCapacity:0#Position:-7.45,71,7.3#Priority:5#InputOnlyLines:FeedTank4FwdXferValve1ToFeedTank4,FeedTank4FwdXferValve2ToFeedTank4,FeedTank4AftXferValve2ToFeedTank4#OutputOnlyLines:FeedTank4ToFeed4TankPump1,FeedTank4ToFeed4TankPump2
+Tank.10 = Name:RightOuter#Title:TT:MENU.FUEL.RIGHT_OUTER#Capacity:2731.5#UnusableCapacity:0#Position:-25.0,100,8.5#Priority:2#OutputOnlyLines:RightOuterTankToRightOuterTankPump,RightOuterTankToRightOuterEmerXferValve
+Tank.11 = Name:Trim#Title:TT:MENU.FUEL.TRIM#Capacity:6260.3#UnusableCapacity:0#Position:-87.14,0,12.1#Priority:1#OutputOnlyLines:TrimTankToTrimTankPumpLeft,TrimTankToTrimTankPumpRight
 Line.1 = Name:FeedTank1ToFeed1TankPump1#Source:Feed1#Destination:Feed1TankPump1
 Line.2 = Name:FeedTank1ToFeed1TankPump2#Source:Feed1#Destination:Feed1TankPump2
 Line.3 = Name:FeedTank2ToFeed2TankPump1#Source:Feed2#Destination:Feed2TankPump1

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/flight_model.cfg
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/flight_model.cfg
@@ -423,7 +423,7 @@ Trigger.38 = Name:CGControlTransferEnd#Threshold:0.405#Condition:CGBelowLimit#Ef
 [AIRPLANE_GEOMETRY]
 wing_area = 9096.0 ; Wing area S (SQUARE FEET)
 wing_span = 261.65 ; Wing span b (FEET)
-wing_root_chord = 57.97 ; Wing root chord croot (FEET)
+wing_root_chord = 58.86 ; Wing root chord croot (FEET), should be 57.97 but increased to match reference MAC length
 wing_camber = 1 ; (DEGREES) (Unkown - estimated value)
 wing_thickness_ratio = 0.05 ; Local thickness is local_chord(x)*wing_thickness_ratio, x = lateral coord
 wing_dihedral = 6.5 ; Dihedral angle Lambda (DEGREES)

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/flight_model.cfg
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/flight_model.cfg
@@ -13,6 +13,10 @@
 
 ; 15 Feb 2024 - Activate new spring method and update strut springs
 
+; 19 Jul 2024 - Adjust CG, wheels and fuel tanks to correct model origin to Airbus reference datum offset
+; The position of the nose in the model coord. system is 35.1927m. The Airbus reference datum distance from the nose is 7.33m.
+; So, the conversion from HArm value to model coordinates in m is: model_coord = (35.1927 + 7.33) - harm_value
+
 [VERSION]
 major = 1
 minor = 0
@@ -526,7 +530,7 @@ yaw_moment_delta_rudder = 0.753 ; (control)The change in yaw moment per change i
 yaw_moment_delta_rudder_propwash = 0.753 ; (control)
 yaw_moment_delta_rudder_trim_scalar = 0.753 ; Change in yaw moment due to rudder trim
 compute_aero_center = 0
-aero_center_lift = 10 ; Init to center
+aero_center_lift = 11 ; Init to center
 lift_coef_aoa_table = -3.15:0, 0:0.138, 0.139:1.32, 0.2:1.48, 0.26:1.76, 0.29:1.750, 0.32:1.60, 0.5:1.50, 3.15:0
 lift_coef_ground_effect_mach_table = 0.1171:0.7211,0.1411:0.7111,0.1761:0.6811,0.2171:0.6631,0.3171:0.647135503,0.4171:0.637668047,0.5171:0.63293432,0.6171:0.628200592,0.7171:0.625833728,0.8171:0.623466864,1:1 ; changed from 0.0:1.178, 0.15:1.178, 0.19:1.178, 0.20:1.176, 0.22:1.173, 0.25:1.17, 0.27:1.1675, 0.30:1.164, 0.35:1.159, 1.0:1
 lift_coef_mach_table = 0:1

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/airframe/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/airframe/mod.rs
@@ -19,8 +19,8 @@ impl A380Airframe {
         operating_empty_weight_kg: 300007.12,
         operating_empty_position: (6.47, 0., 0.),
         per_pax_weight_kg: 84.,
-        mean_aerodynamic_chord_size: 39.9475,
-        leading_edge_mean_aerodynamic_chord: 20.99,
+        mean_aerodynamic_chord_size: 40.35,
+        leading_edge_mean_aerodynamic_chord: 21.09,
     };
 
     pub fn new(context: &mut InitContext) -> Self {

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/airframe/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/airframe/mod.rs
@@ -20,7 +20,7 @@ impl A380Airframe {
         operating_empty_position: (6.47, 0., 0.),
         per_pax_weight_kg: 84.,
         mean_aerodynamic_chord_size: 39.9475,
-        leading_edge_mean_aerodynamic_chord: 19.99,
+        leading_edge_mean_aerodynamic_chord: 20.99,
     };
 
     pub fn new(context: &mut InitContext) -> Self {

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/airframe/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/airframe/mod.rs
@@ -17,10 +17,10 @@ pub struct A380Airframe {
 impl A380Airframe {
     const LOADSHEET: LoadsheetInfo = LoadsheetInfo {
         operating_empty_weight_kg: 300007.12,
-        operating_empty_position: (0.83, 0., 0.),
+        operating_empty_position: (6.47, 0., 0.),
         per_pax_weight_kg: 84.,
         mean_aerodynamic_chord_size: 39.9475,
-        leading_edge_mean_aerodynamic_chord: 15.29,
+        leading_edge_mean_aerodynamic_chord: 19.99,
     };
 
     pub fn new(context: &mut InitContext) -> Self {

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/airframe/test.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/airframe/test.rs
@@ -474,8 +474,8 @@ fn empty() {
     println!("ZFW CG MAC: {}", zero_fuel_weight_center_of_gravity);
     println!("GW CG MAC: {}", gross_weight_center_of_gravity);
 
-    assert_eq!(zero_fuel_weight_center_of_gravity, 36.2);
-    assert_eq!(gross_weight_center_of_gravity, 36.2);
+    assert_eq!(zero_fuel_weight_center_of_gravity, 36.23);
+    assert_eq!(gross_weight_center_of_gravity, 36.23);
     // Equal when fuel is empty
     assert_eq!(
         zero_fuel_weight_center_of_gravity,
@@ -502,8 +502,8 @@ fn low_fuel_half_pax() {
     println!("ZFW CG MAC: {}", zero_fuel_weight_center_of_gravity);
     println!("GW CG MAC: {}", gross_weight_center_of_gravity);
 
-    assert!(zero_fuel_weight_center_of_gravity > 36.);
-    assert!(zero_fuel_weight_center_of_gravity < 37.);
+    assert!(zero_fuel_weight_center_of_gravity > 37.);
+    assert!(zero_fuel_weight_center_of_gravity < 38.);
     assert!(gross_weight_center_of_gravity > 37.);
     assert!(gross_weight_center_of_gravity < 38.);
 }
@@ -527,10 +527,10 @@ fn high_fuel_full_pax_full_cargo() {
     println!("ZFW CG MAC: {}", zero_fuel_weight_center_of_gravity);
     println!("GW CG MAC: {}", gross_weight_center_of_gravity);
 
-    assert!(zero_fuel_weight_center_of_gravity > 38.);
-    assert!(zero_fuel_weight_center_of_gravity < 39.);
-    assert!(gross_weight_center_of_gravity > 39.);
-    assert!(gross_weight_center_of_gravity < 40.);
+    assert!(zero_fuel_weight_center_of_gravity > 39.);
+    assert!(zero_fuel_weight_center_of_gravity < 40.);
+    assert!(gross_weight_center_of_gravity > 41.);
+    assert!(gross_weight_center_of_gravity < 42.);
 }
 
 #[test]
@@ -565,11 +565,11 @@ fn half_pax_cargo_target_full() {
 
     assert!(zero_fuel_weight_center_of_gravity > 37.);
     assert!(zero_fuel_weight_center_of_gravity < 38.);
-    assert!(gross_weight_center_of_gravity > 37.5);
-    assert!(gross_weight_center_of_gravity < 38.);
+    assert!(gross_weight_center_of_gravity > 38.);
+    assert!(gross_weight_center_of_gravity < 39.);
 
-    assert!(target_zero_fuel_weight_center_of_gravity > 38.);
-    assert!(target_zero_fuel_weight_center_of_gravity < 39.);
-    assert!(target_gross_weight_center_of_gravity > 38.);
-    assert!(target_gross_weight_center_of_gravity < 39.);
+    assert!(target_zero_fuel_weight_center_of_gravity > 39.);
+    assert!(target_zero_fuel_weight_center_of_gravity < 40.);
+    assert!(target_gross_weight_center_of_gravity > 39.);
+    assert!(target_gross_weight_center_of_gravity < 40.);
 }

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/fuel/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/fuel/mod.rs
@@ -69,67 +69,67 @@ impl A380Fuel {
         FuelInfo {
             // LEFT_OUTER - Capacity: 2731.5
             fuel_tank_id: "FUEL_TANK_QUANTITY_1",
-            position: (-30.7, -100.0, 8.5),
+            position: (-25., -100.0, 8.5),
             total_capacity_gallons: 2731.5,
         },
         FuelInfo {
             // FEED_ONE - Capacity: 7299.6
             fuel_tank_id: "FUEL_TANK_QUANTITY_2",
-            position: (-13.2, -71.0, 7.3),
+            position: (-7.45, -71.0, 7.3),
             total_capacity_gallons: 7299.6,
         },
         FuelInfo {
             // LEFT_MID - Capacity: 9632
             fuel_tank_id: "FUEL_TANK_QUANTITY_3",
-            position: (1.3, -46.4, 5.9),
+            position: (7.1, -46.4, 5.9),
             total_capacity_gallons: 9632.,
         },
         FuelInfo {
             // LEFT_INNER - Capacity: 12189.4
             fuel_tank_id: "FUEL_TANK_QUANTITY_4",
-            position: (10.8, -24.7, 3.2),
+            position: (16.5, -24.7, 3.2),
             total_capacity_gallons: 12189.4,
         },
         FuelInfo {
             // FEED_TWO - Capacity: 7753.2
             fuel_tank_id: "FUEL_TANK_QUANTITY_5",
-            position: (21.6, -18.4, 1.0),
+            position: (27.3, -18.4, 1.0),
             total_capacity_gallons: 7753.2,
         },
         FuelInfo {
             // FEED_THREE - Capacity: 7753.2
             fuel_tank_id: "FUEL_TANK_QUANTITY_6",
-            position: (21.6, 18.4, 1.0),
+            position: (27.3, 18.4, 1.0),
             total_capacity_gallons: 7753.2,
         },
         FuelInfo {
             // RIGHT_INNER - Capacity: 12189.4
             fuel_tank_id: "FUEL_TANK_QUANTITY_7",
-            position: (10.8, 24.7, 3.2),
+            position: (16.5, 24.7, 3.2),
             total_capacity_gallons: 12189.4,
         },
         FuelInfo {
             // RIGHT_MID - Capacity: 9632
             fuel_tank_id: "FUEL_TANK_QUANTITY_8",
-            position: (1.3, 46.4, 5.9),
+            position: (7.1, 46.4, 5.9),
             total_capacity_gallons: 9632.,
         },
         FuelInfo {
             // FEED_FOUR - Capacity: 7299.6
             fuel_tank_id: "FUEL_TANK_QUANTITY_9",
-            position: (-13.2, 71., 7.3),
+            position: (-7.45, 71., 7.3),
             total_capacity_gallons: 7299.6,
         },
         FuelInfo {
             // RIGHT_OUTER - Capacity: 2731.5
             fuel_tank_id: "FUEL_TANK_QUANTITY_10",
-            position: (-30.7, 100., 8.5),
+            position: (-25., 100., 8.5),
             total_capacity_gallons: 2731.5,
         },
         FuelInfo {
             // TRIM - Capacity: 6260.3
             fuel_tank_id: "FUEL_TANK_QUANTITY_11",
-            position: (-92.9, 0., 12.1),
+            position: (-87.14, 0., 12.1),
             total_capacity_gallons: 6260.3,
         },
     ];

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/fuel/test.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/fuel/test.rs
@@ -359,8 +359,8 @@ fn low_fuel() {
 
     assert_eq!(
         (test_bed.fore_aft_center_of_gravity() * 100.).round() / 100.,
-        -10.3,
-        "Expected cg: -10.3, cg: {}",
+        -4.57,
+        "Expected cg: -4.57, cg: {}",
         (test_bed.fore_aft_center_of_gravity() * 100.).round() / 100.,
     );
 }
@@ -372,8 +372,8 @@ fn high_fuel() {
 
     assert_eq!(
         (test_bed.fore_aft_center_of_gravity() * 100.).round() / 100.,
-        0.41,
-        "Expected cg: 0.41, cg: {}",
+        6.12,
+        "Expected cg: 6.12, cg: {}",
         (test_bed.fore_aft_center_of_gravity() * 100.).round() / 100.,
     );
 }

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
@@ -75,9 +75,9 @@ const AC_EHA_BUS: ElectricalBusType = ElectricalBusType::AlternatingCurrentNamed
 struct A380TiltingGearsFactory {}
 impl A380TiltingGearsFactory {
     fn new_a380_body_gear(context: &mut InitContext, is_left: bool) -> TiltingGear {
-        let mut x_offset_meters = 2.58;
-        let y_offset_meters = -4.7;
-        let z_offset_meters = -1.74;
+        let mut x_offset_meters = 2.85569;
+        let y_offset_meters = -5.04847;
+        let z_offset_meters = -0.235999;
 
         if is_left {
             x_offset_meters *= -1.;
@@ -93,9 +93,9 @@ impl A380TiltingGearsFactory {
     }
 
     fn new_a380_wing_gear(context: &mut InitContext, is_left: bool) -> TiltingGear {
-        let mut x_offset_meters = 6.25;
-        let y_offset_meters = -4.63;
-        let z_offset_meters = 1.74;
+        let mut x_offset_meters = 6.18848;
+        let y_offset_meters = -4.86875;
+        let z_offset_meters = 2.6551;
 
         if is_left {
             x_offset_meters *= -1.;

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
@@ -75,9 +75,9 @@ const AC_EHA_BUS: ElectricalBusType = ElectricalBusType::AlternatingCurrentNamed
 struct A380TiltingGearsFactory {}
 impl A380TiltingGearsFactory {
     fn new_a380_body_gear(context: &mut InitContext, is_left: bool) -> TiltingGear {
-        let mut x_offset_meters = 2.85569;
-        let y_offset_meters = -5.04847;
-        let z_offset_meters = -0.235999;
+        let mut x_offset_meters = 2.58;
+        let y_offset_meters = -4.7;
+        let z_offset_meters = -1.74;
 
         if is_left {
             x_offset_meters *= -1.;
@@ -93,9 +93,9 @@ impl A380TiltingGearsFactory {
     }
 
     fn new_a380_wing_gear(context: &mut InitContext, is_left: bool) -> TiltingGear {
-        let mut x_offset_meters = 6.18848;
-        let y_offset_meters = -4.86875;
-        let z_offset_meters = 2.6551;
+        let mut x_offset_meters = 6.25;
+        let y_offset_meters = -4.63;
+        let z_offset_meters = 1.74;
 
         if is_left {
             x_offset_meters *= -1.;

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/payload/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/payload/mod.rs
@@ -89,91 +89,91 @@ impl A380Payload {
     const A380_PAX: [PaxInfo<'static>; 14] = [
         PaxInfo {
             max_pax: 28,
-            position: (70.7, 0., 7.1),
+            position: (75.7, 0., 7.1),
             pax_id: "PAX_MAIN_FWD_A",
             payload_id: "PAYLOAD_STATION_1_REQ",
         },
         PaxInfo {
             max_pax: 28,
-            position: (70.7, 0., 7.1),
+            position: (75.7, 0., 7.1),
             pax_id: "PAX_MAIN_FWD_B",
             payload_id: "PAYLOAD_STATION_2_REQ",
         },
         // PAX MAIN FWD: 56
         PaxInfo {
             max_pax: 39,
-            position: (25.6, 0., 7.1),
+            position: (30.6, 0., 7.1),
             pax_id: "PAX_MAIN_MID_1A",
             payload_id: "PAYLOAD_STATION_3_REQ",
         },
         PaxInfo {
             max_pax: 50,
-            position: (25.6, 0., 7.1),
+            position: (30.6, 0., 7.1),
             pax_id: "PAX_MAIN_MID_1B",
             payload_id: "PAYLOAD_STATION_4_REQ",
         },
         PaxInfo {
             max_pax: 43,
-            position: (25.6, 0., 7.1),
+            position: (30.6, 0., 7.1),
             pax_id: "PAX_MAIN_MID_1C",
             payload_id: "PAYLOAD_STATION_5_REQ",
         },
         // PAX MAIN MID 1: 132
         PaxInfo {
             max_pax: 48,
-            position: (-16.1, 0., 7.1),
+            position: (-11.1, 0., 7.1),
             pax_id: "PAX_MAIN_MID_2A",
             payload_id: "PAYLOAD_STATION_6_REQ",
         },
         PaxInfo {
             max_pax: 40,
-            position: (-16.1, 0., 7.1),
+            position: (-11.1, 0., 7.1),
             pax_id: "PAX_MAIN_MID_2B",
             payload_id: "PAYLOAD_STATION_7_REQ",
         },
         PaxInfo {
             max_pax: 36,
-            position: (-16.1, 0., 7.1),
+            position: (-11.1, 0., 7.1),
             pax_id: "PAX_MAIN_MID_2C",
             payload_id: "PAYLOAD_STATION_8_REQ",
         },
         // PAX MAIN MID 2: 124
         PaxInfo {
             max_pax: 42,
-            position: (-51.9, 0., 7.1),
+            position: (-46.9, 0., 7.1),
             pax_id: "PAX_MAIN_AFT_A",
             payload_id: "PAYLOAD_STATION_9_REQ",
         },
         PaxInfo {
             max_pax: 40,
-            position: (-51.9, 0., 7.1),
+            position: (-46.9, 0., 7.1),
             pax_id: "PAX_MAIN_AFT_B",
             payload_id: "PAYLOAD_STATION_10_REQ",
         },
         // PAX MAIN AFT: 82
         PaxInfo {
             max_pax: 14,
-            position: (55.8, 0., 15.6),
+            position: (60.8, 0., 15.6),
             pax_id: "PAX_UPPER_FWD",
             payload_id: "PAYLOAD_STATION_11_REQ",
         },
         // PAX UPPER FWD: 14
         PaxInfo {
             max_pax: 30,
-            position: (6.7, 0., 15.6),
+            position: (11.7, 0., 15.6),
             pax_id: "PAX_UPPER_MID_A",
             payload_id: "PAYLOAD_STATION_12_REQ",
         },
         PaxInfo {
             max_pax: 28,
-            position: (6.7, 0., 15.6),
+            position: (11.7, 0., 15.6),
             pax_id: "PAX_UPPER_MID_B",
             payload_id: "PAYLOAD_STATION_13_REQ",
         },
         // PAX UPPER MID: 58
         PaxInfo {
             max_pax: 18,
-            position: (-34.3, 0., 15.6),
+            position: (-29.3, 0., 15.6),
             pax_id: "PAX_UPPER_AFT",
             payload_id: "PAYLOAD_STATION_14_REQ",
         },
@@ -182,19 +182,19 @@ impl A380Payload {
     const A380_CARGO: [CargoInfo<'static>; 3] = [
         CargoInfo {
             max_cargo_kg: 28577.,
-            position: (62.4, 0., -0.95),
+            position: (67.4, 0., -0.95),
             cargo_id: "CARGO_FWD",
             payload_id: "PAYLOAD_STATION_15_REQ",
         },
         CargoInfo {
             max_cargo_kg: 20310.,
-            position: (-23.5, 0., -0.95),
+            position: (-18.5, 0., -0.95),
             cargo_id: "CARGO_AFT",
             payload_id: "PAYLOAD_STATION_16_REQ",
         },
         CargoInfo {
             max_cargo_kg: 2513.,
-            position: (-57.9, 0., -0.71),
+            position: (-52.9, 0., -0.71),
             cargo_id: "CARGO_BULK",
             payload_id: "PAYLOAD_STATION_17_REQ",
         },


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR adjusts the W/B of the A380. Mainly, it was discovered that the reference datum to model coordinate system conversion was incorrect, resulting in MSFS z-coordinates that were significantly (in order of a few meters) incorrect. This PR now fixes many measurements with the new conversion.
Changes:
* Adjust L/G contact point positions to match correct positions and weighed L/G loadings
* Adjust empty weight to match OEW
* Adjust empty CG to match OEWCG
* Adjust fuel tank positions to match correct positions
* Adjust aero center position to match correct 25% chord position.

Also, this PR fixes many of the A380 rust module W/B parameters, such as fuel tank, cargo stations and empty CG position, that were never updated. It also updates the LEMAC and L/G positions according to the changes made.

What was not changed are the actual cargo station positions in the flight model cfg (the rust module values were simply updated to match the old cfg values), since it is not clear to me if they need to be updated with the new offset, or if they are visually placed according to the 3D model, which would mean the values were correct already. Thus I have left them as they were.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
