### PR TITLE
feat(fmgc): selected navaids reset on done phase

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -111,6 +111,7 @@
 1. [FMS] Fix VNAV crash for steep approaches - @BlueberryKing (BlueberryKing)
 1. [GPWS] Fixed behaviour and trigger conditions for GPWS Mode 4 submodes - @LeechCZ (Leech)
 1. [FWS] Improved landing memo gear logic - @tracernz (Mike)
+1. [FMS] Selected navaids are now reset on entering the done flight phase - @tracernz (Mike)
 
 ## 0.11.0
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -222,9 +222,10 @@ class FMCMainDisplay extends BaseAirliners {
         this.dataManager = new Fmgc.DataManager(this);
 
         this.efisInterfaces = { L: new Fmgc.EfisInterface('L', this.currFlightPlanService), R: new Fmgc.EfisInterface('R', this.currFlightPlanService) };
-        this.guidanceController = new Fmgc.GuidanceController(this, this.currFlightPlanService, this.efisInterfaces, Fmgc.a320EfisRangeSettings, Fmgc.A320AircraftConfig);
-        this.navigation = new Fmgc.Navigation(this.currFlightPlanService, this.facilityLoader);
+        this.guidanceController = new Fmgc.GuidanceController(this.bus, this, this.currFlightPlanService, this.efisInterfaces, Fmgc.a320EfisRangeSettings, Fmgc.A320AircraftConfig);
+        this.navigation = new Fmgc.Navigation(this.bus, this.currFlightPlanService, this.facilityLoader);
         this.efisSymbols = new Fmgc.EfisSymbols(
+            this.bus,
             this.guidanceController,
             this.currFlightPlanService,
             this.navigation.getNavaidTuner(),

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/NavSystems/A320_Neo/A32NX_NavSystem.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/NavSystems/A320_Neo/A32NX_NavSystem.js
@@ -52,10 +52,10 @@ class NavSystem extends BaseInstrument {
         this.menuSliderCursor = this.getChildById("SliderMenuCursor");
 
         if (this.nodeName.includes('CDU')) {
-            this.currFlightPhaseManager = Fmgc.getFlightPhaseManager();
-            const bus = new Fmgc.EventBus();
-            this.currFlightPlanService = new Fmgc.FlightPlanService(bus, new Fmgc.A320FlightPlanPerformanceData());
-            this.rpcServer = new Fmgc.FlightPlanRpcServer(bus, this.currFlightPlanService);
+            this.bus = new Fmgc.EventBus();
+            this.currFlightPhaseManager = new Fmgc.FlightPhaseManager(this.bus);
+            this.currFlightPlanService = new Fmgc.FlightPlanService(this.bus, new Fmgc.A320FlightPlanPerformanceData());
+            this.rpcServer = new Fmgc.FlightPlanRpcServer(this.bus, this.currFlightPlanService);
 
             this.currFlightPlanService.createFlightPlans();
 

--- a/fbw-a32nx/src/systems/fmgc/src/flightphase/FlightPhaseManager.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightphase/FlightPhaseManager.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 FlyByWire Simulations
+// Copyright (c) 2021-2024 FlyByWire Simulations
 //
 // SPDX-License-Identifier: GPL-3.0
 
@@ -16,6 +16,12 @@ import {
 import { Arinc429Word, ConfirmationNode } from '@flybywiresim/fbw-sdk';
 import { VerticalMode } from '@shared/autopilot';
 import { FmgcFlightPhase, isAllEngineOn, isAnEngineOn, isOnGround, isReady, isSlewActive } from '@shared/flightphase';
+import { EventBus, Subject } from '@microsoft/msfs-sdk';
+
+export interface FlightPhaseManagerEvents {
+  /** The FMGC flight phase. */
+  fmgc_flight_phase: FmgcFlightPhase;
+}
 
 function canInitiateDes(distanceToDestination: number): boolean {
   const fl = Math.round(Simplane.getAltitude() / 100);
@@ -32,7 +38,7 @@ function canInitiateDes(distanceToDestination: number): boolean {
 export class FlightPhaseManager {
   private onGroundConfirmationNode = new ConfirmationNode(30 * 1000);
 
-  private activePhase: FmgcFlightPhase = this.initialPhase || FmgcFlightPhase.Preflight;
+  private readonly activePhase = Subject.create(this.initialPhase || FmgcFlightPhase.Preflight);
 
   private phases: { [key in FmgcFlightPhase]: Phase } = {
     [FmgcFlightPhase.Preflight]: new PreFlightPhase(),
@@ -48,17 +54,20 @@ export class FlightPhaseManager {
   private phaseChangeListeners: Array<(prev: FmgcFlightPhase, next: FmgcFlightPhase) => void> = [];
 
   get phase() {
-    return this.activePhase;
+    return this.activePhase.get();
   }
 
-  get initialPhase() {
+  get initialPhase(): FmgcFlightPhase {
     return SimVar.GetSimVarValue('L:A32NX_INITIAL_FLIGHT_PHASE', 'number');
   }
+
+  constructor(private readonly bus: EventBus) {}
 
   init(): void {
     console.log(`FMGC Flight Phase: ${this.phase}`);
     this.phases[this.phase].init();
-    this.changePhase(this.activePhase);
+    this.changePhase(this.phase);
+    this.activePhase.sub((v) => this.bus.getPublisher<FlightPhaseManagerEvents>().pub('fmgc_flight_phase', v));
   }
 
   shouldActivateNextPhase(_deltaTime: number): void {
@@ -71,13 +80,13 @@ export class FlightPhaseManager {
       }
     } else if (isReady() && isSlewActive()) {
       this.handleSlewSituation(_deltaTime);
-    } else if (this.activePhase !== this.initialPhase) {
+    } else if (this.phase !== this.initialPhase) {
       // ensure correct init of phase
-      this.activePhase = this.initialPhase;
       this.changePhase(this.initialPhase);
     }
   }
 
+  /** @deprecated Use {@link FlightPhaseManagerEvents} instead. */
   addOnPhaseChanged(cb: (prev: FmgcFlightPhase, next: FmgcFlightPhase) => void): void {
     this.phaseChangeListeners.push(cb);
   }
@@ -137,20 +146,20 @@ export class FlightPhaseManager {
 
   handleNewCruiseAltitudeEntered(newCruiseFlightLevel: number): void {
     const currentFlightLevel = Math.round(SimVar.GetSimVarValue('INDICATED ALTITUDE:3', 'feet') / 100);
-    if (this.activePhase === FmgcFlightPhase.Approach) {
+    if (this.phase === FmgcFlightPhase.Approach) {
       this.changePhase(FmgcFlightPhase.Climb);
-    } else if (currentFlightLevel < newCruiseFlightLevel && this.activePhase === FmgcFlightPhase.Descent) {
+    } else if (currentFlightLevel < newCruiseFlightLevel && this.phase === FmgcFlightPhase.Descent) {
       this.changePhase(FmgcFlightPhase.Climb);
     } else if (
       currentFlightLevel > newCruiseFlightLevel &&
-      (this.activePhase === FmgcFlightPhase.Climb || this.activePhase === FmgcFlightPhase.Descent)
+      (this.phase === FmgcFlightPhase.Climb || this.phase === FmgcFlightPhase.Descent)
     ) {
       this.changePhase(FmgcFlightPhase.Cruise);
     }
   }
 
   handleNewDestinationAirportEntered(): void {
-    if (this.activePhase === FmgcFlightPhase.GoAround) {
+    if (this.phase === FmgcFlightPhase.GoAround) {
       const accAlt = isAllEngineOn()
         ? Arinc429Word.fromSimVarValue('L:A32NX_FM1_MISSED_ACC_ALT')
         : Arinc429Word.fromSimVarValue('L:A32NX_FM1_MISSED_EO_ACC_ALT');
@@ -163,7 +172,7 @@ export class FlightPhaseManager {
   changePhase(newPhase: FmgcFlightPhase): void {
     const prevPhase = this.phase;
     console.log(`FMGC Flight Phase: ${prevPhase} => ${newPhase}`);
-    this.activePhase = newPhase;
+    this.activePhase.set(newPhase);
     SimVar.SetSimVarValue('L:A32NX_FMGC_FLIGHT_PHASE', 'number', newPhase);
     // Updating old SimVar to ensure backwards compatibility
     SimVar.SetSimVarValue(

--- a/fbw-a32nx/src/systems/fmgc/src/flightphase/index.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightphase/index.ts
@@ -1,13 +1,5 @@
-// Copyright (c) 2021-2023 FlyByWire Simulations
+// Copyright (c) 2021-2024 FlyByWire Simulations
 //
 // SPDX-License-Identifier: GPL-3.0
 
-import { FlightPhaseManager } from './FlightPhaseManager';
-
-const flightPhaseManager = new FlightPhaseManager();
-
-export { FlightPhaseManager };
-
-export function getFlightPhaseManager(): FlightPhaseManager {
-  return flightPhaseManager;
-}
+export { FlightPhaseManager, FlightPhaseManagerEvents } from './FlightPhaseManager';

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/GuidanceController.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/GuidanceController.ts
@@ -16,7 +16,6 @@ import { GeometryFactory } from '@fmgc/guidance/geometry/GeometryFactory';
 import { FlightPlanIndex } from '@fmgc/flightplanning/FlightPlanManager';
 import { HMLeg } from '@fmgc/guidance/lnav/legs/HX';
 
-import { getFlightPhaseManager } from '@fmgc/flightphase';
 import { FmgcFlightPhase } from '@shared/flightphase';
 
 import { BaseFlightPlan } from '@fmgc/flightplanning/plans/BaseFlightPlan';
@@ -33,6 +32,8 @@ import { LnavDriver } from './lnav/LnavDriver';
 import { VnavDriver } from './vnav/VnavDriver';
 import { XFLeg } from './lnav/legs/XF';
 import { VMLeg } from './lnav/legs/VM';
+import { ConsumerValue, EventBus } from '@microsoft/msfs-sdk';
+import { FlightPhaseManagerEvents } from '@fmgc/flightphase';
 
 // How often the (milliseconds)
 const GEOMETRY_RECOMPUTATION_TIMER = 5_000;
@@ -158,6 +159,11 @@ export class GuidanceController {
 
   private atmosphericConditions: AtmosphericConditions;
 
+  private readonly flightPhase = ConsumerValue.create(
+    this.bus.getSubscriber<FlightPhaseManagerEvents>().on('fmgc_flight_phase'),
+    FmgcFlightPhase.Preflight,
+  );
+
   private updateEfisState(side: EfisSide, state: EfisState<number>): void {
     const ndMode = SimVar.GetSimVarValue(`L:A32NX_EFIS_${side}_ND_MODE`, 'Enum') as EfisNdMode;
     const ndRange = this.efisNDRangeValues[SimVar.GetSimVarValue(`L:A32NX_EFIS_${side}_ND_RANGE`, 'Enum')];
@@ -205,7 +211,7 @@ export class GuidanceController {
     const runway = this.flightPlanService.active.destinationRunway;
 
     if (runway) {
-      const phase = getFlightPhaseManager().phase;
+      const phase = this.flightPhase.get();
       const distanceToDestination = this.alongTrackDistanceToDestination ?? -1;
 
       if (phase > FmgcFlightPhase.Cruise || (phase === FmgcFlightPhase.Cruise && distanceToDestination < 250)) {
@@ -228,7 +234,7 @@ export class GuidanceController {
 
   private updateEfisData() {
     const gs = SimVar.GetSimVarValue('GPS GROUND SPEED', 'Knots');
-    const flightPhase = getFlightPhaseManager().phase;
+    const flightPhase = this.flightPhase.get();
     const etaComputable = flightPhase >= FmgcFlightPhase.Takeoff && gs > 100;
     const activeLeg = this.activeGeometry?.legs.get(this.activeLegIndex);
     if (activeLeg) {
@@ -262,6 +268,7 @@ export class GuidanceController {
   }
 
   constructor(
+    private readonly bus: EventBus,
     fmgc: Fmgc,
     private readonly flightPlanService: FlightPlanService,
     private efisInterfaces: Record<EfisSide, EfisInterface>,
@@ -286,7 +293,7 @@ export class GuidanceController {
       this.acConfig,
     );
     this.pseudoWaypoints = new PseudoWaypoints(flightPlanService, this, this.atmosphericConditions);
-    this.efisVectors = new EfisVectors(this.flightPlanService, this, efisInterfaces);
+    this.efisVectors = new EfisVectors(this.bus, this.flightPlanService, this, efisInterfaces);
   }
 
   init() {

--- a/fbw-a32nx/src/systems/fmgc/src/index.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/index.ts
@@ -10,7 +10,7 @@ import { EventBus } from '@microsoft/msfs-sdk';
 import { FlightPlanRpcServer } from '@fmgc/flightplanning/rpc/FlightPlanRpcServer';
 import { FlightPlanService } from './flightplanning/FlightPlanService';
 import { NavigationDatabase, NavigationDatabaseBackend } from './NavigationDatabase';
-import { FlightPhaseManager, getFlightPhaseManager } from './flightphase';
+import { FlightPhaseManager } from './flightphase';
 import { GuidanceController } from './guidance/GuidanceController';
 import { EfisSymbols } from './efis/EfisSymbols';
 import { DescentPathBuilder } from './guidance/vnav/descent/DescentPathBuilder';
@@ -47,7 +47,6 @@ export {
   NavigationDatabaseService,
   FlightPlanIndex,
   FlightPhaseManager,
-  getFlightPhaseManager,
   GuidanceController,
   initFmgcLoop,
   updateFmgcLoop,

--- a/fbw-a32nx/src/systems/fmgc/src/navigation/NavaidTuner.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/navigation/NavaidTuner.ts
@@ -294,7 +294,7 @@ export class NavaidTuner {
     }
 
     // All selections are reset upon entering the DONE phase after landing.
-    this.flightPhase.sub((v) => v === FmgcFlightPhase.Done && this.resetState());
+    this.flightPhase.sub((v) => v === FmgcFlightPhase.Done && this.resetState(false));
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -763,7 +763,7 @@ export class NavaidTuner {
   }
 
   /** Reset all state e.g. when the nav database is switched */
-  public resetState(): void {
+  public resetState(withLockout = true): void {
     for (let i = 1; i <= 2; i++) {
       const n = i as 1 | 2;
       this.setManualAdf(n, null);
@@ -773,6 +773,8 @@ export class NavaidTuner {
     this.setManualIls(null);
     this.setIlsCourse(null);
 
-    this.tuningLockoutTimer = NavaidTuner.DELAY_AFTER_RMP_TUNING;
+    if (withLockout) {
+      this.tuningLockoutTimer = NavaidTuner.DELAY_AFTER_RMP_TUNING;
+    }
   }
 }

--- a/fbw-a32nx/src/systems/fmgc/src/navigation/NavaidTuner.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/navigation/NavaidTuner.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2023 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
-import { FlightPhaseManager, getFlightPhaseManager } from '@fmgc/flightphase';
+import { FlightPhaseManagerEvents } from '@fmgc/flightphase';
 import { LandingSystemSelectionManager } from '@fmgc/navigation/LandingSystemSelectionManager';
 import { NavaidSelectionManager, VorSelectionReason } from '@fmgc/navigation/NavaidSelectionManager';
 import { NavigationProvider } from '@fmgc/navigation/NavigationProvider';
@@ -16,7 +16,7 @@ import {
   VhfNavaidType,
 } from '@flybywiresim/fbw-sdk';
 import { FmgcFlightPhase } from '@shared/flightphase';
-import { SimVarValueType, Subject } from '@microsoft/msfs-sdk';
+import { ConsumerSubject, EventBus, SimVarValueType, Subject } from '@microsoft/msfs-sdk';
 
 interface NavRadioTuningStatus {
   frequency: number | null;
@@ -258,7 +258,10 @@ export class NavaidTuner {
 
   private tuningActive = false;
 
-  private readonly flightPhaseManager: FlightPhaseManager;
+  private readonly flightPhase = ConsumerSubject.create(
+    this.bus.getSubscriber<FlightPhaseManagerEvents>().on('fmgc_flight_phase'),
+    FmgcFlightPhase.Preflight,
+  );
 
   /** FM 1 and 2 backbeam selection LVAR output. */
   private readonly backbeamOutput = [
@@ -272,12 +275,11 @@ export class NavaidTuner {
   private notificationManager = new NotificationManager();
 
   constructor(
+    private readonly bus: EventBus,
     private readonly navigationProvider: NavigationProvider,
     private readonly navaidSelectionManager: NavaidSelectionManager,
     private readonly landingSystemSelectionManager: LandingSystemSelectionManager,
-  ) {
-    this.flightPhaseManager = getFlightPhaseManager();
-  }
+  ) {}
 
   init(): void {
     this.resetAllReceivers();
@@ -589,7 +591,7 @@ export class NavaidTuner {
   /** check if MMR tuning is locked during final approach */
   public isMmrTuningLocked() {
     return (
-      this.flightPhaseManager.phase === FmgcFlightPhase.Approach &&
+      this.flightPhase.get() === FmgcFlightPhase.Approach &&
       (this.navigationProvider.getRadioHeight() ?? Infinity) < 700
     );
   }

--- a/fbw-a32nx/src/systems/fmgc/src/navigation/NavaidTuner.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/navigation/NavaidTuner.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 FlyByWire Simulations
+// Copyright (c) 2023-2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
 import { FlightPhaseManagerEvents } from '@fmgc/flightphase';
@@ -292,6 +292,9 @@ export class NavaidTuner {
     for (const backbeam of this.backbeamOutput) {
       backbeam.selected.sub((v) => SimVar.SetSimVarValue(backbeam.localVar, SimVarValueType.Bool, v), true);
     }
+
+    // All selections are reset upon entering the DONE phase after landing.
+    this.flightPhase.sub((v) => v === FmgcFlightPhase.Done && this.resetState());
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/fbw-a32nx/src/systems/fmgc/src/navigation/Navigation.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/navigation/Navigation.ts
@@ -4,7 +4,7 @@
 
 import { Arinc429Register, IlsNavaid, NdbNavaid, VhfNavaid, VhfNavaidType, Icao } from '@flybywiresim/fbw-sdk';
 
-import { FlightPlanService } from '@fmgc/index';
+import { EventBus, FlightPlanService } from '@fmgc/index';
 import { LandingSystemSelectionManager } from '@fmgc/navigation/LandingSystemSelectionManager';
 import { NavaidSelectionManager, VorSelectionReason } from '@fmgc/navigation/NavaidSelectionManager';
 import { NavaidTuner } from '@fmgc/navigation/NavaidTuner';
@@ -89,11 +89,14 @@ export class Navigation implements NavigationProvider {
     facility: null,
   }));
 
-  constructor(private flightPlanService: FlightPlanService) {
-    this.requiredPerformance = new RequiredPerformance(this.flightPlanService);
+  constructor(
+    private readonly bus: EventBus,
+    private flightPlanService: FlightPlanService,
+  ) {
+    this.requiredPerformance = new RequiredPerformance(this.bus, this.flightPlanService);
     this.navaidSelectionManager = new NavaidSelectionManager(this.flightPlanService, this);
-    this.landingSystemSelectionManager = new LandingSystemSelectionManager(this.flightPlanService, this);
-    this.navaidTuner = new NavaidTuner(this, this.navaidSelectionManager, this.landingSystemSelectionManager);
+    this.landingSystemSelectionManager = new LandingSystemSelectionManager(this.bus, this.flightPlanService, this);
+    this.navaidTuner = new NavaidTuner(this.bus, this, this.navaidSelectionManager, this.landingSystemSelectionManager);
   }
 
   init(): void {
@@ -101,7 +104,6 @@ export class Navigation implements NavigationProvider {
   }
 
   update(deltaTime: number): void {
-    // TODO... why different to master...
     this.requiredPerformance.update(deltaTime);
 
     this.updateCurrentPerformance();

--- a/fbw-common/src/typings/fmgc.d.ts
+++ b/fbw-common/src/typings/fmgc.d.ts
@@ -1,7 +1,7 @@
 import type {
     GuidanceController as GuidanceController_,
+    FlightPhaseManager as FlightPhaseManager_,
     FlightPlanService as FlightPlanService_,
-    getFlightPhaseManager as getFlightPhaseManager_,
     EfisSymbols as EfisSymbols_,
 } from "../../../fbw-a32nx/src/systems/fmgc/src";
 import { a320EfisRangeSettings as a320EfisRangeSettings_ } from "../systems/instruments/src/NavigationDisplay"
@@ -17,9 +17,7 @@ declare global {
 
         const EfisSymbols: typeof EfisSymbols_
 
-        const getFlightPhaseManager: typeof getFlightPhaseManager_
-
-        const FlightPhaseManager: ReturnType<typeof getFlightPhaseManager_>
+        const FlightPhaseManager: typeof FlightPhaseManager_
 
         const a320EfisRangeSettings: typeof a320EfisRangeSettings_
     }

--- a/fbw-common/src/typings/fs-base-ui/html_ui/JS/common.d.ts
+++ b/fbw-common/src/typings/fs-base-ui/html_ui/JS/common.d.ts
@@ -626,6 +626,7 @@ declare global {
             on(name: string, callback: (...args: any[]) => void, context?: any): void;
             trigger(name: string, ...args: any[]): void;
             triggerToAllSubscribers(event: any, ...args: any[]): void;
+            call(arg0: string, arg1: string, arg2: string);
         }
 
         class ViewListenerMgr {
@@ -640,7 +641,7 @@ declare global {
 
     function RegisterViewListenerT<T>(name: string, callback: (() => void) | void, type: new() => T,
                                       requiresSingleton?: boolean): T;
-    function RegisterViewListener(name: string, callback?: () => void,
+    function RegisterViewListener(name: string, callback?: (listener: ViewListener.ViewListener) => void,
                                   requiresSingleton?: boolean): ViewListener.ViewListener;
 
     class Name_Z {

--- a/fbw-common/src/typings/types.d.ts
+++ b/fbw-common/src/typings/types.d.ts
@@ -93,7 +93,5 @@ declare global {
         const WaypointEntryUtils: typeof WaypointEntryUtils_
 
         const SimBriefUplinkAdapter: typeof SimBriefUplinkAdapter_
-
-        function getFlightPhaseManager(): FlightPhaseManager_
     }
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8740

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Rip a bandaid off and refactor the flight phase to use the event bus.
- Selected navaids reset on entering the done phase.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
See linked issue.

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Perform a full flight. Ensure the FMS works normally. Tune manually some navaids in the FMS. Ensure just after landing (30 seconds) that the navaids are all reset back to auto-tuned navaids (M flags disappear on the ND etc. See the linked issue for a video).

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
