### PR TITLE
fix(fms): fix tailwind being treated as headwind

### DIFF
--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -544,11 +544,11 @@ class CDUInitPage {
         const tripWindAvgCell = new Column(21, "---");
 
         if (mcdu.flightPlanService.active.originAirport && mcdu.flightPlanService.active.destinationAirport) {
-            tripWindDirCell.update(mcdu._windDir, Column.cyan, Column.small);
-            tripWindAvgCell.update(mcdu.averageWind.toFixed(0).padStart(3, "0"), Column.cyan);
+            tripWindDirCell.update(CDUInitPage.formatWindDirection(mcdu.averageWind), Column.cyan, Column.small);
+            tripWindAvgCell.update(CDUInitPage.formatWindComponent(mcdu.averageWind), Column.cyan);
 
-            mcdu.onRightInput[4] = async (value, scratchpadCallback) => {
-                if (await mcdu.trySetAverageWind(value)) {
+            mcdu.onRightInput[4] = (value, scratchpadCallback) => {
+                if (mcdu.trySetAverageWind(value)) {
                     CDUInitPage.ShowPage2(mcdu);
                 } else {
                     scratchpadCallback();
@@ -670,16 +670,14 @@ class CDUInitPage {
                 lwCell.update(NXUnits.kgToUser(mcdu.landingWeight).toFixed(1), Column.green, Column.small);
                 towLwCellDivider.updateAttributes(Column.green, Column.small);
 
-                tripWindDirCell.update(mcdu._windDir, Column.small);
-                tripWindAvgCell.update("000", Column.small);
+                const windComponent = Number.isFinite(mcdu.averageWind) ? mcdu.averageWind : 0;
 
-                if (isFinite(mcdu.averageWind)) {
-                    tripWindDirCell.update(mcdu._windDir, Column.small);
-                    tripWindAvgCell.update(mcdu.averageWind.toFixed(0).padStart(3, "0"), Column.big);
-                }
+                tripWindDirCell.update(CDUInitPage.formatWindDirection(windComponent), Column.small);
+                tripWindAvgCell.update(CDUInitPage.formatWindComponent(windComponent), Column.big);
+
                 mcdu.onRightInput[4] = async (value, scratchpadCallback) => {
-                    setTimeout(async () => {
-                        if (await mcdu.trySetAverageWind(value)) {
+                    setTimeout(() => {
+                        if (mcdu.trySetAverageWind(value)) {
                             if (mcdu.page.Current === mcdu.page.InitPageB) {
                                 CDUInitPage.ShowPage2(mcdu);
                             }
@@ -814,5 +812,13 @@ class CDUInitPage {
             min : Math.abs(0 | M / 1e7),
             sec : Math.abs((0 | M / 1e6 % 1 * 6e4) / 100)
         };
+    }
+
+    static formatWindDirection(tailwindComponent) {
+        return Math.round(tailwindComponent) > 0 ? "TL" : "HD";
+    }
+
+    static formatWindComponent(tailwindComponent) {
+        return Math.round(Math.abs(tailwindComponent)).toFixed(0).padStart(3, "0");
     }
 }

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -28,6 +28,7 @@ class FMCMainDisplay extends BaseAirliners {
         this._routeReservedPercent = undefined;
         this.takeOffWeight = undefined;
         this.landingWeight = undefined;
+        // +ve for tailwind, -ve for headwind
         this.averageWind = undefined;
         this.perfApprQNH = undefined;
         this.perfApprTemp = undefined;
@@ -44,11 +45,9 @@ class FMCMainDisplay extends BaseAirliners {
         this.perfApprFlaps3 = undefined;
         this._debug = undefined;
         this._checkFlightPlan = undefined;
-        this._windDirections = undefined;
         this._fuelPlanningPhases = undefined;
         this._zeroFuelWeightZFWCGEntered = undefined;
         this._taxiEntered = undefined;
-        this._windDir = undefined;
         this._DistanceToAlt = undefined;
         this._routeAltFuelWeight = undefined;
         this._routeAltFuelTime = undefined;
@@ -333,6 +332,7 @@ class FMCMainDisplay extends BaseAirliners {
         this._routeReservedPercent = 5;
         this.takeOffWeight = NaN;
         this.landingWeight = NaN;
+        // +ve for tailwind, -ve for headwind
         this.averageWind = 0;
         this.perfApprQNH = NaN;
         this.perfApprTemp = NaN;
@@ -349,10 +349,6 @@ class FMCMainDisplay extends BaseAirliners {
         this.perfApprFlaps3 = false;
         this._debug = 0;
         this._checkFlightPlan = 0;
-        this._windDirections = {
-            TAILWIND: "TL",
-            HEADWIND: "HD",
-        };
         this._fuelPlanningPhases = {
             PLANNING: 1,
             IN_PROGRESS: 2,
@@ -360,7 +356,6 @@ class FMCMainDisplay extends BaseAirliners {
         };
         this._zeroFuelWeightZFWCGEntered = false;
         this._taxiEntered = false;
-        this._windDir = this._windDirections.HEADWIND;
         this._DistanceToAlt = 0;
         this._routeAltFuelWeight = 0;
         this._routeAltFuelTime = 0;
@@ -2164,12 +2159,7 @@ class FMCMainDisplay extends BaseAirliners {
             this._routeAltFuelTime = 0;
         } else {
             const placeholderFl = 120;
-            let airDistance = 0;
-            if (this._windDir === this._windDirections.TAILWIND) {
-                airDistance = A32NX_FuelPred.computeAirDistance(Math.round(this._DistanceToAlt), this.averageWind);
-            } else if (this._windDir === this._windDirections.HEADWIND) {
-                airDistance = A32NX_FuelPred.computeAirDistance(Math.round(this._DistanceToAlt), -this.averageWind);
-            }
+            const airDistance = A32NX_FuelPred.computeAirDistance(Math.round(this._DistanceToAlt), this.averageWind);
 
             const deviation = (this.zeroFuelWeight + this._routeFinalFuelWeight - A32NX_FuelPred.refWeight) * A32NX_FuelPred.computeNumbers(airDistance, placeholderFl, A32NX_FuelPred.computations.CORRECTIONS, true);
             if ((20 < airDistance && airDistance < 200) && (100 < placeholderFl && placeholderFl < 290)) { //This will always be true until we can setup alternate routes
@@ -2185,14 +2175,9 @@ class FMCMainDisplay extends BaseAirliners {
      * won't be updated.
      */
     tryUpdateRouteTrip(dynamic = false) {
-        let airDistance = 0;
         // TODO Use static distance for `dynamic = false` (fms-v2)
         const groundDistance = Number.isFinite(this.getDistanceToDestination()) ? this.getDistanceToDestination() : -1;
-        if (this._windDir === this._windDirections.TAILWIND) {
-            airDistance = A32NX_FuelPred.computeAirDistance(groundDistance, this.averageWind);
-        } else if (this._windDir === this._windDirections.HEADWIND) {
-            airDistance = A32NX_FuelPred.computeAirDistance(groundDistance, -this.averageWind);
-        }
+        const airDistance = A32NX_FuelPred.computeAirDistance(groundDistance, this.averageWind);
 
         let altToUse = this.cruiseLevel;
         // Use the cruise level for calculations otherwise after cruise use descent altitude down to 10,000 feet.
@@ -3566,7 +3551,7 @@ class FMCMainDisplay extends BaseAirliners {
         return false;
     }
 
-    async trySetAverageWind(s) {
+    trySetAverageWind(s) {
         const validDelims = ["TL", "T", "+", "HD", "H", "-"];
         const matchedIndex = validDelims.findIndex(element => s.startsWith(element));
         const digits = matchedIndex >= 0 ? s.replace(validDelims[matchedIndex], "") : s;
@@ -3576,12 +3561,11 @@ class FMCMainDisplay extends BaseAirliners {
             return false;
         }
         const wind = parseInt(digits);
-        this._windDir = matchedIndex <= 2 ? this._windDirections.TAILWIND : this._windDirections.HEADWIND;
         if (wind > 250) {
             this.setScratchpadMessage(NXSystemMessages.entryOutOfRange);
             return false;
         }
-        this.averageWind = wind;
+        this.averageWind = matchedIndex <= 2 ? wind : -wind;
         return true;
     }
 
@@ -4827,7 +4811,8 @@ class FMCMainDisplay extends BaseAirliners {
     }
 
     getTripWind() {
-        return this.averageWind;
+        // FIXME convert vnav to use +ve for tailwind, -ve for headwind, it's the other way around at the moment
+        return -this.averageWind;
     }
 
     getWinds() {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8274 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Previously, vertical predictions did not check the wind direction and always treated the trip wind as a headwind component. This is fixed in this PR.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://github.com/user-attachments/assets/aed5bf36-18a2-4b53-9053-d50903325609) 
![image](https://github.com/user-attachments/assets/d4783bc9-932b-45ed-8af5-b60011a22f02)

![image](https://github.com/user-attachments/assets/27d007b7-b66c-42e3-a6ef-6b2e93475473)
![image](https://github.com/user-attachments/assets/40c7834a-2418-4b62-a328-5198d4d8cb21)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
I am aware that the trip wind field should be blanked out once a climb, cruise, or descent wind entry has been made. This is not addressed in this PR.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BlueberryKing

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Spawn cold & dark.
- Enter a route.
- Observe how the fuel prediction on the FPLN page changes as you enter a headwind vs. a tailwind as average trip wind.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
