### PR TITLE
feat(a380x/mfd): remap comma to dot

### DIFF
--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/common/InputField.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/common/InputField.tsx
@@ -190,10 +190,14 @@ export class InputField<T> extends DisplayComponent<InputFieldProps<T>> {
     // ev.key is undefined, so we have to use the deprecated keyCode here
     const key = String.fromCharCode(ev.keyCode).toUpperCase();
 
-    if (ev.keyCode !== KeyCode.KEY_ENTER) {
-      this.handleKeyInput(key);
-    } else {
+    if (ev.keyCode === KeyCode.KEY_ENTER) {
       this.handleEnter();
+    } else if (key === ',') {
+      // Most non-English-speaking countries use comma as their decimal separator. Remap comma to dot to make it easier
+      // to enter decimals in those keyboard layouts - it is not a valid KCCU key anyway.
+      this.handleKeyInput('.');
+    } else {
+      this.handleKeyInput(key);
     }
   }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Many countries in the world do not use dot as their decimal separator (anything that isn't blue):
![World Map with countries colored by decimal separator](https://github.com/user-attachments/assets/a363219b-2384-4edd-8d25-ca52fb87c85d)

In those countries it is common for the numpad to have the appropriate decimal separator on the numpad (e.g. most of Europe).
When focussing an input field in the MFD and using the numpad to enter decimals on such a keyboard layout there is two common issues, explained e.g. on a German keyboard layout where the decimal separator is a comma:
- the comma is not available in the MFD font and a whitespace is rendered
- the decimal is not parsed after blurring the input (due to a FORMAT ERROR)

This is very annoying when one is used to entering e.g. frequencies via the numpad. So for now, this PR just replaces any entered comma with a dot. This should not be a problem, as the comma is not a valid key on the KCCU.

Whether you *should* be able to enter keys that are not on the KCCU at all (basically anything that isn'z A-Z, Space, Dot, plus or minus) is another question, and one that we could tackle in future. We could decide to just outright ignore all of those (probably a future PR).

*Sidenote*: if this were a real browser we could detect the numpad decimal key by checking for `KeyboardEvent.keyCode == KeyCode.KEY_DECIMAL`. That would then not interfere if you actually wanted to enter the comma explicitly. Unfortunately Coherent doesn't expose this an just exposes both as a generic comma.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before:
![image](https://github.com/user-attachments/assets/37328536-55c5-4ee6-bc96-3bb0c48489a2)

After:
![image](https://github.com/user-attachments/assets/70879a73-d0a5-417a-82ef-2cb787b8a4b7)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Set your Windows keyboard layout to one where the decimal separator is a comma (e.g. German).
2. Focus any input on the MFD (e.g. FMS 1/2 > POSITION > NAVAIDS > FREQ
3. Enter a decimal number entirely via the numpad on your keyboard. You should notice the decimal key being consistenly entered as a dot.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
