### PR TITLE
feat(tcas): add additional lvars for A429 word compatability

### DIFF
--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -3910,6 +3910,50 @@ In the variables below, {number} should be replaced with one item in the set: { 
         - 0
         - 1
 
+- A32NX_TCAS_RA_TYPE
+    - Enum
+    - Read-only
+    - The type of currently active RA
+      Description | Value
+        --- | ---
+        None of the following | 0
+        Crossing | 1
+        Reversal | 2
+        Increase | 3
+        Maintain | 4
+
+- A32NX_TCAS_RA_RATE_TO_MAINTAIN
+    - Feet per minute
+    - Read-only
+    - The rate to maintain (green sector) of the currently active RA. 0 if up/down advisory status is neither Climb nor Descend or no RA is present
+
+- A32NX_TCAS_RA_UP_ADVISORY_STATUS
+    - Enum
+    - Read-only
+    - The up advisory status of the currently active RA
+      Description | Value
+        --- | ---
+        No Up Advisory       | 0
+        Climb                | 1
+        Don't Descend        | 2
+        Don't Descend > 500  | 3
+        Don't Descend > 1000 | 4
+        Don't Descend > 2000 | 5
+
+- A32NX_TCAS_RA_DOWN_ADVISORY_STATUS
+    - Enum
+    - Read-only
+    - The down advisory status of the currently active RA
+      Description | Value
+        --- | ---
+        No Down Advisory   | 0
+        Descend            | 1
+        Don't Climb        | 2
+        Don't Climb > 500  | 3
+        Don't Climb > 1000 | 4
+        Don't Climb > 2000 | 5
+
+
 ## Radio Altimeter (ATA 34)
 
 - A32NX_RA_{number}_RADIO_ALTITUDE

--- a/fbw-a32nx/src/systems/tcas/src/lib/TcasConstants.ts
+++ b/fbw-a32nx/src/systems/tcas/src/lib/TcasConstants.ts
@@ -67,6 +67,21 @@ export enum RaType {
   CORRECT = 0,
   PREVENT = 1,
 }
+export enum RaType2 {
+  NONE = 0,
+  CROSSING = 1,
+  REVERSAL = 2,
+  INCREASE = 3,
+  MAINTAIN = 4,
+}
+export enum UpDownAdvisoryStatus {
+  NO_ADVISORY = 0,
+  CLIMB_DESCEND = 1,
+  DONT_CLIMB_DONT_DESCEND = 2,
+  DONT_CLIMB_DONT_DESCEND_GREATER_500 = 3,
+  DONT_CLIMB_DONT_DESCEND_GREATER_1000 = 4,
+  DONT_CLIMB_DONT_DESCEND_GREATER_2000 = 5,
+}
 export enum Limits {
   MIN = 0,
   MAX = 1,
@@ -131,7 +146,11 @@ export interface RaParams {
   callout: RaCallout;
   sense: RaSense;
   type: RaType;
+  type2: RaType2;
   vs: VerticalSpeedLimits;
+  rateToMaintain: number;
+  upAdvisory: UpDownAdvisoryStatus;
+  downAdvisory: UpDownAdvisoryStatus;
 }
 
 interface VerticalSpeedLimits {
@@ -475,74 +494,106 @@ const RA_VARIANTS: { [key: string]: RaParams } = {
     callout: CALLOUTS.monitor_vs,
     sense: RaSense.UP,
     type: RaType.PREVENT,
+    type2: RaType2.NONE,
     vs: {
       green: [0, MAX_VS],
       red: [MIN_VS, 0],
     },
+    rateToMaintain: 0,
+    upAdvisory: UpDownAdvisoryStatus.DONT_CLIMB_DONT_DESCEND,
+    downAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
   },
   monitor_vs_climb_500: {
     callout: CALLOUTS.monitor_vs,
     sense: RaSense.UP,
     type: RaType.PREVENT,
+    type2: RaType2.NONE,
     vs: {
       green: [-500, MAX_VS],
       red: [MIN_VS, -500],
     },
+    rateToMaintain: 0,
+    upAdvisory: UpDownAdvisoryStatus.DONT_CLIMB_DONT_DESCEND_GREATER_500,
+    downAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
   },
   monitor_vs_climb_1000: {
     callout: CALLOUTS.monitor_vs,
     sense: RaSense.UP,
     type: RaType.PREVENT,
+    type2: RaType2.NONE,
     vs: {
       green: [-1000, MAX_VS],
       red: [MIN_VS, -1000],
     },
+    rateToMaintain: 0,
+    upAdvisory: UpDownAdvisoryStatus.DONT_CLIMB_DONT_DESCEND_GREATER_1000,
+    downAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
   },
   monitor_vs_climb_2000: {
     callout: CALLOUTS.monitor_vs,
     sense: RaSense.UP,
     type: RaType.PREVENT,
+    type2: RaType2.NONE,
     vs: {
       green: [-2000, MAX_VS],
       red: [MIN_VS, -2000],
     },
+    rateToMaintain: 0,
+    upAdvisory: UpDownAdvisoryStatus.DONT_CLIMB_DONT_DESCEND_GREATER_2000,
+    downAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
   },
 
   monitor_vs_descend_0: {
     callout: CALLOUTS.monitor_vs,
     sense: RaSense.DOWN,
     type: RaType.PREVENT,
+    type2: RaType2.NONE,
     vs: {
       green: [MIN_VS, 0],
       red: [0, MAX_VS],
     },
+    rateToMaintain: 0,
+    upAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
+    downAdvisory: UpDownAdvisoryStatus.DONT_CLIMB_DONT_DESCEND,
   },
   monitor_vs_descend_500: {
     callout: CALLOUTS.monitor_vs,
     sense: RaSense.DOWN,
     type: RaType.PREVENT,
+    type2: RaType2.NONE,
     vs: {
       green: [MIN_VS, 500],
       red: [500, MAX_VS],
     },
+    rateToMaintain: 0,
+    upAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
+    downAdvisory: UpDownAdvisoryStatus.DONT_CLIMB_DONT_DESCEND_GREATER_500,
   },
   monitor_vs_descend_1000: {
     callout: CALLOUTS.monitor_vs,
     sense: RaSense.DOWN,
     type: RaType.PREVENT,
+    type2: RaType2.NONE,
     vs: {
       green: [MIN_VS, 1000],
       red: [1000, MAX_VS],
     },
+    rateToMaintain: 0,
+    upAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
+    downAdvisory: UpDownAdvisoryStatus.DONT_CLIMB_DONT_DESCEND_GREATER_1000,
   },
   monitor_vs_descend_2000: {
     callout: CALLOUTS.monitor_vs,
     sense: RaSense.DOWN,
     type: RaType.PREVENT,
+    type2: RaType2.NONE,
     vs: {
       green: [MIN_VS, 2000],
       red: [2000, MAX_VS],
     },
+    rateToMaintain: 0,
+    upAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
+    downAdvisory: UpDownAdvisoryStatus.DONT_CLIMB_DONT_DESCEND_GREATER_2000,
   },
   // CORRECTIVE RA's
   // CLIMB
@@ -550,37 +601,53 @@ const RA_VARIANTS: { [key: string]: RaParams } = {
     callout: CALLOUTS.climb,
     sense: RaSense.UP,
     type: RaType.CORRECT,
+    type2: RaType2.NONE,
     vs: {
       green: [1500, 2000],
       red: [MIN_VS, 1500],
     },
+    rateToMaintain: 1500,
+    upAdvisory: UpDownAdvisoryStatus.CLIMB_DESCEND,
+    downAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
   },
   climb_cross: {
     callout: CALLOUTS.climb_cross,
     sense: RaSense.UP,
     type: RaType.CORRECT,
+    type2: RaType2.CROSSING,
     vs: {
       green: [1500, 2000],
       red: [MIN_VS, 1500],
     },
+    rateToMaintain: 1500,
+    upAdvisory: UpDownAdvisoryStatus.CLIMB_DESCEND,
+    downAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
   },
   climb_increase: {
     callout: CALLOUTS.climb_increase,
     sense: RaSense.UP,
     type: RaType.CORRECT,
+    type2: RaType2.INCREASE,
     vs: {
       green: [2500, 4400],
       red: [MIN_VS, 2500],
     },
+    rateToMaintain: 2500,
+    upAdvisory: UpDownAdvisoryStatus.CLIMB_DESCEND,
+    downAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
   },
   climb_now: {
     callout: CALLOUTS.climb_now,
     sense: RaSense.UP,
     type: RaType.CORRECT,
+    type2: RaType2.REVERSAL,
     vs: {
       green: [1500, 2000],
       red: [MIN_VS, 1500],
     },
+    rateToMaintain: 1500,
+    upAdvisory: UpDownAdvisoryStatus.CLIMB_DESCEND,
+    downAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
   },
   // CORRECTIVE RA's
   // DESCEND
@@ -588,37 +655,53 @@ const RA_VARIANTS: { [key: string]: RaParams } = {
     callout: CALLOUTS.descend,
     sense: RaSense.DOWN,
     type: RaType.CORRECT,
+    type2: RaType2.NONE,
     vs: {
       green: [-2000, -1500],
       red: [-1500, MAX_VS],
     },
+    rateToMaintain: -1500,
+    upAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
+    downAdvisory: UpDownAdvisoryStatus.CLIMB_DESCEND,
   },
   descend_cross: {
     callout: CALLOUTS.descend_cross,
     sense: RaSense.DOWN,
     type: RaType.CORRECT,
+    type2: RaType2.CROSSING,
     vs: {
       green: [-2000, -1500],
       red: [-1500, MAX_VS],
     },
+    rateToMaintain: -1500,
+    upAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
+    downAdvisory: UpDownAdvisoryStatus.CLIMB_DESCEND,
   },
   descend_increase: {
     callout: CALLOUTS.descend_increase,
     sense: RaSense.DOWN,
     type: RaType.CORRECT,
+    type2: RaType2.INCREASE,
     vs: {
       green: [-4400, -2500],
       red: [-2500, MAX_VS],
     },
+    rateToMaintain: -2500,
+    upAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
+    downAdvisory: UpDownAdvisoryStatus.CLIMB_DESCEND,
   },
   descend_now: {
     callout: CALLOUTS.descend_now,
     sense: RaSense.DOWN,
     type: RaType.CORRECT,
+    type2: RaType2.REVERSAL,
     vs: {
       green: [-2000, -1500],
       red: [-1500, MAX_VS],
     },
+    rateToMaintain: -1500,
+    upAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
+    downAdvisory: UpDownAdvisoryStatus.CLIMB_DESCEND,
   },
   // CORRECTIVE RA's
   // LEVEL OFF
@@ -629,6 +712,7 @@ const RA_VARIANTS: { [key: string]: RaParams } = {
   //     callout: CALLOUTS.level_off,
   //     sense: RaSense.UP,
   //     type: RaType.CORRECT,
+  //     type2: RaType2.NONE,
   //     vs: {
   //         green: [-250, 250],
   //         red: [
@@ -636,24 +720,35 @@ const RA_VARIANTS: { [key: string]: RaParams } = {
   //             [250, MAX_VS]
   //         ]
   //     }
+  //     rateToMaintain: 0,
+  //     upAdvisory: UpDownAdvisoryStatus.DONT_CLIMB_DONT_DESCEND,
+  //     downAdvisory: UpDownAdvisoryStatus.DONT_CLIMB_DONT_DESCEND,
   // },
   level_off_300_below: {
     callout: CALLOUTS.level_off,
     sense: RaSense.DOWN,
     type: RaType.CORRECT,
+    type2: RaType2.NONE,
     vs: {
       green: [-400, 0],
       red: [0, MAX_VS],
     },
+    rateToMaintain: 0,
+    upAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
+    downAdvisory: UpDownAdvisoryStatus.DONT_CLIMB_DONT_DESCEND,
   },
   level_off_300_above: {
     callout: CALLOUTS.level_off,
     sense: RaSense.UP,
     type: RaType.CORRECT,
+    type2: RaType2.NONE,
     vs: {
       green: [0, 400],
       red: [MIN_VS, 0],
     },
+    rateToMaintain: 0,
+    upAdvisory: UpDownAdvisoryStatus.DONT_CLIMB_DONT_DESCEND,
+    downAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
   },
   // CORRECTIVE RA's
   // MAINTAIN VS, CLIMB
@@ -661,19 +756,27 @@ const RA_VARIANTS: { [key: string]: RaParams } = {
     callout: CALLOUTS.maintain_vs,
     sense: RaSense.UP,
     type: RaType.CORRECT,
+    type2: RaType2.MAINTAIN,
     vs: {
       green: [1500, 4400],
       red: [MIN_VS, 1500],
     },
+    rateToMaintain: 1500,
+    upAdvisory: UpDownAdvisoryStatus.CLIMB_DESCEND,
+    downAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
   },
   climb_maintain_vs_crossing: {
     callout: CALLOUTS.maintain_vs,
     sense: RaSense.UP,
     type: RaType.CORRECT,
+    type2: RaType2.MAINTAIN,
     vs: {
       green: [1500, 4400],
       red: [MIN_VS, 1500],
     },
+    rateToMaintain: 1500,
+    upAdvisory: UpDownAdvisoryStatus.CLIMB_DESCEND,
+    downAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
   },
   // CORRECTIVE RA's
   // MAINTAIN VS, DESCEND
@@ -681,19 +784,27 @@ const RA_VARIANTS: { [key: string]: RaParams } = {
     callout: CALLOUTS.maintain_vs,
     sense: RaSense.DOWN,
     type: RaType.CORRECT,
+    type2: RaType2.MAINTAIN,
     vs: {
       green: [-4400, -1500],
       red: [-1500, MAX_VS],
     },
+    rateToMaintain: -1500,
+    upAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
+    downAdvisory: UpDownAdvisoryStatus.CLIMB_DESCEND,
   },
   descend_maintain_vs_crossing: {
     callout: CALLOUTS.maintain_vs,
     sense: RaSense.DOWN,
     type: RaType.CORRECT,
+    type2: RaType2.MAINTAIN,
     vs: {
       green: [-4400, -1500],
       red: [-1500, MAX_VS],
     },
+    rateToMaintain: -1500,
+    upAdvisory: UpDownAdvisoryStatus.NO_ADVISORY,
+    downAdvisory: UpDownAdvisoryStatus.CLIMB_DESCEND,
   },
 } as const;
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR adds Lvars to the TCAS outputs that are necessary to create the TCAS vertical resolution advisory output word:
1. The RA type (crossing, reversal, etc.) which is currently not output
2. The advisory rate to maintain, which is currently only output as the green sector range, which is inconvenient
3. The up and down advisory, which is currently output as the red sector ranges, which is inconvenient.

The word also requires information if the current state is clear of conflict, but I decided that this is out of scope for this PR.

These outputs are currently unused, but will be used in the FMGC PR (#7587) as it will add a TCAS bus shim. A possible future PR could also add the TCAS output bus directly, and change over the PFD to it as well.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
For information, the A429 word is structured as follows: 

| Bit | Description |
|--------|--------|
| 11 - 16 | Advisory rate to maintain |
| 17 | Advisory rate to maintain sign |
| 18-20 | Combined Control: |
| | 0 - No advisory |
| | 1 - Clear of Conflict |
| | 2,3 - Spare |
| | 4 - Up advisory Corrective |
| | 5 - Down advisory Corrective |
| | 6 - Preventive |
| 21-23 | Vertical Control: |
| | 0 - None of the following |
| | 1 - Crossing |
| | 2 - Reversal |
| | 3 - Increase |
| | 4 - Maintain |
| 24-26 | Up Advisory: |
| | 0 - No up advisory |
| | 1 - Climb |
| | 2 - Don't descend |
| | 3 - Don't descend > 500 |
| | 4 - Don't descend > 1000 |
| | 5 - Don't descend > 2000 |
| 27-29 | Down Advisory: |
| | 0 - No down advisory |
| | 1 - Descend |
| | 2 - Don't climb |
| | 3 - Don't climb > 500 |
| | 4 - Don't climb > 1000 |
| | 5 - Don't climb > 2000 |

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
