### PR TITLE
build: bump fragmenter to v0.8.0 and specify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "a32nx",
   "version": "0.12.0",
-  "edition": "stable",
+  "edition": "development",
   "imports": {
     "#build-utils": "./build-utils.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "a32nx",
   "version": "0.12.0",
-  "edition": "development",
+  "edition": "stable",
   "imports": {
     "#build-utils": "./build-utils.js"
   },
@@ -75,7 +75,7 @@
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",
     "@babel/preset-typescript": "~7.12.7",
-    "@flybywiresim/fragmenter": "^0.7.0",
+    "@flybywiresim/fragmenter": "^0.8.0",
     "@flybywiresim/igniter": "^1.2.3",
     "@flybywiresim/rnp": "^2.1.0",
     "@navigraph/pkce": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,8 +179,8 @@ devDependencies:
     specifier: ~7.12.7
     version: 7.12.17(@babel/core@7.23.5)
   '@flybywiresim/fragmenter':
-    specifier: ^0.7.0
-    version: 0.7.4
+    specifier: ^0.8.0
+    version: 0.8.0
   '@flybywiresim/igniter':
     specifier: ^1.2.3
     version: 1.2.3
@@ -2139,8 +2139,8 @@ packages:
       - debug
     dev: false
 
-  /@flybywiresim/fragmenter@0.7.4:
-    resolution: {integrity: sha512-CBNKQyjp5w4pVyqT5H0ixI6SOyQdXBYvkLF9dQiZJ+1RxxpNBG0NN8pH+gNL38+BMdL3Z++0KpHOHvZNyy2uPg==}
+  /@flybywiresim/fragmenter@0.8.0:
+    resolution: {integrity: sha512-IpFfUuJi/Ix4B8s57k0N9glMVmwVT8FOC6qT2LgL1bmrC9Xfjjfuty8IDjNZH0KjAHvolk/7TzTEhbh7qUPnpQ==}
     dependencies:
       axios: 0.27.2
       split-file: 2.3.0

--- a/scripts/fragment-ingamepanels-checklist-fix.js
+++ b/scripts/fragment-ingamepanels-checklist-fix.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const execute = async () => {
   try {
     const result = await fragmenter.pack({
+      version: require('./fragmenter_version').version,
       packOptions: { splitFileSize: 102_760_448, keepCompleteModulesAfterSplit: false },
       baseDir: './fbw-ingamepanels-checklist-fix/out/flybywire-ingamepanels-checklist-fix',
       outDir: './fbw-ingamepanels-checklist-fix/out/build-modules',

--- a/scripts/fragment_a32nx.js
+++ b/scripts/fragment_a32nx.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const execute = async () => {
   try {
     const result = await fragmenter.pack({
+      version: require('./fragmenter_version').version,
       packOptions: { splitFileSize: 102_760_448, keepCompleteModulesAfterSplit: false },
       baseDir: './fbw-a32nx/out/flybywire-aircraft-a320-neo',
       outDir: './fbw-a32nx/out/build-modules',

--- a/scripts/fragment_a380x.js
+++ b/scripts/fragment_a380x.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const execute = async () => {
   try {
     const result = await fragmenter.pack({
+      version: require('./fragmenter_version').version,
       packOptions: { splitFileSize: 102_760_448, keepCompleteModulesAfterSplit: false },
       baseDir: './fbw-a380x/out/flybywire-aircraft-a380-842',
       outDir: './fbw-a380x/out/build-modules',

--- a/scripts/fragmenter_version.js
+++ b/scripts/fragmenter_version.js
@@ -1,0 +1,18 @@
+const buildInfo = require('./git_build_info').getGitBuildInfo();
+const packageInfo = require('../package.json');
+
+let version;
+if (packageInfo.edition === 'stable') {
+  version = `v${packageInfo.version}`;
+} else {
+  const hash = buildInfo?.shortHash;
+
+  if (!hash) {
+    console.error('[!] buildInfo.shortHash is falsy');
+    process.exit(-1);
+  }
+
+  version = buildInfo.shortHash;
+}
+
+module.exports = { version };


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

- Bump fragmenter to v0.8.0
- Specify version in fragmenter scripts

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Not needed.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
