### PR TITLE
fix(a380/bat): fix voltage display on BAT KNOW in OFF position

### DIFF
--- a/fbw-a380x/src/systems/instruments/src/BAT/index.tsx
+++ b/fbw-a380x/src/systems/instruments/src/BAT/index.tsx
@@ -17,9 +17,15 @@ const BatRoot = () => {
 
   // mapping of knob (lvar) values to battery numbers to allow easy lvar and model values
   const batteryMap = [4, 3, 0, 1, 2]; // ESS, APU, OFF, BAT1, BAT2
+
+  // only display battery voltage if not in OFF position
+  const batteryNumber = batteryMap[selectedBattery];
+  
   return (
     <svg className="bat-svg" viewBox="0 0 200 100">
-      <BatDisplay batteryNumber={batteryMap[selectedBattery]} x="196" y="48" />
+      {batteryNumber !== 2 ? ( // Condition to hide display when in OFF position
+        <BatDisplay batteryNumber={batteryNumber} x="196" y="48" />
+      ) : null}
     </svg>
   );
 };


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9002 

## Summary of Changes
The battery voltage was displaying a voltage of 00.0V when it was on the off position.
This script modification return (null) when the know is on position OFF instead of 00.0V

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): tommytknuckles

## Testing instructions
Load the A380X
Observe bat knob on the off position
Observe null being displayed
Observe bat knob on other positions
Observe voltage being displayed

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
