### PR TITLE
feat(a380): further improved default VR position

### DIFF
--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/cameras.cfg
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/cameras.cfg
@@ -1633,7 +1633,7 @@ ZoomPanScalar=1
 Category="Cockpit"
 SubCategory="Pilot"
 SubCategoryItem="PilotVR"
-InitialXyz = 0.0, 1.86, 18.6
+InitialXyz = 0.0, 1.89, 18.75
 InitialPbh = -7.5, 0, 0
 
 [CAMERADEFINITION.40]


### PR DESCRIPTION
## Summary of Changes
This PR adjusts and improves the default VR head position.

## Testing instructions
Test head position in virtual reality (VR).

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
