### PR TITLE
fix(A380x): Turned off PB lights for INOP systems on upper OVHD 

### DIFF
--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/A380_COCKPIT.xml
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/A380_COCKPIT.xml
@@ -2982,15 +2982,17 @@
                     <!-- NSS DATA TO AVNCS-->
                     <UseTemplate Name="FBW_Push_Toggle">
                         <NODE_ID>PUSH_OVHD_NSSAVNCS</NODE_ID>
-                        <TOGGLE_SIMVAR>L:A32NX_OVHD_COCKPITDOORVIDEO_TOGGLE</TOGGLE_SIMVAR>
+                        <INOP></INOP>
+                        <TOGGLE_SIMVAR>L:A32NX_OVHD_NSS_DATA_TO_AVNCS_TOGGLE</TOGGLE_SIMVAR>
                         <SEQ_POWERED>(L:A32NX_ELEC_AC_1_BUS_IS_POWERED, Bool)</SEQ_POWERED>
-                        <SEQ2_CODE>(L:A32NX_OVHD_COCKPITDOORVIDEO_TOGGLE, Bool) !</SEQ2_CODE>
+						<SEQ1_CODE>(L:A32NX_OVHD_NSS_DATA_TO_AVNCS_TOGGLE, Bool)</SEQ1_CODE>
+                        <SEQ2_CODE>(L:A32NX_OVHD_NSS_DATA_TO_AVNCS_TOGGLE, Bool) !</SEQ2_CODE>
                         <SEQ1_EMISSIVE_DRIVES_VISIBILITY>False</SEQ1_EMISSIVE_DRIVES_VISIBILITY>
                         <SEQ2_EMISSIVE_DRIVES_VISIBILITY>False</SEQ2_EMISSIVE_DRIVES_VISIBILITY>
                         <SEQ1_CODE_DRIVES_VISIBILITY>False</SEQ1_CODE_DRIVES_VISIBILITY>
                         <SEQ2_CODE_DRIVES_VISIBILITY>False</SEQ2_CODE_DRIVES_VISIBILITY>
-                        <TOOLTIPID>%((L:A32NX_OVHD_COCKPITDOORVIDEO_TOGGLE, Bool))%{if}Turn OFF door
-                            video%{else}Turn ON door video%{end}</TOOLTIPID>
+                        <TOOLTIPID>%((L:A32NX_OVHD_NSS_DATA_TO_AVNCS_TOGGLE, Bool))%{if}Turn OFF NSS
+                            Data%{else}Turn ON NSS Data%{end}</TOOLTIPID>
                     </UseTemplate>
 
                     <UseTemplate Name="FBW_Push_Toggle">
@@ -4856,6 +4858,53 @@
                         <NODE_ID>PUSH_OVHD_APU_AUTOEXITING_RESET</NODE_ID>
                         <HOLD_SIMVAR>L:A32NX_APU_AUTOEXITING_RESET</HOLD_SIMVAR>
                         <TOOLTIPID>Reset APU autoexiting (Inop.)</TOOLTIPID>
+                    </UseTemplate>
+                    
+					<!-- INOP PBs ON UPPER OVERHEAD -->
+					<!-- FUEL -->
+					<UseTemplate Name="FBW_Push_Toggle">
+                        <NODE_ID>PUSH_OVHD_REFUEL</NODE_ID>
+						<INOP></INOP>
+                    </UseTemplate>
+					<UseTemplate Name="FBW_Push_Toggle">
+                        <NODE_ID>PUSH_OVHD_AUTO_GND_XFR</NODE_ID>
+						<INOP></INOP>
+                    </UseTemplate>
+					
+					<!-- MISC -->
+					<UseTemplate Name="FBW_Covered_Push_Toggle">
+                        <NODE_ID>PUSH_GND_HF_DATA_LINK</NODE_ID>
+						<DUMMY_BUTTON>True</DUMMY_BUTTON>
+						<DISABLE_SEQ1></DISABLE_SEQ1>
+						<DISABLE_SEQ2></DISABLE_SEQ2>
+                    </UseTemplate>
+					
+					<!-- MAINT -->
+					<UseTemplate Name="FBW_Covered_Push_Toggle">
+                        <NODE_ID>PUSH_OVHD_MAINT_GND_CONNECTION</NODE_ID>
+						<DUMMY_BUTTON>True</DUMMY_BUTTON>
+						<DISABLE_SEQ1></DISABLE_SEQ1>
+						<DISABLE_SEQ2></DISABLE_SEQ2>
+                    </UseTemplate>
+					
+					<!-- NSS -->
+					<UseTemplate Name="FBW_Push_Toggle">
+                        <NODE_ID>PUSH_OVHD_GATELINK</NODE_ID>
+						<INOP></INOP>
+                    </UseTemplate>
+					<UseTemplate Name="FBW_Push_Toggle">
+                        <NODE_ID>PUSH_OVHD_CAB_DATA_TO_NSS</NODE_ID>
+						<INOP></INOP>
+                    </UseTemplate>
+					
+					<!-- AIR / VENT -->
+					<UseTemplate Name="FBW_Push_Toggle">
+                        <NODE_ID>PUSH_OVHD_OVHT_COND_FANS</NODE_ID>
+						<INOP></INOP>
+                    </UseTemplate>
+					<UseTemplate Name="FBW_Push_Toggle">
+                        <NODE_ID>PUSH_OVHD_AVNCS_GND_COOLG</NODE_ID>
+						<INOP></INOP>
                     </UseTemplate>
                 </Component>
 


### PR DESCRIPTION
Turned off emissives for no simulated systems with BPs on upper overhead.

Decoupled the overhead NSS AVNCS switch from the Cockpit Door Video Switch (some previous copypasta).

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->


## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![overhead](https://github.com/user-attachments/assets/056582f5-53df-40f2-bed0-49175844f026)



Discord username (if different from GitHub): Shrike


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
