### PR TITLE
fix(fms): merge constraints when stringing

### DIFF
--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
@@ -180,7 +180,6 @@ class CDUAvailableArrivalsPage {
                         runwayCourse = Utils.leadingZeros(Math.round(runway.magneticBearing), 3);
 
                         const finalLeg = approach.legs[approach.legs.length - 1];
-                        console.log("trying to use ilss");
                         const matchingIls = approach.type === Fmgc.ApproachType.Ils ? ilss.find(
                             (ils) => finalLeg && finalLeg.recommendedNavaid && ils.databaseId === finalLeg.recommendedNavaid.databaseId
                         ) : undefined;

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/plans/BaseFlightPlan.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/plans/BaseFlightPlan.ts
@@ -2105,7 +2105,8 @@ export abstract class BaseFlightPlan<P extends FlightPlanPerformanceData = Fligh
 
       if (bothXf) {
         if (element.terminatesWithWaypoint(firstLegInSecond.terminationWaypoint())) {
-          // Use leg from the first segment, do not transfer any information from the second segment, see FBW-22-08
+          // Use leg from the first segment for annotation and ident, see FBW-22-08,
+          // but merge constraints
           this.mergeConstraints(element, firstLegInSecond);
 
           second.allLegs.shift();

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/plans/BaseFlightPlan.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/plans/BaseFlightPlan.ts
@@ -1962,6 +1962,8 @@ export abstract class BaseFlightPlan<P extends FlightPlanPerformanceData = Fligh
               lastLegInFirst.annotation,
             );
 
+            this.mergeConstraints(element, lastLegInFirst);
+
             if (LnavConfig.VERBOSE_FPM_LOG) {
               console.trace('[fpm] stringSegmentsForwards - popping legs of first');
             }
@@ -2104,6 +2106,8 @@ export abstract class BaseFlightPlan<P extends FlightPlanPerformanceData = Fligh
       if (bothXf) {
         if (element.terminatesWithWaypoint(firstLegInSecond.terminationWaypoint())) {
           // Use leg from the first segment, do not transfer any information from the second segment, see FBW-22-08
+          this.mergeConstraints(element, firstLegInSecond);
+
           second.allLegs.shift();
           second.flightPlan.syncSegmentLegsChange(first);
           cutBefore = i;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes an issue where constraints at the IAF would be discarded when the approach was string to the arrival.

Also removes a `console.log` I accidentally left in in a previous PR.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before: 
![Screenshot 2024-10-07 101454](https://github.com/user-attachments/assets/ee61ff9c-a3ee-4603-b317-e0fc19294869)

After:
![Screenshot 2024-10-07 101957](https://github.com/user-attachments/assets/75448232-2a44-4b27-914d-e5dca71f0588)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Try entering different destinations, arrivals and approaches, make sure that the constraints at the IAF always matches the charts.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
