### PR TITLE
fix(fms): nav radio frequency entry

### DIFF
--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -88,15 +88,19 @@ class CDUNavRadioPage {
                 return;
             }
         } else if (input.match(/^\d{3}(\.\d{1,2})?$/) !== null) {
-            const freq = parseFloat(input);
-            // 108.00 - 117.95 with some tolerance for FP precision
-            if (freq <= 107.975 || freq >= 117.975 || !RadioNav.isHz50Compliant(freq)) {
+            const freq = parseInt(input.replace('.', '').padEnd(5, '0'), 16) << 8;
+
+            if (!Fmgc.RadioUtils.isValidRange(freq, Fmgc.RadioUtils.RadioChannelType.VhfNavaid50)) {
                 mcdu.setScratchpadMessage(NXSystemMessages.entryOutOfRange);
+                scratchpadCallback();
+                return false;
+            } else if (!Fmgc.RadioUtils.isValidSpacing(freq, Fmgc.RadioUtils.RadioChannelType.VhfNavaid50)) {
+                mcdu.setScratchpadMessage(NXSystemMessages.formatError);
                 scratchpadCallback();
                 return false;
             }
 
-            mcdu.setManualVor(receiverIndex, freq);
+            mcdu.setManualVor(receiverIndex, Fmgc.RadioUtils.unpackBcd32(freq) / 1e6);
         } else if (input.length >= 1 && input.length <= 4) {
             // ident
             mcdu.getOrSelectVORsByIdent(input, (navaid) => {
@@ -198,15 +202,19 @@ class CDUNavRadioPage {
                 return;
             }
         } else if (input.match(/^\d{3}(\.\d{1,2})?$/) !== null) {
-            const freq = parseFloat(input);
-            // 108.00 - 111.95 with some tolerance for FP precision
-            if (freq <= 107.975 || freq >= 111.975 || !RadioNav.isHz50Compliant(freq)) {
+            const freq = parseInt(input.replace('.', '').padEnd(5, '0'), 16) << 8;
+
+            if (!Fmgc.RadioUtils.isValidRange(freq, Fmgc.RadioUtils.RadioChannelType.IlsNavaid50)) {
                 mcdu.setScratchpadMessage(NXSystemMessages.entryOutOfRange);
+                scratchpadCallback();
+                return false;
+            } else if (!Fmgc.RadioUtils.isValidSpacing(freq, Fmgc.RadioUtils.RadioChannelType.IlsNavaid50)) {
+                mcdu.setScratchpadMessage(NXSystemMessages.formatError);
                 scratchpadCallback();
                 return false;
             }
 
-            mcdu.setManualIls(freq).then(onDone);
+            mcdu.setManualIls(Fmgc.RadioUtils.unpackBcd32(freq) / 1e6).then(onDone);
         } else if (input.length >= 1 && input.length <= 4) {
             // ident
             mcdu.getOrSelectILSsByIdent(input, (navaid) => {

--- a/fbw-a32nx/src/systems/fmgc/src/index.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/index.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-import { ApproachType, ApproachUtils, RunwayUtils, a320EfisRangeSettings } from '@flybywiresim/fbw-sdk';
+import { ApproachType, ApproachUtils, RadioUtils, RunwayUtils, a320EfisRangeSettings } from '@flybywiresim/fbw-sdk';
 import { DataManager } from '@fmgc/flightplanning/DataManager';
 import { CoRouteUplinkAdapter } from '@fmgc/flightplanning/uplink/CoRouteUplinkAdapter';
 import { EfisInterface } from '@fmgc/efis/EfisInterface';
@@ -63,6 +63,7 @@ export {
   CoRouteUplinkAdapter,
   DataManager,
   EventBus,
+  RadioUtils,
   a320EfisRangeSettings,
   A320AircraftConfig,
 };

--- a/fbw-common/src/systems/shared/src/RadioUtils.spec.ts
+++ b/fbw-common/src/systems/shared/src/RadioUtils.spec.ts
@@ -20,6 +20,22 @@ describe('RadioUtils.packBcd32', () => {
   });
 });
 
+describe('RadioUtils.unpackBcd16', () => {
+  it('correctly unpacks bcd16', () => {
+    expect(RadioUtils.unpackBcd16(0x1850)).toBe(118_500_000);
+    expect(RadioUtils.unpackBcd16(0x2225)).toBe(122_250_000);
+    expect(RadioUtils.unpackBcd16(0x3697)).toBe(136_970_000);
+  });
+});
+
+describe('RadioUtils.unpackBcd32', () => {
+  it('correctly unpacks bcd32', () => {
+    expect(RadioUtils.unpackBcd32(0x118_500_0)).toBe(118_500_000);
+    expect(RadioUtils.unpackBcd32(0x122_250_0)).toBe(122_250_000);
+    expect(RadioUtils.unpackBcd32(0x136_975_0)).toBe(136_975_000);
+  });
+});
+
 describe('RadioUtils.unpackVhfComFrequencyFromArincToHz', () => {
   it('correctly unpacks arinc BCD to Hz', () => {
     expect(RadioUtils.unpackVhfComFrequencyFromArincToHz(0x18_500)).toBe(118_500_000);

--- a/fbw-common/src/systems/shared/src/RadioUtils.ts
+++ b/fbw-common/src/systems/shared/src/RadioUtils.ts
@@ -12,6 +12,8 @@ export enum RadioChannelType {
   VhfCom8_33_25,
   /** 50 kHz channels. */
   VhfNavaid50,
+  /** 50 kHz ILS channels. */
+  IlsNavaid50,
 }
 
 interface ChannelParameters {
@@ -53,6 +55,12 @@ export class RadioUtils {
       channels: [0, 0x500],
       min: 0x1080000,
       max: 0x1179500,
+    },
+    [RadioChannelType.IlsNavaid50]: {
+      channelMask: 0xfff,
+      channels: [0, 0x500],
+      min: 0x1080000,
+      max: 0x1119500,
     },
     [RadioChannelType.Hf1]: {
       channelMask: 0xff,

--- a/fbw-common/src/systems/shared/src/RadioUtils.ts
+++ b/fbw-common/src/systems/shared/src/RadioUtils.ts
@@ -28,6 +28,11 @@ interface ChannelParameters {
 }
 
 export class RadioUtils {
+  /**
+   * @deprecated Channel types for easier use with legacy JS. For TS use {@link RadioChannelType} directly.
+   */
+  public static readonly RadioChannelType = RadioChannelType;
+
   /** The channel spacings in kHz for each frequency spacing. */
   public static readonly CHANNEL_TYPES: Record<RadioChannelType, ChannelParameters> = {
     [RadioChannelType.VhfCom8_33]: {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8944

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes VHF frequency entry on the RADIO NAV page.

Also prepares us a little more for transitioning to BCD for frequencies in the FMS.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Ensure that VOR frequencies in the range 108.00-117.95, in 0.05 MHz steps can be entered on both sides, and frequencies outside that range or spacing cannot.
- Ensure that ILS frequencies in the range 108.00-111.95, in 0.05 MHz steps can be entered on both sides, and frequencies outside that range or spacing cannot.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
