### PR TITLE
fix(a380x/mfd): add approach phase button confirmation

### DIFF
--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnArr.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnArr.tsx
@@ -6,6 +6,7 @@ import { Footer } from 'instruments/src/MFD/pages/common/Footer';
 import { Button, ButtonMenuItem } from 'instruments/src/MFD/pages/common/Button';
 import { FmsPage } from 'instruments/src/MFD/pages/common/FmsPage';
 import { ApproachType } from '@fmgc/index';
+import { ApproachUtils } from '@flybywiresim/fbw-sdk';
 
 const ApproachTypeOrder = Object.freeze({
   [ApproachType.Mls]: 0,
@@ -153,7 +154,7 @@ export class MfdFmsFplnArr extends FmsPage<MfdFmsFplnArrProps> {
         let isFirstMatch = true;
         sortedApproaches.forEach((el, idx) => {
           appr.push({
-            label: el.ident,
+            label: ApproachUtils.longApproachName(el),
             action: async () => {
               await this.props.fmcService.master?.flightPlanService.setDestinationRunway(
                 el.runwayIdent ?? '',
@@ -185,7 +186,7 @@ export class MfdFmsFplnArr extends FmsPage<MfdFmsFplnArrProps> {
       }
 
       if (flightPlan.approach) {
-        this.appr.set(flightPlan.approach.ident);
+        this.appr.set(ApproachUtils.longApproachName(flightPlan.approach));
         this.rwyFreq.set(flightPlan.destinationRunway.lsFrequencyChannel?.toFixed(2) ?? '');
 
         if (flightPlan.availableApproachVias.length > 0) {

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnArr.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnArr.tsx
@@ -6,7 +6,6 @@ import { Footer } from 'instruments/src/MFD/pages/common/Footer';
 import { Button, ButtonMenuItem } from 'instruments/src/MFD/pages/common/Button';
 import { FmsPage } from 'instruments/src/MFD/pages/common/FmsPage';
 import { ApproachType } from '@fmgc/index';
-import { ApproachUtils } from '@flybywiresim/fbw-sdk';
 
 const ApproachTypeOrder = Object.freeze({
   [ApproachType.Mls]: 0,
@@ -154,7 +153,7 @@ export class MfdFmsFplnArr extends FmsPage<MfdFmsFplnArrProps> {
         let isFirstMatch = true;
         sortedApproaches.forEach((el, idx) => {
           appr.push({
-            label: ApproachUtils.longApproachName(el),
+            label: el.ident,
             action: async () => {
               await this.props.fmcService.master?.flightPlanService.setDestinationRunway(
                 el.runwayIdent ?? '',
@@ -186,7 +185,7 @@ export class MfdFmsFplnArr extends FmsPage<MfdFmsFplnArrProps> {
       }
 
       if (flightPlan.approach) {
-        this.appr.set(ApproachUtils.longApproachName(flightPlan.approach));
+        this.appr.set(flightPlan.approach.ident);
         this.rwyFreq.set(flightPlan.destinationRunway.lsFrequencyChannel?.toFixed(2) ?? '');
 
         if (flightPlan.availableApproachVias.length > 0) {

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
@@ -37,11 +37,12 @@ import { MfdSimvars } from 'instruments/src/MFD/shared/MFDSimvarPublisher';
 import { VerticalCheckpointReason } from '@fmgc/guidance/vnav/profile/NavGeometryProfile';
 import { A380SpeedsUtils } from '@shared/OperatingSpeeds';
 import { NXSystemMessages } from 'instruments/src/MFD/shared/NXSystemMessages';
-import { ApproachUtils } from '@flybywiresim/fbw-sdk';
 
 interface MfdFmsPerfProps extends AbstractMfdPageProps {}
 
 export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
+  private approachPhaseConfirmationDialogVisible = Subject.create<boolean>(false);
+
   private activateApprButton = FSComponent.createRef<HTMLDivElement>();
 
   private managedSpeedActive = Subject.create<boolean>(false);
@@ -522,7 +523,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
     }
 
     if (this.loadedFlightPlan.approach) {
-      this.apprIdent.set(ApproachUtils.longApproachName(this.loadedFlightPlan.approach));
+      this.apprIdent.set(this.loadedFlightPlan.approach.ident);
     }
 
     if (fm.approachFlapConfig) {
@@ -2689,6 +2690,20 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                   onClick={() => this.props.mfd.uiService.navigateTo('back')}
                   buttonStyle="margin-right: 5px;"
                 />
+                <ConfirmationDialog
+                  visible={this.approachPhaseConfirmationDialogVisible}
+                  cancelAction={() => {
+                    this.approachPhaseConfirmationDialogVisible.set(false);
+                  }}
+                  confirmAction={() => {
+                    this.approachPhaseConfirmationDialogVisible.set(false);
+                    this.props.fmcService.master?.tryGoInApproachPhase();
+                  }}
+                  contentContainerStyle="width: 280px; height: 165px; bottom: -6px; left: -5px;"
+                  amberLabel={true}
+                >
+                  {'ACTIVATE APPR ?'}
+                </ConfirmationDialog>
               </div>
               <div ref={this.activateApprButton} style="margin-right: 5px;">
                 <Button
@@ -2702,7 +2717,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                       <span style="display: flex; align-items: center; justify-content: center;">*</span>
                     </div>,
                   )}
-                  onClick={() => this.props.fmcService.master?.tryGoInApproachPhase()}
+                  onClick={() => this.approachPhaseConfirmationDialogVisible.set(true)}
                   buttonStyle="color: #e68000; padding-right: 2px;"
                 />
               </div>

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
@@ -37,6 +37,7 @@ import { MfdSimvars } from 'instruments/src/MFD/shared/MFDSimvarPublisher';
 import { VerticalCheckpointReason } from '@fmgc/guidance/vnav/profile/NavGeometryProfile';
 import { A380SpeedsUtils } from '@shared/OperatingSpeeds';
 import { NXSystemMessages } from 'instruments/src/MFD/shared/NXSystemMessages';
+import { ApproachUtils } from '@flybywiresim/fbw-sdk';
 
 interface MfdFmsPerfProps extends AbstractMfdPageProps {}
 
@@ -521,7 +522,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
     }
 
     if (this.loadedFlightPlan.approach) {
-      this.apprIdent.set(this.loadedFlightPlan.approach.ident);
+      this.apprIdent.set(ApproachUtils.longApproachName(this.loadedFlightPlan.approach));
     }
 
     if (fm.approachFlapConfig) {

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/common/ConfirmationDialog.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/common/ConfirmationDialog.tsx
@@ -7,6 +7,7 @@ interface ConfirmationDialogProps extends ComponentProps {
   cancelAction: () => void;
   confirmAction: () => void;
   contentContainerStyle?: string;
+  amberLabel?: boolean;
 }
 
 /*
@@ -42,7 +43,7 @@ export class ConfirmationDialog extends DisplayComponent<ConfirmationDialogProps
       <div ref={this.topRef} style="position: relative;">
         <div class="mfd-dialog" style={`${this.props.contentContainerStyle ?? ''}`}>
           <div class="mfd-dialog-title">
-            <span class="mfd-label">{this.props.children}</span>
+            <span class={`mfd-label ${this.props.amberLabel ? 'amber' : ''}`}>{this.props.children}</span>
           </div>
           <div class="mfd-dialog-buttons">
             <Button label="CANCEL" onClick={() => this.props.cancelAction()} />


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Adds confirmation button to activate approach phase.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
FCOM & https://youtu.be/DtIF26FEZug?t=127
<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
Missing ? char on the font file is out of scope for this PR & couldn't find any better reference for the approach button.
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
bruno_pt99
## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
