### PR TITLE
chore: add NOMINMAX to fbw, revert clang-format change for fbw

### DIFF
--- a/fbw-a32nx/src/wasm/fbw_a320/.clang-format
+++ b/fbw-a32nx/src/wasm/fbw_a320/.clang-format
@@ -1,0 +1,5 @@
+---
+BasedOnStyle: Chromium
+---
+Language: Cpp
+ColumnLimit: 140

--- a/fbw-a32nx/src/wasm/fbw_a320/build.sh
+++ b/fbw-a32nx/src/wasm/fbw_a320/build.sh
@@ -81,6 +81,7 @@ clang++ \
   -D_LIBCPP_HAS_NO_THREADS \
   -D_WINDLL \
   -D_MBCS \
+  -DNOMINMAX \
   -mthread-model single \
   -fno-exceptions \
   -fms-extensions \

--- a/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
@@ -369,7 +369,7 @@ void FlyByWireInterface::setupLocalVariables() {
   idFmgcAccelerationAltitudeGoAround = std::make_unique<LocalVariable>("A32NX_FM1_MISSED_ACC_ALT");
   idFmgcAccelerationAltitudeGoAroundEngineOut = std::make_unique<LocalVariable>("A32NX_FM1_MISSED_EO_ACC_ALT");
 
-  idFmgcCruiseAltitude  = std::make_unique<LocalVariable>("A32NX_AIRLINER_CRUISE_ALTITUDE");
+  idFmgcCruiseAltitude = std::make_unique<LocalVariable>("A32NX_AIRLINER_CRUISE_ALTITUDE");
   idFmgcFlexTemperature = std::make_unique<LocalVariable>("A32NX_AIRLINER_TO_FLEX_TEMP");
 
   idFlightGuidanceAvailable = std::make_unique<LocalVariable>("A32NX_FG_AVAIL");
@@ -894,7 +894,7 @@ bool FlyByWireInterface::readDataAndLocalVariables(double sampleTime) {
   }
 
   // calculate delta time (and ensure it does not get 0 -> max 500 fps)
-  calculatedSampleTime = max(0.002, simData.simulationTime - previousSimulationTime);
+  calculatedSampleTime = std::max(0.002, simData.simulationTime - previousSimulationTime);
 
   monotonicTime += calculatedSampleTime;
 
@@ -955,7 +955,7 @@ bool FlyByWireInterface::handleSimulationRate(double sampleTime) {
   if (simData.simulation_rate > idMaximumSimulationRate->get()) {
     // set target simulation rate
     targetSimulationRateModified = true;
-    targetSimulationRate = max(1, simData.simulation_rate / 2);
+    targetSimulationRate = std::max(1., simData.simulation_rate / 2);
     // sed event to reduce simulation rate
     simConnectInterface.sendEvent(SimConnectInterface::Events::SIM_RATE_DECR, 0, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
     // log event of reduction
@@ -977,7 +977,7 @@ bool FlyByWireInterface::handleSimulationRate(double sampleTime) {
       elac2ProtActive || autopilotStateMachineOutput.speed_protection_mode == 1) {
     // set target simulation rate
     targetSimulationRateModified = true;
-    targetSimulationRate = max(1, simData.simulation_rate / 2);
+    targetSimulationRate = std::max(1., simData.simulation_rate / 2);
     // send event to reduce simulation rate
     simConnectInterface.sendEvent(SimConnectInterface::Events::SIM_RATE_DECR, 0, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
     // reset low performance timer
@@ -2383,7 +2383,7 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
   idSideStickPositionY->set(-1.0 * simInput.inputs[0]);
 
   // set rudder pedals position
-  idRudderPedalPosition->set(max(-100, min(100, (-100.0 * simInput.inputs[2]))));
+  idRudderPedalPosition->set(std::max(-100., std::min(100., (-100. * simInput.inputs[2]))));
 
   // provide tracking mode state
   idTrackingMode->set(wasInSlew || pauseDetected || idExternalOverride->get());

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
@@ -2767,7 +2767,7 @@ void SimConnectInterface::processEventWithOneParam(const DWORD eventId, const DW
     }
 
     case Events::SIM_RATE_SET: {
-      long targetSimulationRate = min(maxSimulationRate, max(1, static_cast<long>(data0)));
+      long targetSimulationRate = std::min(static_cast<long>(maxSimulationRate), std::max(1l, static_cast<long>(data0)));
       sendEvent(SIM_RATE_SET, targetSimulationRate, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
       std::cout << "WASM: Simulation Rate set to " << targetSimulationRate << std::endl;
       break;

--- a/fbw-a380x/src/wasm/fbw_a380/.clang-format
+++ b/fbw-a380x/src/wasm/fbw_a380/.clang-format
@@ -1,0 +1,5 @@
+---
+BasedOnStyle: Chromium
+---
+Language: Cpp
+ColumnLimit: 140

--- a/fbw-a380x/src/wasm/fbw_a380/build.sh
+++ b/fbw-a380x/src/wasm/fbw_a380/build.sh
@@ -36,6 +36,7 @@ clang \
   -D_LIBCPP_HAS_NO_THREADS \
   -D_WINDLL \
   -D_MBCS \
+  -DNOMINMAX \
   -mthread-model single \
   -fno-exceptions \
   -fms-extensions \
@@ -76,6 +77,7 @@ clang++ \
   -D_LIBCPP_HAS_NO_THREADS \
   -D_WINDLL \
   -D_MBCS \
+  -DNOMINMAX \
   -mthread-model single \
   -fno-exceptions \
   -fms-extensions \

--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
@@ -370,8 +370,8 @@ void FlyByWireInterface::setupLocalVariables() {
   idFmgcAccelerationAltitudeEngineOut = std::make_unique<LocalVariable>("A32NX_FM1_EO_ACC_ALT");
   idFmgcAccelerationAltitudeGoAround = std::make_unique<LocalVariable>("A32NX_FM1_MISSED_ACC_ALT");
   idFmgcAccelerationAltitudeGoAroundEngineOut = std::make_unique<LocalVariable>("A32NX_FM1_MISSED_EO_ACC_ALT");
-  idFmgcCruiseAltitude                        = std::make_unique<LocalVariable>("A32NX_AIRLINER_CRUISE_ALTITUDE");
-  idFmgcFlexTemperature                       = std::make_unique<LocalVariable>("A32NX_AIRLINER_TO_FLEX_TEMP");
+  idFmgcCruiseAltitude = std::make_unique<LocalVariable>("A32NX_AIRLINER_CRUISE_ALTITUDE");
+  idFmgcFlexTemperature = std::make_unique<LocalVariable>("A32NX_AIRLINER_TO_FLEX_TEMP");
 
   idFlightGuidanceAvailable = std::make_unique<LocalVariable>("A32NX_FG_AVAIL");
   idFlightGuidanceCrossTrackError = std::make_unique<LocalVariable>("A32NX_FG_CROSS_TRACK_ERROR");
@@ -935,7 +935,7 @@ bool FlyByWireInterface::readDataAndLocalVariables(double sampleTime) {
   }
 
   // calculate delta time (and ensure it does not get 0 -> max 500 fps)
-  calculatedSampleTime = max(0.002, simData.simulationTime - previousSimulationTime);
+  calculatedSampleTime = std::max(0.002, simData.simulationTime - previousSimulationTime);
 
   monotonicTime += calculatedSampleTime;
 
@@ -996,7 +996,7 @@ bool FlyByWireInterface::handleSimulationRate(double sampleTime) {
   if (simData.simulation_rate > idMaximumSimulationRate->get()) {
     // set target simulation rate
     targetSimulationRateModified = true;
-    targetSimulationRate = max(1, simData.simulation_rate / 2);
+    targetSimulationRate = std::max(1., simData.simulation_rate / 2);
     // sed event to reduce simulation rate
     simConnectInterface.sendEvent(SimConnectInterface::Events::SIM_RATE_DECR, 0, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
     // log event of reduction
@@ -1018,7 +1018,7 @@ bool FlyByWireInterface::handleSimulationRate(double sampleTime) {
       elac2ProtActive || autopilotStateMachineOutput.speed_protection_mode == 1) {
     // set target simulation rate
     targetSimulationRateModified = true;
-    targetSimulationRate = max(1, simData.simulation_rate / 2);
+    targetSimulationRate = std::max(1., simData.simulation_rate / 2);
     // send event to reduce simulation rate
     simConnectInterface.sendEvent(SimConnectInterface::Events::SIM_RATE_DECR, 0, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
     // reset low performance timer
@@ -2593,8 +2593,8 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
   idSideStickPositionY->set(-1.0 * simInput.inputs[0]);
 
   // set rudder pedals position
-  idRudderPedalPosition->set(max(-100, min(100, (-100.0 * simInput.inputs[2]))));
-  idRudderPedalAnimationPosition->set(max(-100, min(100, (-100.0 * simInput.inputs[2]) + (100.0 * simData.zeta_trim_pos))));
+  idRudderPedalPosition->set(std::max(-100., std::min(100., (-100. * simInput.inputs[2]))));
+  idRudderPedalAnimationPosition->set(std::max(-100., std::min(100., (-100. * simInput.inputs[2]) + (100. * simData.zeta_trim_pos))));
 
   // provide tracking mode state
   idTrackingMode->set(wasInSlew || pauseDetected || idExternalOverride->get());

--- a/fbw-a380x/src/wasm/fbw_a380/src/interface/SimConnectInterface.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/interface/SimConnectInterface.cpp
@@ -3021,7 +3021,7 @@ void SimConnectInterface::processEventWithOneParam(const DWORD eventId, const DW
     }
 
     case Events::SIM_RATE_SET: {
-      long targetSimulationRate = min(maxSimulationRate, max(1, static_cast<long>(data0)));
+      long targetSimulationRate = std::min(static_cast<long>(maxSimulationRate), std::max(1l, static_cast<long>(data0)));
       sendEvent(Events::SIM_RATE_SET, targetSimulationRate, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
       std::cout << "WASM: Simulation Rate set to " << targetSimulationRate << std::endl;
       break;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Mini-PR to add the NOMINMAX macro define to the fbw, and fix code accordingly. Also adds a separate `.clang-format`-file to the fbw folders, as #8640 changed the global clang-format-config, which would result in huge changes in all fbw cpp files and thus merge conflicts.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
