### PR TITLE
fix(a32nx/EFB): Small fix to takeoff perf calculator CONF 2 climb-limited takeoff speeds

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -124,6 +124,7 @@
 1. [FMS] Run vertical predictions without V-speeds - @BlueberryKing (BlueberryKing)
 1. [ELEC] Use ADIRU and LGCIU signals for speed and in flight determination - @Gurgel100 (Pascal)
 1. [FMS] Do not transmit bearing information to ND on manual legs - @BravoMike99 (bruno_pt99)
+1. [EFB] Small fix to takeoff calculator for CONF 2 climb speeds - @donstim (donbikes)
 
 ## 0.11.0
 

--- a/fbw-a32nx/src/systems/shared/src/performance/a32nx_takeoff.ts
+++ b/fbw-a32nx/src/systems/shared/src/performance/a32nx_takeoff.ts
@@ -915,7 +915,7 @@ export class A320251NTakeoffPerformanceCalculator implements TakeoffPerformanceC
 
   private static readonly v2SecondSegBrakeThresholds: Record<number, [number, number]> = {
     1: [-0.009368, 186.79],
-    2: [0.017926, 89.07],
+    2: [0.030256, 50.12],
     3: [0.022112, 83.141],
   };
 

--- a/fbw-a32nx/src/systems/shared/src/performance/a32nx_takeoff.ts
+++ b/fbw-a32nx/src/systems/shared/src/performance/a32nx_takeoff.ts
@@ -915,7 +915,7 @@ export class A320251NTakeoffPerformanceCalculator implements TakeoffPerformanceC
 
   private static readonly v2SecondSegBrakeThresholds: Record<number, [number, number]> = {
     1: [-0.009368, 186.79],
-    2: [0.02346, 68.33],
+    2: [0.01738, 90.82],
     3: [0.022112, 83.141],
   };
 

--- a/fbw-a32nx/src/systems/shared/src/performance/a32nx_takeoff.ts
+++ b/fbw-a32nx/src/systems/shared/src/performance/a32nx_takeoff.ts
@@ -915,7 +915,7 @@ export class A320251NTakeoffPerformanceCalculator implements TakeoffPerformanceC
 
   private static readonly v2SecondSegBrakeThresholds: Record<number, [number, number]> = {
     1: [-0.009368, 186.79],
-    2: [0.01738, 90.82],
+    2: [0.017926, 89.07],
     3: [0.022112, 83.141],
   };
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->


## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Changes the threshold no wind V2 speed for CONF 2 at which a switch to lower V2 speeds is activated. Discussion in Discord support ops channel with @tshomas pointed out a discrepancy in takeoff speeds for a certain takeoff conditions at EDDB for CONF 1+F and 2. While this PR does not completely address the issue, it at least fixes the issue for CONF 2 at the runway length of 3180 meters used as the base runway length for computing second-segment climb limited takeoff speeds.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
