### PR TITLE
fix(fms/nd): altitude constraint display on altitude terminated legs

### DIFF
--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -1044,7 +1044,7 @@ function formatMachNumber(rawNumber) {
  * @return {boolean}
  */
 function legHasAltConstraint(leg) {
-    return leg.hasPilotEnteredAltitudeConstraint() || leg.hasDatabaseAltitudeConstraint();
+    return !leg.isXA() && (leg.hasPilotEnteredAltitudeConstraint() || leg.hasDatabaseAltitudeConstraint());
 }
 
 /**

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
@@ -120,7 +120,7 @@ class CDUVerticalRevisionPage {
             l3Cell = "";
             r5Cell = "";
         } else {
-            if (canHaveAltConstraint) {
+            if (canHaveAltConstraint && altitudeConstraint) {
                 r3Cell = `{magenta}${altitudeConstraint}{end}`;
             }
             if (speedConstraint) {

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
@@ -70,9 +70,10 @@ class CDUVerticalRevisionPage {
         const speedConstraint = waypoint.speedConstraint ? Math.round(waypoint.speedConstraint.speed).toFixed(0) : undefined;
         const transAltLevel = constraintType === WaypointConstraintType.DES ? performanceData.transitionLevel * 100 : performanceData.transitionAltitude;
         const altitudeConstraint = this.formatAltConstraint(waypoint.altitudeConstraint, transAltLevel);
+        const canHaveAltConstraint = !isDestination && !waypoint.isXA();
 
-        let r3Title = "ALT CSTR\xa0";
-        let r3Cell = "{cyan}[\xa0\xa0\xa0\xa0]*{end}";
+        let r3Title = canHaveAltConstraint ? "ALT CSTR\xa0" : "";
+        let r3Cell = canHaveAltConstraint ? "{cyan}[\xa0\xa0\xa0\xa0]*{end}" : "";
         let l3Title = "\xa0SPD CSTR";
         let l3Cell = "{cyan}*[\xa0\xa0\xa0]{end}";
         let l4Title = "MACH/START WPT[color]inop";
@@ -119,7 +120,7 @@ class CDUVerticalRevisionPage {
             l3Cell = "";
             r5Cell = "";
         } else {
-            if (altitudeConstraint) {
+            if (canHaveAltConstraint) {
                 r3Cell = `{magenta}${altitudeConstraint}{end}`;
             }
             if (speedConstraint) {
@@ -245,50 +246,52 @@ class CDUVerticalRevisionPage {
 
             this.ShowPage(mcdu, waypoint, wpIndex, verticalWaypoint, undefined, undefined, undefined, forPlan, inAlternate);
         }; // SPD CSTR
-        mcdu.onRightInput[2] = async (value, scratchpadCallback) => {
-            if (value === FMCMainDisplay.clrValue) {
-                await mcdu.flightPlanService.setPilotEnteredAltitudeConstraintAt(wpIndex, constraintType === WaypointConstraintType.DES, undefined, forPlan, inAlternate);
+        if (canHaveAltConstraint) {
+            mcdu.onRightInput[2] = async (value, scratchpadCallback) => {
+                if (value === FMCMainDisplay.clrValue) {
+                    await mcdu.flightPlanService.setPilotEnteredAltitudeConstraintAt(wpIndex, constraintType === WaypointConstraintType.DES, undefined, forPlan, inAlternate);
+
+                    mcdu.updateConstraints();
+                    mcdu.guidanceController.vnavDriver.invalidateFlightPlanProfile();
+
+                    this.ShowPage(mcdu, waypoint, wpIndex, verticalWaypoint, undefined, undefined, undefined, forPlan, inAlternate);
+
+                    return;
+                }
+
+                const matchResult = value.match(/^([+-])?(((FL)?([0-9]{1,3}))|([0-9]{4,5}))$/);
+
+                if (matchResult === null) {
+                    mcdu.setScratchpadMessage(NXSystemMessages.formatError);
+                    scratchpadCallback();
+                    return;
+                }
+
+                const altitude = matchResult[5] !== undefined ? parseInt(matchResult[5]) * 100 : parseInt(matchResult[6]);
+                const code = matchResult[1] === undefined ? '@' : (matchResult[1] === '-' ? '-' : '+');
+
+                if (altitude > 45000) {
+                    mcdu.setScratchpadMessage(NXSystemMessages.entryOutOfRange);
+                    scratchpadCallback();
+                    return;
+                }
+
+                if (constraintType === WaypointConstraintType.Unknown) {
+                    CDUVerticalRevisionPage.ShowPage(mcdu, waypoint, wpIndex, verticalWaypoint, undefined, altitude, code, forPlan, inAlternate,);
+                    return;
+                }
+
+                await mcdu.flightPlanService.setPilotEnteredAltitudeConstraintAt(wpIndex, constraintType === WaypointConstraintType.DES, {
+                    altitudeDescriptor: code,
+                    altitude1: altitude,
+                }, forPlan, inAlternate);
 
                 mcdu.updateConstraints();
                 mcdu.guidanceController.vnavDriver.invalidateFlightPlanProfile();
 
                 this.ShowPage(mcdu, waypoint, wpIndex, verticalWaypoint, undefined, undefined, undefined, forPlan, inAlternate);
-
-                return;
-            }
-
-            const matchResult = value.match(/^([+-])?(((FL)?([0-9]{1,3}))|([0-9]{4,5}))$/);
-
-            if (matchResult === null) {
-                mcdu.setScratchpadMessage(NXSystemMessages.formatError);
-                scratchpadCallback();
-                return;
-            }
-
-            const altitude = matchResult[5] !== undefined ? parseInt(matchResult[5]) * 100 : parseInt(matchResult[6]);
-            const code = matchResult[1] === undefined ? '@' : (matchResult[1] === '-' ? '-' : '+');
-
-            if (altitude > 45000) {
-                mcdu.setScratchpadMessage(NXSystemMessages.entryOutOfRange);
-                scratchpadCallback();
-                return;
-            }
-
-            if (constraintType === WaypointConstraintType.Unknown) {
-                CDUVerticalRevisionPage.ShowPage(mcdu, waypoint, wpIndex, verticalWaypoint, undefined, altitude, code, forPlan, inAlternate,);
-                return;
-            }
-
-            await mcdu.flightPlanService.setPilotEnteredAltitudeConstraintAt(wpIndex, constraintType === WaypointConstraintType.DES, {
-                altitudeDescriptor: code,
-                altitude1: altitude,
-            }, forPlan, inAlternate);
-
-            mcdu.updateConstraints();
-            mcdu.guidanceController.vnavDriver.invalidateFlightPlanProfile();
-
-            this.ShowPage(mcdu, waypoint, wpIndex, verticalWaypoint, undefined, undefined, undefined, forPlan, inAlternate);
-        }; // ALT CSTR
+            }; // ALT CSTR
+        }
         mcdu.onLeftInput[4] = () => {
             //TODO: show appropriate wind page based on waypoint
             CDUWindPage.Return = () => {

--- a/fbw-a32nx/src/systems/fmgc/src/efis/EfisSymbols.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/efis/EfisSymbols.ts
@@ -673,7 +673,8 @@ export class EfisSymbols<T extends number> {
         !isBeforeActiveLeg &&
         altConstraint &&
         shouldShowConstraintCircleInPhase(flightPhase, leg) &&
-        !isAlternate
+        !isAlternate &&
+        !leg.isXA()
       ) {
         if (!isSelectedVerticalModeActive) {
           type |= NdSymbolTypeFlags.Constraint;
@@ -691,32 +692,34 @@ export class EfisSymbols<T extends number> {
       }
 
       if ((efisOption & EfisOption.Constraints) > 0 && !isBeforeActiveLeg) {
-        const descent = leg.constraintType === WaypointConstraintType.DES;
-        switch (altConstraint?.altitudeDescriptor) {
-          case AltitudeDescriptor.AtAlt1:
-          case AltitudeDescriptor.AtAlt1GsIntcptAlt2:
-          case AltitudeDescriptor.AtAlt1AngleAlt2:
-            constraints.push(formatConstraintAlt(altConstraint.altitude1, descent));
-            break;
-          case AltitudeDescriptor.AtOrAboveAlt1:
-          case AltitudeDescriptor.AtOrAboveAlt1GsIntcptAlt2:
-          case AltitudeDescriptor.AtOrAboveAlt1AngleAlt2:
-            constraints.push(formatConstraintAlt(altConstraint.altitude1, descent, '+'));
-            break;
-          case AltitudeDescriptor.AtOrBelowAlt1:
-          case AltitudeDescriptor.AtOrBelowAlt1AngleAlt2:
-            constraints.push(formatConstraintAlt(altConstraint.altitude1, descent, '-'));
-            break;
-          case AltitudeDescriptor.BetweenAlt1Alt2:
-            constraints.push(formatConstraintAlt(altConstraint.altitude1, descent, '-'));
-            constraints.push(formatConstraintAlt(altConstraint.altitude2, descent, '+'));
-            break;
-          case AltitudeDescriptor.AtOrAboveAlt2:
-            constraints.push(formatConstraintAlt(altConstraint.altitude2, descent, '+'));
-            break;
-          default:
-            // No constraint
-            break;
+        if (!leg.isXA()) {
+          const descent = leg.constraintType === WaypointConstraintType.DES;
+          switch (altConstraint?.altitudeDescriptor) {
+            case AltitudeDescriptor.AtAlt1:
+            case AltitudeDescriptor.AtAlt1GsIntcptAlt2:
+            case AltitudeDescriptor.AtAlt1AngleAlt2:
+              constraints.push(formatConstraintAlt(altConstraint.altitude1, descent));
+              break;
+            case AltitudeDescriptor.AtOrAboveAlt1:
+            case AltitudeDescriptor.AtOrAboveAlt1GsIntcptAlt2:
+            case AltitudeDescriptor.AtOrAboveAlt1AngleAlt2:
+              constraints.push(formatConstraintAlt(altConstraint.altitude1, descent, '+'));
+              break;
+            case AltitudeDescriptor.AtOrBelowAlt1:
+            case AltitudeDescriptor.AtOrBelowAlt1AngleAlt2:
+              constraints.push(formatConstraintAlt(altConstraint.altitude1, descent, '-'));
+              break;
+            case AltitudeDescriptor.BetweenAlt1Alt2:
+              constraints.push(formatConstraintAlt(altConstraint.altitude1, descent, '-'));
+              constraints.push(formatConstraintAlt(altConstraint.altitude2, descent, '+'));
+              break;
+            case AltitudeDescriptor.AtOrAboveAlt2:
+              constraints.push(formatConstraintAlt(altConstraint.altitude2, descent, '+'));
+              break;
+            default:
+              // No constraint
+              break;
+          }
         }
 
         const speedConstraint = leg.speedConstraint;

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/legs/FlightPlanLeg.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/legs/FlightPlanLeg.ts
@@ -208,6 +208,12 @@ export class FlightPlanLeg implements ReadonlyFlightPlanLeg {
     return legType === LegType.PI || legType === LegType.CI || legType === LegType.VI;
   }
 
+  isXA() {
+    const legType = this.definition.type;
+
+    return legType === LegType.CA || legType === LegType.FA || legType === LegType.HA || legType === LegType.VA;
+  }
+
   isVectors() {
     const legType = this.definition.type;
 

--- a/fbw-common/src/systems/instruments/src/ND/shared/map/ConstraintsLayer.ts
+++ b/fbw-common/src/systems/instruments/src/ND/shared/map/ConstraintsLayer.ts
@@ -17,15 +17,11 @@ export class ConstraintsLayer implements MapLayer<NdSymbol> {
     mapParameters: MapParameters,
   ) {
     for (const symbol of this.data) {
-      if (!symbol.constraints || !(symbol.type & NdSymbolTypeFlags.Constraint)) {
-        continue;
-      }
-
       const [x, y] = mapParameters.coordinatesToXYy(symbol.location);
       const rx = x + mapWidth / 2;
       const ry = y + mapHeight / 2;
 
-      this.paintConstraintCircle(true, context, rx, ry, symbol);
+      this.paintConstraintCircle(false, context, rx, ry, symbol);
     }
   }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes the following:
- The MCDU F-PLN page no longer shows altitude constraints for xA legs.
- The ND no longer shows altitude constraints or constraint predictions for xA legs.
- The ND now draws the constraint ring shadow correctly, and does not hide it when the CSTR option is off.
- The MCDU F-PLN page no longer shows the ALT CSTR field for xA legs, and entry is disabled for the destination leg too.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Setup a flight plan with an altitude terminated leg in the departure and at least one other altitude constraint.
- Toggle the EFIS CSTR button on/off and ensure the altitude constraint prediction circle(s) on the ND do not change in brightness.
- Ensure the altitude terminated leg does not have an altitude constraint prediction circle, and does not show a magenta altitude when the CSTR button is turned on.
- In the MCDU, go to the VERT REV page (right LSK) for the altitude leg, ensure it has no ALT CSTR field.
- Go to other legs, including the other leg with an altitude constraint, and ensure their VERT REVs show the ALT CSTR field.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
