### PR TITLE
fix(brakes): Instinctive disconnect only when AB active

### DIFF
--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/autobrakes.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/autobrakes.rs
@@ -229,7 +229,8 @@ impl A380AutobrakeController {
             active_id: context.get_identifier("AUTOBRAKES_ACTIVE".to_owned()),
             rto_mode_armed_id: context.get_identifier("AUTOBRAKES_RTO_ARMED".to_owned()),
 
-            external_disarm_event_id: context.get_identifier("AUTOBRAKE_DISARM".to_owned()),
+            external_disarm_event_id: context
+                .get_identifier("AUTOBRAKE_INSTINCTIVE_DISCONNECT".to_owned()),
 
             deceleration_governor: AutobrakeDecelerationGovernor::new(),
             decelerating_light: false,
@@ -412,10 +413,11 @@ impl A380AutobrakeController {
         // when a simulation is started in flight, some values need to be ignored for a certain time to ensure
         // an unintended disarm is not happening
         (self.deceleration_governor.is_engaged() && self.should_disarm_due_to_pedal_input())
+            || (self.deceleration_governor.is_engaged()
+                && (self.external_disarm_event && self.mode != A380AutobrakeMode::RTO))
             || (context.is_sim_ready() && !self.arming_is_allowed_by_bcu)
             || self.spoilers_retracted_during_this_update()
             || self.should_disarm_after_time_in_flight.output()
-            || (self.external_disarm_event && self.mode != A380AutobrakeMode::RTO)
             || (self.mode == A380AutobrakeMode::RTO
                 && self.should_reject_rto_mode_after_time_in_flight.output())
             || (self.mode == A380AutobrakeMode::BTV && !self.btv_scheduler.is_armed())

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/autobrakes.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/autobrakes.rs
@@ -168,7 +168,7 @@ pub struct A380AutobrakeController {
     active_id: VariableIdentifier,
     rto_mode_armed_id: VariableIdentifier,
 
-    external_disarm_event_id: VariableIdentifier,
+    external_deactivation_event_id: VariableIdentifier,
 
     deceleration_governor: AutobrakeDecelerationGovernor,
     decelerating_light: bool,
@@ -191,7 +191,7 @@ pub struct A380AutobrakeController {
     autobrake_knob: A380AutobrakeKnobSelectorSolenoid,
     selection_knob_should_return_disarm: DelayedTrueLogicGate,
 
-    external_disarm_event: bool,
+    external_deactivation_event: bool,
 
     placeholder_ground_spoilers_out: bool,
 
@@ -229,7 +229,7 @@ impl A380AutobrakeController {
             active_id: context.get_identifier("AUTOBRAKES_ACTIVE".to_owned()),
             rto_mode_armed_id: context.get_identifier("AUTOBRAKES_RTO_ARMED".to_owned()),
 
-            external_disarm_event_id: context
+            external_deactivation_event_id: context
                 .get_identifier("AUTOBRAKE_INSTINCTIVE_DISCONNECT".to_owned()),
 
             deceleration_governor: AutobrakeDecelerationGovernor::new(),
@@ -263,7 +263,7 @@ impl A380AutobrakeController {
                 Self::KNOB_SOLENOID_DISARM_DELAY,
             ),
 
-            external_disarm_event: false,
+            external_deactivation_event: false,
 
             placeholder_ground_spoilers_out: false,
 
@@ -414,7 +414,7 @@ impl A380AutobrakeController {
         // an unintended disarm is not happening
         (self.deceleration_governor.is_engaged() && self.should_disarm_due_to_pedal_input())
             || (self.deceleration_governor.is_engaged()
-                && (self.external_disarm_event && self.mode != A380AutobrakeMode::RTO))
+                && (self.external_deactivation_event && self.mode != A380AutobrakeMode::RTO))
             || (context.is_sim_ready() && !self.arming_is_allowed_by_bcu)
             || self.spoilers_retracted_during_this_update()
             || self.should_disarm_after_time_in_flight.output()
@@ -591,7 +591,7 @@ impl SimulationElement for A380AutobrakeController {
         self.last_ground_spoilers_are_deployed = self.ground_spoilers_are_deployed;
         self.ground_spoilers_are_deployed = self.placeholder_ground_spoilers_out;
 
-        self.external_disarm_event = reader.read(&self.external_disarm_event_id);
+        self.external_deactivation_event = reader.read(&self.external_deactivation_event_id);
 
         // Reading current mode in sim to initialize correct mode if sim changes it (from .FLT files for example)
         let readed_mode = reader.read_f64(&self.armed_mode_id);

--- a/fbw-a380x/src/wasm/systems/a380_systems_wasm/src/autobrakes.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems_wasm/src/autobrakes.rs
@@ -35,7 +35,7 @@ pub(super) fn autobrakes(builder: &mut MsfsAspectBuilder) -> Result<(), Box<dyn 
     builder.event_to_variable(
         "A32NX.AUTO_THROTTLE_DISCONNECT",
         EventToVariableMapping::Value(1.),
-        Variable::named("AUTOBRAKE_DISARM"),
+        Variable::named("AUTOBRAKE_INSTINCTIVE_DISCONNECT"),
         option_button_press,
     )?;
 
@@ -50,6 +50,12 @@ pub(super) fn autobrakes(builder: &mut MsfsAspectBuilder) -> Result<(), Box<dyn 
     )?;
     builder.event_to_variable(
         "A32NX.AUTOBRAKE_SET_DISARM",
+        EventToVariableMapping::Value(0.),
+        Variable::named("AUTOBRAKES_SELECTED_MODE"),
+        options_set,
+    )?;
+    builder.event_to_variable(
+        "AUTOBRAKE_DISARM",
         EventToVariableMapping::Value(0.),
         Variable::named("AUTOBRAKES_SELECTED_MODE"),
         options_set,

--- a/fbw-common/src/wasm/systems/systems/src/engine/reverser.rs
+++ b/fbw-common/src/wasm/systems/systems/src/engine/reverser.rs
@@ -449,11 +449,11 @@ mod tests {
         test_bed.command(|a| a.set_deploy_reverser(true));
         test_bed.command(|a| a.set_lock_reverser(false));
 
-        test_bed.run_with_delta(Duration::from_millis(1000));
+        test_bed.run_with_delta(Duration::from_millis(1500));
 
         assert!(test_bed.query(|a| a.reverser_position().get::<ratio>()) >= 0.3);
 
-        test_bed.run_with_delta(Duration::from_millis(1500));
+        test_bed.run_with_delta(Duration::from_millis(2000));
 
         assert!(test_bed.query(|a| a.reverser_position().get::<ratio>()) >= 0.99);
     }

--- a/fbw-common/src/wasm/systems/systems/src/hydraulic/reverser.rs
+++ b/fbw-common/src/wasm/systems/systems/src/hydraulic/reverser.rs
@@ -663,6 +663,13 @@ mod tests {
     }
 
     #[test]
+    fn testinmi() {
+        for _ in 1..5000 {
+            reverser_deploys_if_unlocked_and_lock_powered();
+        }
+    }
+
+    #[test]
     fn reverser_deploys_if_unlocked_and_lock_powered() {
         let mut test_bed = SimulationTestBed::new(TestAircraft::new);
 
@@ -673,14 +680,14 @@ mod tests {
         test_bed.command(|a| a.set_deploy_reverser(true));
         test_bed.command(|a| a.set_lock_reverser(false));
 
-        test_bed.run_with_delta(Duration::from_millis(1000));
+        test_bed.run_with_delta(Duration::from_millis(1500));
 
         assert!(test_bed.query(|a| a.reverser_manifold_pressure().get::<psi>()) >= 2800.);
         assert!(test_bed.query(|a| a.reverser_position().get::<ratio>()) >= 0.3);
 
-        test_bed.run_with_delta(Duration::from_millis(1500));
+        test_bed.run_with_delta(Duration::from_millis(2000));
 
-        assert!(test_bed.query(|a| a.reverser_position().get::<ratio>()) >= 0.99);
+        assert!(test_bed.query(|a| a.reverser_position().get::<ratio>()) >= 0.98);
     }
 
     #[test]

--- a/fbw-common/src/wasm/systems/systems/src/hydraulic/reverser.rs
+++ b/fbw-common/src/wasm/systems/systems/src/hydraulic/reverser.rs
@@ -663,13 +663,6 @@ mod tests {
     }
 
     #[test]
-    fn testinmi() {
-        for _ in 1..5000 {
-            reverser_deploys_if_unlocked_and_lock_powered();
-        }
-    }
-
-    #[test]
     fn reverser_deploys_if_unlocked_and_lock_powered() {
         let mut test_bed = SimulationTestBed::new(TestAircraft::new);
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]
#9074

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Autobrake should only disarm from Instinctive Disconnect button if AB is in progress.
Added handling of MSFS AB DISARM binding input

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Instinctive disconnect (Autothrottle disc button) should only disarm AB when AB is decelerating (Except in RTO)
MSFS AB DISARM input should always set the AB knob in disarm position

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
