### PR TITLE
fix(fms): always show runway ident on lat/vert rev page

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -115,9 +115,10 @@
 1. [FMS] Selected navaids are now reset on entering the done flight phase - @tracernz (Mike)
 1. [FMS] Fix tailwind component of trip wind being treated as a headwind - @BlueberryKing (BlueberryKing)
 1. [FMS] Improved NAVAID page - @tracernz (Mike)
-1. [MCDU] Fixed ZFW Autofill with lbs during boarding @ShreyasKallingal 
+1. [MCDU] Fixed ZFW Autofill with lbs during boarding @ShreyasKallingal
 1. [FADEC] Added quick start for engines and APU - @frankkopp (Frank Kopp) - @Gurgel100 (Pascal)
 1. [EFB] Added expedited presets - @frankkopp (Frank Kopp)
+1. [FMS] Show runway ident on lateral/vertical revision page of the missed approach point - @BlueberryKing (BlueberryKing)
 
 ## 0.11.0
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
@@ -33,7 +33,11 @@ class CDULateralRevisionPage {
         let waypointIdent = isPpos ? "PPOS" : '---';
 
         if (leg) {
-            waypointIdent = leg.ident;
+            if (isDestination && targetPlan.destinationRunway) {
+                waypointIdent = targetPlan.destinationRunway.ident;
+            } else {
+                waypointIdent = leg.ident;
+            }
         }
 
         let departureCell = "";

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
@@ -34,7 +34,11 @@ class CDUVerticalRevisionPage {
 
         let waypointIdent = "---";
         if (waypoint) {
-            waypointIdent = waypoint.ident;
+            if (isDestination && targetPlan.destinationRunway) {
+                waypointIdent = targetPlan.destinationRunway.ident;
+            } else {
+                waypointIdent = waypoint.ident;
+            }
         }
 
         let coordinates = "---";


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR makes sure that the lateral and vertical revision pages at the destination (i.e the missed approach point) always show the runway ident in the title, rather than the leg ident.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![Screenshot 2024-09-18 113310](https://github.com/user-attachments/assets/a392b423-8e75-4f70-96ff-a9c8bef36800)
![Screenshot 2024-09-18 113324](https://github.com/user-attachments/assets/c6efef5e-6bad-43e3-8cfc-4205d410e428)
![Screenshot 2024-09-18 113318](https://github.com/user-attachments/assets/b0dd4b88-e6b4-4704-9679-6ec96d670a5b)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
According to pilot feedback

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Check the vertical and lateral revision pages of the missed approach points on approaches that do not end at the runway threshold (e.g LPMA RNP A 05, LGSR VOR 15) and make sure that they show the runway ident ("LPMA05", "LGSR15")

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
