### PR TITLE
fix(a380x/btv): Remove problematic auto-selection of BTV runway 

### DIFF
--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcAircraftInterface.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcAircraftInterface.ts
@@ -1110,8 +1110,6 @@ export class FmcAircraftInterface {
     return Number.isFinite(landingWeight) ? landingWeight : NaN;
   }
 
-  private filteredAoA: number = 0;
-
   /**
    * Updates performance speeds such as GD, F, S, Vls and approach speeds. Write to SimVars
    */

--- a/fbw-a380x/src/systems/instruments/src/ND/OansControlPanel.tsx
+++ b/fbw-a380x/src/systems/instruments/src/ND/OansControlPanel.tsx
@@ -265,11 +265,12 @@ export class OansControlPanel extends DisplayComponent<OansProps> {
         this.pposLonWord.setWord(value);
       });
 
-    this.btvUtils.below300ftRaAndLanding.sub((v) => {
+    // This lead to BTV being disarmed at 300ft. We'll have to investigate and then fix FIXME
+    /* this.btvUtils.below300ftRaAndLanding.sub((v) => {
       if (this.navigraphAvailable.get() === false && v && !this.btvUtils.runwayIsSet()) {
         this.setBtvRunwayFromFmsRunway();
       }
-    });
+    });*/
 
     this.fmsDataStore.landingRunway.sub(async (it) => {
       // Set control panel display

--- a/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
+++ b/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
@@ -443,11 +443,12 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
       }
     }, true);
 
-    this.btvUtils.below300ftRaAndLanding.sub(async (v) => {
+    // This lead to BTV being disarmed at 300ft. We'll have to investigate and then fix FIXME
+    /* this.btvUtils.below300ftRaAndLanding.sub(async (v) => {
       if (this.oansNotAvailable.get() === false && v && !this.btvUtils.runwayIsSet()) {
         [, this.arpCoordinates] = await Oanc.setBtvRunwayFromFmsRunway(this.fmsDataStore, this.btvUtils);
       }
-    });
+    });*/
 
     this.fmsDataStore.origin.sub(() => this.updateLabelClasses());
     this.fmsDataStore.departureRunway.sub(() => this.updateLabelClasses());


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9107 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Disables the automatic selection of BTV runway at 300ft, which lead to BTV disconnects before

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. **With navigraph linked in EFB:** Perform normal approach with BTV runway and exit selected through the OANS, and BTV armed. Should NOT disarm at 300ft RA
2. **Without navigraph linked in EFB:** Perform normal approach with BTV runway and requested stopping distance selected through the "fallback OANS control panel (MAP DATA)", and BTV armed. Should NOT disarm at 300ft RA


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
