### PR TITLE
build: fixes cmake config after other PR changed and removed files.

### DIFF
--- a/fbw-a380x/src/wasm/fbw_a380/CMakeLists.txt
+++ b/fbw-a380x/src/wasm/fbw_a380/CMakeLists.txt
@@ -56,7 +56,6 @@ add_executable(flybywire-a380x-fbw
     src/model/intrp3d_l_pw.cpp
     src/model/look1_binlxpw.cpp
     src/model/look2_binlxpw.cpp
-    src/model/look2_binlxpw.cpp
     src/model/look2_pbinlxpw.cpp
     src/model/maximum_Abpa9SzA.cpp
     src/model/mod_OlzklkXq.cpp

--- a/fbw-a380x/src/wasm/fbw_a380/CMakeLists.txt
+++ b/fbw-a380x/src/wasm/fbw_a380/CMakeLists.txt
@@ -36,9 +36,7 @@ add_executable(flybywire-a380x-fbw
     ${FBW_ROOT}/fbw-common/src/wasm/fbw_common/src/ThrottleAxisMapping.cpp
     ${FBW_ROOT}/fbw-common/src/wasm/fbw_common/src/InterpolatingLookupTable.cpp
     src/interface/SimConnectInterface.cpp
-    #        src/elac/Elac.cpp
     src/sec/Sec.cpp
-    #        src/fcdc/Fcdc.cpp
     src/fac/Fac.cpp
     src/failures/FailuresConsumer.cpp
     src/utils/ConfirmNode.cpp
@@ -52,26 +50,16 @@ add_executable(flybywire-a380x-fbw
     src/model/Autothrust_data.cpp
     src/model/Autothrust.cpp
     src/model/Double2MultiWord.cpp
-    #        src/model/ElacComputer_data.cpp
-    #        src/model/ElacComputer.cpp
-    #        src/model/SecComputer_data.cpp
-    #        src/model/SecComputer.cpp
-    #        src/model/PitchNormalLaw.cpp
-    #        src/model/PitchAlternateLaw.cpp
-    #        src/model/PitchDirectLaw.cpp
-    #        src/model/LateralNormalLaw.cpp
-    #        src/model/LateralDirectLaw.cpp
     src/model/FacComputer_data.cpp
     src/model/FacComputer.cpp
     src/model/binsearch_u32d.cpp
     src/model/intrp3d_l_pw.cpp
     src/model/look1_binlxpw.cpp
-    src/model/look2_binlcpw.cpp
+    src/model/look2_binlxpw.cpp
     src/model/look2_binlxpw.cpp
     src/model/look2_pbinlxpw.cpp
     src/model/maximum_Abpa9SzA.cpp
-    src/model/mod_2RcCQkwc.cpp
-    src/model/mod_mvZvttxs.cpp
+    src/model/mod_OlzklkXq.cpp
     src/model/MultiWordIor.cpp
     src/model/plook_binx.cpp
     src/model/rt_modd.cpp
@@ -79,9 +67,8 @@ add_executable(flybywire-a380x-fbw
     src/model/uMultiWord2Double.cpp
     src/FlyByWireInterface.cpp
     src/FlightDataRecorder.cpp
-    #        src/Arinc429.cpp
     src/Arinc429Utils.cpp
     src/SpoilersHandler.cpp
     src/CalculatedRadioReceiver.cpp
     src/main.cpp
-    )
+)


### PR DESCRIPTION
## Summary of Changes
CMake config fixed after files have been chenged/renamed/removed in other PR.
This config allows IDE who use the CMake config to also have syntax highlighting and code navigation for the fbw wasm code. 

Discord username (if different from GitHub): cdr_maverick

## Testing instructions
n/a - only changes cmake config - no impact on aircraft

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
