### PR TITLE
fix(a380x/window): Hotfix for Windows in Flight

### DIFF
--- a/fbw-a380x/docs/a380-simvars.md
+++ b/fbw-a380x/docs/a380-simvars.md
@@ -345,6 +345,10 @@
         - B3
         - B4
 
+- A32NX_PRESS_MAN_CABIN_DELTA_PRESSURE
+    - PSI
+    - As above, but analog system transmitted by the manual partition of CPC1
+
 - A32NX_PRESS_OCSM_{id1}_CHANNEL_{id2}_FAILURE
     - Bool
     - True if the channel is failed

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/interactive-parts.xml
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/interactive-parts.xml
@@ -557,7 +557,7 @@
             </UseTemplate>
             <UseTemplate Name = "ASOBO_GT_Interaction_LeftSingle_Leave_Code">
                 <LEFT_SINGLE_CODE>
-                    (L:A32NX_PRESS_CABIN_DELTA_PRESSURE, psi) 1.2 &lt; if{
+                    (L:A32NX_PRESS_MAN_CABIN_DELTA_PRESSURE, psi) 1.2 &lt; if{
                         (L:FO_SLIDING_WINDOW) ! (&gt;L:FO_SLIDING_WINDOW)
                     } els{
                         0 (&gt;L:FO_SLIDING_WINDOW)
@@ -577,7 +577,7 @@
             </UseTemplate>
             <UseTemplate Name = "ASOBO_GT_Interaction_LeftSingle_Leave_Code">
                 <LEFT_SINGLE_CODE>
-                    (A:IS CAMERA RAY INTERSECT WITH NODE:1, Bool) 0 == (L:A32NX_PRESS_CABIN_DELTA_PRESSURE, psi) 1.2 &lt; and if{
+                    (A:IS CAMERA RAY INTERSECT WITH NODE:1, Bool) 0 == (L:A32NX_PRESS_MAN_CABIN_DELTA_PRESSURE, psi) 1.2 &lt; and if{
                         (L:CPT_SLIDING_WINDOW) ! (&gt;L:CPT_SLIDING_WINDOW)
                     } els{
                         0 (&gt;L:CPT_SLIDING_WINDOW)


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Delta pressure L:Var has changed, but XML was not, this fix ensures the windows cannot be opened if cabin is pressurized. 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- No testing required

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
