### PR TITLE
fix(fms): gs intcp altitude

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/plans/BaseFlightPlan.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/plans/BaseFlightPlan.ts
@@ -7,6 +7,7 @@ import {
   Airport,
   AltitudeDescriptor,
   Approach,
+  ApproachType,
   ApproachWaypointDescriptor,
   Arrival,
   Departure,
@@ -1035,14 +1036,17 @@ export abstract class BaseFlightPlan<P extends FlightPlanPerformanceData = Fligh
   }
 
   glideslopeIntercept(): number | undefined {
-    for (const leg of this.approachSegment.allLegs) {
-      if (
-        leg.isDiscontinuity === false &&
-        leg.definition.approachWaypointDescriptor === ApproachWaypointDescriptor.FinalApproachFix &&
-        (leg.definition.altitudeDescriptor === AltitudeDescriptor.AtAlt1GsMslAlt2 ||
-          leg.definition.altitudeDescriptor === AltitudeDescriptor.AtOrAboveAlt1GsMslAlt2)
-      ) {
-        return leg.definition.altitude2;
+    // On ILS approaches altitude2 on the FACF is the GS intercept alt,
+    // even when there is no descriptor (i.e. there's no alt constraint) - ARINC 424 5.29.
+    if (this.approach.type === ApproachType.Ils) {
+      for (const leg of this.approachSegment.allLegs) {
+        if (
+          leg.isDiscontinuity === false &&
+          leg.definition.approachWaypointDescriptor === ApproachWaypointDescriptor.FinalApproachCourseFix &&
+          leg.definition.altitude2 > 0
+        ) {
+          return leg.definition.altitude2;
+        }
       }
     }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8810

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Implements the FACF flag for localiser-based approaches, and corrects the glideslope intercept altitude according to ARINC 424 coding rules.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before:
![image](https://github.com/user-attachments/assets/c530b415-431d-4f6a-95db-5adfd6e7c56b)
After:
![image](https://github.com/user-attachments/assets/af871004-7179-446a-bdb8-bc0180117a2d)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
ARINC 424

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
No changelog as this is an fms-v2 bug that's never been in a stable release.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Select some ILS approaches of your choice in a flight plan, and check the GS INTCP altitude on the destination VERT REV page against charts.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
