### PR TITLE
fix(efb): fix checklists not turning green if completed but not in the relevant flight phase

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -109,6 +109,7 @@
 1. [MCDU] Fixed ZFW Autofill with lbs during boarding @ShreyasKallingal
 1. [FWC] Fix NW STRG DISC turning amber too soon - @adoggman (Andrew)
 1. [FMS] Fix VNAV crash for steep approaches - @BlueberryKing (BlueberryKing)
+1. [EFB] Fix checklists not turning green if completed but not in the relevant flight phase - @Fabi-02 (Fabi)
 
 ## 0.11.0
 

--- a/fbw-common/src/systems/instruments/src/EFB/Checklists/Checklists.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Checklists/Checklists.tsx
@@ -153,7 +153,7 @@ export const Checklists = () => {
     const isMarkedCompleted = checklists[index].markedCompleted;
     const isSelected = index === selectedChecklistIndex;
     const isIndexRelevant = relevantChecklistIndices.includes(index);
-    if (isSelected && isChecklistCompleted && isIndexRelevant) {
+    if (isSelected && isChecklistCompleted) {
       return isMarkedCompleted
         ? 'bg-utility-green font-bold text-theme-body'
         : 'bg-utility-amber font-bold text-theme-body';
@@ -161,14 +161,17 @@ export const Checklists = () => {
     if (isSelected) {
       return 'bg-theme-highlight font-bold text-theme-body';
     }
-    if (isChecklistCompleted && isIndexRelevant) {
+    if (isChecklistCompleted) {
       return isMarkedCompleted
         ? 'bg-theme-body border-2 border-utility-green font-bold text-utility-green ' +
             'hover:text-theme-body hover:bg-utility-green'
         : 'bg-theme-body border-2 border-utility-amber ' +
             'font-bold text-utility-amber hover:text-theme-body hover:bg-utility-amber';
     }
-    return 'bg-theme-accent border-2 border-theme-accent font-bold text-theme-text hover:bg-theme-highlight hover:text-theme-body';
+    return (
+      'bg-theme-accent border-2 border-theme-accent font-bold text-theme-text hover:bg-theme-highlight hover:text-theme-body' +
+      (!isIndexRelevant ? ' opacity-50 hover:opacity-100' : '')
+    );
   };
 
   /**


### PR DESCRIPTION
Fixes #8783 

## Summary of Changes
If checklists are completed, they are now turning green, even if the plane is not in the relevant flight phase.
Additionally, the checklists that have not been completed yet gets a bit faded if they belong to a non-relevant flight phase.

## Screenshots
![Screenshot 2024-07-31 104250](https://github.com/user-attachments/assets/0190f97a-a107-4343-bcee-26f2cd505b8b)
![Screenshot 2024-07-31 104331](https://github.com/user-attachments/assets/ef762fc2-9490-43dc-8330-e690dda596f3)

## References
N/A

## Additional context
Discord username (if different from GitHub): xaliburmc

## Testing instructions
Check the correct behavior of the checklist tabs on the EFB.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
