### PR TITLE
fix(fms): remove forced turn on following leg after leg insertion

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -279,6 +279,7 @@
 1. [FMS] Run vertical predictions without V-speeds - @BlueberryKing (BlueberryKing)
 1. [ELEC] Use ADIRU and LGCIU signals for speed and in flight determination - @Gurgel100 (Pascal)
 1. [FMS] Do not transmit bearing information to ND on manual legs - @BravoMike99 (bruno_pt99)
+1. [FMS] Remove forced turn on following leg after leg insertion - @BlueberryKing (BlueberryKing)
 
 ## 0.11.0
 

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/plans/FlightPlan.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/plans/FlightPlan.ts
@@ -159,13 +159,14 @@ export class FlightPlan<P extends FlightPlanPerformanceData = FlightPlanPerforma
     const magneticCourse = A32NX_Util.trueToMagnetic(trueTrack, magVar);
 
     const turningPoint = FlightPlanLeg.turningPoint(this.enrouteSegment, ppos, magneticCourse);
-    const turnEnd = FlightPlanLeg.directToTurnEnd(this.enrouteSegment, targetLeg.terminationWaypoint());
-
     turningPoint.flags |= FlightPlanLegFlags.DirectToTurningPoint;
     if (this.index === FlightPlanIndex.Temporary) {
       turningPoint.flags |= FlightPlanLegFlags.PendingDirectToTurningPoint;
     }
-    turnEnd.withDefinitionFrom(targetLeg).withPilotEnteredDataFrom(targetLeg);
+
+    const turnEnd = FlightPlanLeg.directToTurnEnd(this.enrouteSegment, targetLeg.terminationWaypoint())
+      .withDefinitionFrom(targetLeg)
+      .withPilotEnteredDataFrom(targetLeg);
     // If we don't do this, the turn end will have the termination waypoint's ident which may not be the leg ident (for runway legs for example)
     turnEnd.ident = targetLeg.ident;
 
@@ -182,6 +183,7 @@ export class FlightPlan<P extends FlightPlanPerformanceData = FlightPlanPerforma
 
     const turnEndLegIndexInPlan = this.allLegs.findIndex((it) => it === turnEnd);
 
+    this.removeForcedTurnAt(turnEndLegIndexInPlan + 1);
     this.setActiveLegIndex(turnEndLegIndexInPlan);
   }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes a few issues with flight plan modifications:
1. After deleting a discontinuity, it could happen that the turn of the new leg went the wrong way due to the leg constellation. This is fixes by creating a TF leg from the leg after the discontinuity.
2. After truncating the flight plan by insertion of an existing waypoint or using DIR to, the outbound turn would sometimes go the wrong way because the following leg was coded with a forced turn. This is fixed by removing the forced turn on the following leg.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before: 
![image](https://cdn.discordapp.com/attachments/1277032019540316212/1277032020433965146/Screenshot_2024-08-24_215701.png?ex=66cbb03f&is=66ca5ebf&hm=a44db70a705dcdfddbd200516887b807fd6fabdc8a739372a3c7969c85ca9f08&)
After:
![image](https://github.com/user-attachments/assets/98cf21ed-2c31-4568-bd87-66f2fa2fd7a9)

Before:
![image](https://media.discordapp.net/attachments/748096886531162123/1251427705895784509/image3.png?ex=66cc24df&is=66cad35f&hm=8b897eea1bbced9ed1d5b1521125b89341a4ea0d34e2ac33dbf7c5330ea4f3b9&=&format=webp&quality=lossless)
After:
![image](https://github.com/user-attachments/assets/44318004-bb4e-4406-ae3e-0b655c5fc6ca)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Fly a procedure with a forced turn, try going DIR to the leg with the forced turn (indicated by a left/right arrow in the FPLN page). Make sure the turn goes the wrong way.
- Clear discontinuities on procedures. Make sure all turns go the right way.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
