### PR TITLE
fix(adirs): fix ADIRS low speed warning discrete logic

### DIFF
--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/mod.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/mod.rs
@@ -2695,7 +2695,7 @@ impl A320GearHydraulicController {
         lgciu2: &impl LgciuWeightOnWheels,
     ) {
         let speed_condition =
-            !adirs.low_speed_warning_4_260kts(1) || !adirs.low_speed_warning_4_260kts(3);
+            adirs.low_speed_warning_4_260kts(1) || adirs.low_speed_warning_4_260kts(3);
 
         let on_ground_condition = lgciu1.left_and_right_gear_compressed(true)
             || lgciu2.left_and_right_gear_compressed(true);
@@ -6062,7 +6062,7 @@ mod tests {
             }
 
             fn low_speed_warning_4_260kts(&self, _: usize) -> bool {
-                self.airspeed.get::<knot>() > 260.
+                self.airspeed.get::<knot>() < 260.
             }
         }
 

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
@@ -3023,7 +3023,7 @@ impl A380GearHydraulicController {
         lgciu2: &impl LgciuWeightOnWheels,
     ) {
         let speed_condition =
-            !adirs.low_speed_warning_4_260kts(1) || !adirs.low_speed_warning_4_260kts(3);
+            adirs.low_speed_warning_4_260kts(1) || adirs.low_speed_warning_4_260kts(3);
 
         let on_ground_condition = lgciu1.left_and_right_gear_compressed(true)
             || lgciu2.left_and_right_gear_compressed(true);
@@ -6594,7 +6594,7 @@ mod tests {
             }
 
             fn low_speed_warning_4_260kts(&self, _: usize) -> bool {
-                self.airspeed.get::<knot>() > 260.
+                self.airspeed.get::<knot>() < 260.
             }
         }
         impl AdirsMeasurementOutputs for A380TestAdirus {

--- a/fbw-common/src/wasm/systems/systems/src/navigation/adirs.rs
+++ b/fbw-common/src/wasm/systems/systems/src/navigation/adirs.rs
@@ -611,10 +611,6 @@ impl AirDataInertialReferenceUnit {
         self.ir.has_fault()
     }
 
-    fn adr_is_valid(&self) -> bool {
-        self.adr.is_valid()
-    }
-
     // When the ADR is unpowered (i.e. knob is set to OFF), all discretes go to open circuit (false).
     // Discrete #4 is inverted, so ground when below 260kts, OC otherwise.
     // When CAS is invalid but the ADR is otherwise powered (currently only possible when ADR p/b is off),

--- a/fbw-common/src/wasm/systems/systems/src/navigation/adirs.rs
+++ b/fbw-common/src/wasm/systems/systems/src/navigation/adirs.rs
@@ -4613,13 +4613,13 @@ mod tests {
             test_bed.run();
 
             assert!(
-                !test_bed.query(|a| a.adirs.adirus[adiru_number - 1].low_speed_warning_4_260kts())
+                test_bed.query(|a| a.adirs.adirus[adiru_number - 1].low_speed_warning_4_260kts())
             );
 
             test_bed.set_indicated_airspeed(Velocity::new::<knot>(265.));
             test_bed.run();
             assert!(
-                test_bed.query(|a| a.adirs.adirus[adiru_number - 1].low_speed_warning_4_260kts())
+                !test_bed.query(|a| a.adirs.adirus[adiru_number - 1].low_speed_warning_4_260kts())
             );
         }
 
@@ -4633,19 +4633,19 @@ mod tests {
             test_bed.run();
 
             assert!(
-                test_bed.query(|a| a.adirs.adirus[adiru_number - 1].low_speed_warning_1_104kts())
+                !test_bed.query(|a| a.adirs.adirus[adiru_number - 1].low_speed_warning_1_104kts())
             );
 
             assert!(
-                test_bed.query(|a| a.adirs.adirus[adiru_number - 1].low_speed_warning_2_54kts())
+                !test_bed.query(|a| a.adirs.adirus[adiru_number - 1].low_speed_warning_2_54kts())
             );
 
             assert!(
-                test_bed.query(|a| a.adirs.adirus[adiru_number - 1].low_speed_warning_3_159kts())
+                !test_bed.query(|a| a.adirs.adirus[adiru_number - 1].low_speed_warning_3_159kts())
             );
 
             assert!(
-                test_bed.query(|a| a.adirs.adirus[adiru_number - 1].low_speed_warning_4_260kts())
+                !test_bed.query(|a| a.adirs.adirus[adiru_number - 1].low_speed_warning_4_260kts())
             );
         }
     }

--- a/fbw-common/src/wasm/systems/systems/src/navigation/adirs.rs
+++ b/fbw-common/src/wasm/systems/systems/src/navigation/adirs.rs
@@ -618,22 +618,24 @@ impl AirDataInertialReferenceUnit {
     fn update_discrete_outputs(&mut self) {
         let speed_knot = self.adr.computed_airspeed_raw().get::<knot>();
 
-        if speed_knot < 100. && self.adr.is_on {
-            self.low_speed_warning_1_104kts = false;
-        } else if speed_knot > 104. && self.adr.is_on {
-            self.low_speed_warning_1_104kts = true;
-        }
+        if self.adr.is_on {
+            if speed_knot < 100. {
+                self.low_speed_warning_1_104kts = false;
+            } else if speed_knot > 104. {
+                self.low_speed_warning_1_104kts = true;
+            }
 
-        if speed_knot < 50. && self.adr.is_on {
-            self.low_speed_warning_2_54kts = false;
-        } else if speed_knot > 54. && self.adr.is_on {
-            self.low_speed_warning_2_54kts = true;
-        }
+            if speed_knot < 50. {
+                self.low_speed_warning_2_54kts = false;
+            } else if speed_knot > 54. {
+                self.low_speed_warning_2_54kts = true;
+            }
 
-        if speed_knot < 155. && self.adr.is_on {
-            self.low_speed_warning_3_159kts = false;
-        } else if speed_knot > 159. && self.adr.is_on {
-            self.low_speed_warning_3_159kts = true;
+            if speed_knot < 155. {
+                self.low_speed_warning_3_159kts = false;
+            } else if speed_knot > 159. {
+                self.low_speed_warning_3_159kts = true;
+            }
         }
 
         if speed_knot < 260. && self.adr.is_on {

--- a/fbw-common/src/wasm/systems/systems/src/navigation/adirs.rs
+++ b/fbw-common/src/wasm/systems/systems/src/navigation/adirs.rs
@@ -615,39 +615,42 @@ impl AirDataInertialReferenceUnit {
         self.adr.is_valid()
     }
 
-    // If above speed threshold OR if data is unavailable: all discrete are set to TRUE
+    // When the ADR is unpowered (i.e. knob is set to OFF), all discretes go to open circuit (false).
+    // Discrete #4 is inverted, so ground when below 260kts, OC otherwise.
+    // When CAS is invalid but the ADR is otherwise powered (currently only possible when ADR p/b is off),
+    // 1-3 remain in their previous state, and 4 goes OC.
     fn update_discrete_outputs(&mut self) {
         let speed_knot = self.adr.computed_airspeed_raw().get::<knot>();
 
-        if speed_knot < 100. {
+        if speed_knot < 100. && self.adr.is_on {
             self.low_speed_warning_1_104kts = false;
-        } else if speed_knot > 104. {
+        } else if speed_knot > 104. && self.adr.is_on {
             self.low_speed_warning_1_104kts = true;
         }
 
-        if speed_knot < 50. {
+        if speed_knot < 50. && self.adr.is_on {
             self.low_speed_warning_2_54kts = false;
-        } else if speed_knot > 54. {
+        } else if speed_knot > 54. && self.adr.is_on {
             self.low_speed_warning_2_54kts = true;
         }
 
-        if speed_knot < 155. {
+        if speed_knot < 155. && self.adr.is_on {
             self.low_speed_warning_3_159kts = false;
-        } else if speed_knot > 159. {
+        } else if speed_knot > 159. && self.adr.is_on {
             self.low_speed_warning_3_159kts = true;
         }
 
-        if speed_knot < 260. {
+        if speed_knot < 260. && self.adr.is_on {
+            self.low_speed_warning_4_260kts = true;
+        } else if speed_knot > 264. || !self.adr.is_on {
             self.low_speed_warning_4_260kts = false;
-        } else if speed_knot > 264. {
-            self.low_speed_warning_4_260kts = true;
         }
 
-        if !self.adr_is_valid() {
-            self.low_speed_warning_1_104kts = true;
-            self.low_speed_warning_2_54kts = true;
-            self.low_speed_warning_3_159kts = true;
-            self.low_speed_warning_4_260kts = true;
+        if !self.adr.is_initialised() {
+            self.low_speed_warning_1_104kts = false;
+            self.low_speed_warning_2_54kts = false;
+            self.low_speed_warning_3_159kts = false;
+            self.low_speed_warning_4_260kts = false;
         }
     }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR updates the ADR low speed warning discretes with the correct logic when unpowered or invalid, and also inverts the discrete 4. It also updates the usages of discrete 4 accordingly.

The logic is as follows (false is open circuit, true is ground):
- Discretes 1-3 are false when at low speed, and true when at high speed, while 4 is inverted.
- All discretes are false when the ADR is unpowered (represented by the IR selected knob being OFF)
- Discretes 1-3 remain in their previous state when the CAS is invalid but the ADR is powered (represented by the ADR p/b being off), while 4 is false in this case.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Currently the only usage of the discretes on the A32NX is for the L/G safety valve. The rest of the discretes are only used in the A380X.
* Confirm that the gear retraction/extension works correctly (and doesn't work correctly above the safety valve speed of 260kts)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
