### PR TITLE
fix(gpws/ewd): A380x Flap 3 selection check

### DIFF
--- a/fbw-a380x/src/systems/systems-host/systems/LegacyGpws.ts
+++ b/fbw-a380x/src/systems/systems-host/systems/LegacyGpws.ts
@@ -199,9 +199,9 @@ export class LegacyGpws {
             radioAltValid && radioAlt.value >= 10 && radioAlt.value <= 2450
             && !SimVar.GetSimVarValue('L:A32NX_GPWS_SYS_OFF', 'Bool')
         ) { // Activate between 10 - 2450 radio alt unless SYS is off
-            const FlapPushButton = SimVar.GetSimVarValue('L:A32NX_GPWS_FLAPS3', 'Bool');
+            const flapsThreeSelected = SimVar.GetSimVarValue('L:A32NX_SPEEDS_LANDING_CONF3', 'Bool');
             const FlapPosition = SimVar.GetSimVarValue('L:A32NX_FLAPS_HANDLE_INDEX', 'Number');
-            const FlapsInLandingConfig = FlapPushButton ? (FlapPosition === 3) : (FlapPosition === 4);
+            const FlapsInLandingConfig = flapsThreeSelected ? (FlapPosition === 3) : (FlapPosition === 4); // fixme should be actual flap angle
             const vSpeed = Simplane.getVerticalSpeed();
             const Airspeed = SimVar.GetSimVarValue('AIRSPEED INDICATED', 'Knots');
             const gearExtended = SimVar.GetSimVarValue('GEAR TOTAL PCT EXTENDED', 'Percent') > 0.9;

--- a/fbw-a380x/src/systems/systems-host/systems/PseudoFWC.ts
+++ b/fbw-a380x/src/systems/systems-host/systems/PseudoFWC.ts
@@ -900,7 +900,6 @@ export class PseudoFWC {
   private readonly trueNorthRef = Subject.create(false);
 
   /* SURVEILLANCE */
-  private readonly gpwsFlaps3 = Subject.create(false);
 
   private readonly gpwsFlapMode = Subject.create(0);
 
@@ -1981,7 +1980,6 @@ export class PseudoFWC {
     this.ndXfrKnob.set(SimVar.GetSimVarValue('L:A32NX_ECAM_ND_XFR_SWITCHING_KNOB', 'enum'));
     this.noMobileSwitchPosition.set(SimVar.GetSimVarValue('L:XMLVAR_SWITCH_OVHD_INTLT_NOSMOKING_Position', 'number'));
     this.strobeLightsOn.set(SimVar.GetSimVarValue('L:LIGHTING_STROBE_0', 'Bool'));
-    this.gpwsFlaps3.set(SimVar.GetSimVarValue('L:A32NX_GPWS_FLAPS3', 'Bool'));
     this.gpwsFlapMode.set(SimVar.GetSimVarValue('L:A32NX_GPWS_FLAP_OFF', 'Bool'));
     this.gpwsTerrOff.set(SimVar.GetSimVarValue('L:A32NX_GPWS_TERR_OFF', 'Bool'));
     this.predWSOn.set(SimVar.GetSimVarValue('L:A32NX_SWITCH_RADAR_PWS_Position', 'Bool'));
@@ -3236,17 +3234,6 @@ export class PseudoFWC {
       sysPage: -1,
       side: 'RIGHT',
     },
-    '0000300': {
-      // GPWS FLAPS 3
-      flightPhaseInhib: [],
-      simVarIsActive: this.gpwsFlaps3,
-      whichCodeToReturn: () => [0],
-      codesToReturn: ['000030001'],
-      memoInhibit: () => false,
-      failure: 0,
-      sysPage: -1,
-      side: 'RIGHT',
-    },
     '0000230': {
       // MAN LANDING ELEVATION
       flightPhaseInhib: [],
@@ -3707,9 +3694,9 @@ export class PseudoFWC {
           : 1,
         SimVar.GetSimVarValue('L:A32NX_CABIN_READY', 'bool') ? 4 : 3,
         SimVar.GetSimVarValue('GEAR HANDLE POSITION', 'bool') ? 6 : 5,
-        (!SimVar.GetSimVarValue('L:A32NX_GPWS_FLAPS3', 'bool') &&
+        (!SimVar.GetSimVarValue('L:A32NX_SPEEDS_LANDING_CONF3', 'bool') &&
           SimVar.GetSimVarValue('L:A32NX_FLAPS_HANDLE_INDEX', 'enum') === 4) ||
-        (SimVar.GetSimVarValue('L:A32NX_GPWS_FLAPS3', 'bool') &&
+        (SimVar.GetSimVarValue('L:A32NX_SPEEDS_LANDING_CONF3', 'bool') &&
           SimVar.GetSimVarValue('L:A32NX_FLAPS_HANDLE_INDEX', 'enum') === 3)
           ? 8
           : 7,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Changes gpws & FWC on the A380 to take into account the landing flap setting selected on the FMS as there is no dedicated flap 3 button.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
FCOM
<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
bruno_pt99
## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
