### PR TITLE
fix: A380X fix page cycling with ACP ALL button

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -20,6 +20,9 @@
 1. [A380X/OVHD] Fix RCDR GND CTL button/logic - @flogross89 (floridude)
 1. [A380X] Various fixes in FMS and ECL - @flogross89 (floridude)
 1. [A380X/EWD] QoL: Add soft keys to EWD checklists, can be enabled via EFB - @flogross89 (floridude)
+1. [A380X] Various fixes in FMS and ECL @flogross89 (floridude)
+1. [A380X/TELEX] Added popup for telex consent @saschl (saschl) @Maximilian-Reuter (\_chaoz)
+1. [A380X/SD] Added correct ECP ALL button SD page cycling to the A380X - @frankkopp (Frank Kopp)
 
 ## 0.12.0
 
@@ -48,7 +51,7 @@
 1. [MODEL] General improvements to 3d model and textures - @MoreRightRudder, @Repsol2k, @tracernz
 1. [MODEL] Folding armrests - @Repsol2k
 1. [LIGHTING] Fixed Automatic Lighting on Spawn depending on outside lightcondition - @Maximilian-Reuter (\_chaoz_)
-1. [EFCS] Implement calculated yaw damper gain  - @lukecologne (luke)
+1. [EFCS] Implement calculated yaw damper gain - @lukecologne (luke)
 1. [EFCS] Decrease yaw damper at low speeds on ground, down to 0 below 40kts - @lukecologne (luke)
 1. [FLIGHTMODEL] Fix pitch trim on approach - @donstim (donbikes)
 1. [GENERAL] Added C++ WASM framework and migrated all flypad-backend code to it - @frankkopp (Frank Kopp)
@@ -90,7 +93,7 @@
 1. [FUEL] Lowered starting fuel on C/D spawn, will only load last saved fuel on C/D spawn, center tank refuel now happens simultaneous with wing refuel - @Maximilian-Reuter
 1. [EFB/SIMBRIEF] Option to import SimBrief Fuel & Payload when SimBrief Data is imported - @Fragtality (Fragtality) + @Maximilian-Reuter
 1. [FLIGHTMODEL] Fixes some crosswind issues - @donstim (donbikes)
-1. [LIGHTS] Movement of landing lights now requires power and position is output into LVAR -  @Maximilian-Reuter
+1. [LIGHTS] Movement of landing lights now requires power and position is output into LVAR - @Maximilian-Reuter
 1. [CDU] Fix auto weight and balance import on INIT B during GSX boarding not using the target values - @Maximilian-Reuter
 1. [FAC] Improve sideslip estimation - @lukecologne (luke)
 1. [FWC] Implement overspeed VMO/MMO warning - @tracernz (Mike)
@@ -267,7 +270,7 @@
 1. [ATSU] ATSU as single instrument according to A20N architecture - @svengcz (Sven)
 1. [DATALINK] Splitted up ATC/AOC/Router to single components @svengcz (Sven)
 1. [ND] Fixed RNP <= 0.3 indications to appear more reliably and consistently - @tracernz (Mike)
-1. [EFB] Mitigated issue with flypad fuel page for very long translation strings  - @frankkopp (Frank Kopp)
+1. [EFB] Mitigated issue with flypad fuel page for very long translation strings - @frankkopp (Frank Kopp)
 1. [ISIS] Show baro correction during power-up sequence - @tracernz (Mike)
 1. [FWC] Add GND SPLR NOT ARMED warning - @tracernz (Mike)
 1. [FWC] Add SPD BRK STILL OUT warning - @tracernz (Mike)
@@ -304,7 +307,7 @@
 1. [FLIGHTMODEL/EFB] Updated CG for ELAC 103 - @donstim (donbikes#4084)
 1. [FLIGHTMODEL/FUEL] Update of fuel system (center tank transfer and crossfeed) - @donstim (donbikes#4084), @tracernz (Mike), @Taz5150 (TazX [Z+2]#0405)
 1. [MODEL] Fix mouse collision boxes for the fire guards on the overhead - @tracernz (Mike)
-1. [FLIGHTMODEL/FUEL] Reinstate updated outer fuel tank position from updated CG for ELAC 103 -  @donstim (donbikes#4084)
+1. [FLIGHTMODEL/FUEL] Reinstate updated outer fuel tank position from updated CG for ELAC 103 - @donstim (donbikes#4084)
 1. [MODEL] Change pitch trim scale to correct neo scale - @tracernz (Mike)
 1. [MCDU] Fix no overfly shown on forced turn on F-PLN page, return to F-PLN page on TMPY insert - @tracernz (Mike)
 1. [FMS] Handle approach transitions hidden inside other transition with Navigraph data - @tracernz (Mike)
@@ -1455,4 +1458,4 @@
 1. [ISIS] Fixed issue where ISIS was allowing a bug to be set while in the OFF state - Patrick Macken (@Pat M on
    Discord)
 1. [EFB] Restructured APIs and made Navigraph Auth a reusable component - @MicahBCode (Mischa Binder)
-1. [ECAM] Added F units to CRZ and COND pages for Cabin temps.  Currently tied to kg/lbs  option in EFB -Patrick Macken  (@PatM on Discord)
+1. [ECAM] Added F units to CRZ and COND pages for Cabin temps. Currently tied to kg/lbs option in EFB -Patrick Macken  (@PatM on Discord)

--- a/fbw-a380x/docs/a380-simvars.md
+++ b/fbw-a380x/docs/a380-simvars.md
@@ -3,25 +3,25 @@
 ## Contents
 
 - [A380 Local SimVars](#a380-local-simvars)
-  - [Contents](#contents)
-  - [Uncategorized](#uncategorized)
-  - [Air Conditioning Pressurisation Ventilation ATA 21](#air-conditioning-pressurisation-ventilation-ata-21)
-  - [Auto Flight System ATA 22](#auto-flight-system-ata-22)
-  - [Flight Management System ATA 22](#flight-management-system-ata-22)
-  - [Electrical ATA 24](#electrical-ata-24)
-  - [Fire and Smoke Protection ATA 26](#fire-and-smoke-protection-ata-26)
-  - [Flaps / Slats (ATA 27)](#flaps--slats-ata-27)
-  - [Indicating-Recording ATA 31](#indicating-recording-ata-31)
-  - [ECAM Control Panel ATA 31](#ecam-control-panel-ata-31)
-  - [EFIS Control Panel ATA 31](#efis-control-panel-ata-31)
-  - [Bleed Air ATA 36](#bleed-air-ata-36)
-  - [Integrated Modular Avionics ATA 42](#integrated-modular-avionics-ata-42)
-  - [Auxiliary Power Unit ATA 49](#auxiliary-power-unit-ata-49)
-  - [Engines ATA 70](#engines-ata-70)
-  - [Hydraulics](#hydraulics)
-  - [Sound Variables](#sound-variables)
-  - [Autobrakes](#autobrakes)
-  - [Non-Systems Related](#non-systems-related)
+    - [Contents](#contents)
+    - [Uncategorized](#uncategorized)
+    - [Air Conditioning Pressurisation Ventilation ATA 21](#air-conditioning-pressurisation-ventilation-ata-21)
+    - [Auto Flight System ATA 22](#auto-flight-system-ata-22)
+    - [Flight Management System ATA 22](#flight-management-system-ata-22)
+    - [Electrical ATA 24](#electrical-ata-24)
+    - [Fire and Smoke Protection ATA 26](#fire-and-smoke-protection-ata-26)
+    - [Flaps / Slats (ATA 27)](#flaps--slats-ata-27)
+    - [Indicating-Recording ATA 31](#indicating-recording-ata-31)
+    - [ECAM Control Panel ATA 31](#ecam-control-panel-ata-31)
+    - [EFIS Control Panel ATA 31](#efis-control-panel-ata-31)
+    - [Bleed Air ATA 36](#bleed-air-ata-36)
+    - [Integrated Modular Avionics ATA 42](#integrated-modular-avionics-ata-42)
+    - [Auxiliary Power Unit ATA 49](#auxiliary-power-unit-ata-49)
+    - [Engines ATA 70](#engines-ata-70)
+    - [Hydraulics](#hydraulics)
+    - [Sound Variables](#sound-variables)
+    - [Autobrakes](#autobrakes)
+    - [Non-Systems Related](#non-systems-related)
 
 ## Uncategorized
 
@@ -29,7 +29,7 @@
     - Enum
     - Represents the state of the ANN LT switch
     - | State | Value |
-      |-------|-------|
+            |-------|-------|
       | TEST  | 0     |
       | BRT   | 1     |
       | DIM   | 2     |
@@ -136,7 +136,7 @@
     - Will be reset to 0 after loading is done
     - When set to 0 during loading will stop and cancel the loading process
     - | Value | Meaning            |
-            |-------|--------------------|
+                  |-------|--------------------|
       | 1     | Cold & Dark        |
       | 2     | Powered            |
       | 3     | Ready for Pushback |
@@ -170,7 +170,6 @@
     - Turn factor for pushback
     - -1.0 is full left, 0.0 is straight, 1.0 is full right
 
-
 ## Air Conditioning Pressurisation Ventilation ATA 21
 
 - A32NX_COND_CPIOM_B{id}_AGS_DISCRETE_WORD
@@ -178,7 +177,7 @@
     - Discrete Data word of the AGS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-      |:---:|:----------------------------------------------------:|
+            |:---:|:----------------------------------------------------:|
       | 11  | AGS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | Pack 1 operating                                     |
@@ -189,7 +188,7 @@
     - Discrete Data word of the TCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-      |:---:|:----------------------------------------------------:|
+            |:---:|:----------------------------------------------------:|
       | 11  | TCS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | Hot Air 1 position disagrees                         |
@@ -202,7 +201,7 @@
     - Discrete Data word of the VCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-      |:---:|:----------------------------------------------------:|
+            |:---:|:----------------------------------------------------:|
       | 11  | VCS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | FWD Extraction fan is on                             |
@@ -223,7 +222,7 @@
     - Discrete Data word of the CPCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-      |:---:|:----------------------------------------------------:|
+            |:---:|:----------------------------------------------------:|
       | 11  | CPCS Application INOP                                |
       | 12  | Unused                                               |
       | 13  | Excessive cabin altitude - warn                      |
@@ -385,7 +384,7 @@
 - A32NX_OVHD_COND_RAM_AIR_PB_IS_ON
     - Bool
     - True if the ram air pushbutton is pressed in the on position
-  (on light iluminates)
+      (on light iluminates)
 
 - A32NX_OVHD_CARGO_AIR_{id}_SELECTOR_KNOB
     - Number (0 to 300)
@@ -505,44 +504,44 @@
     - Bool
     - True when the given bus is powered
     - {name}
-      - AC_1
-      - AC_2
-      - AC_3
-      - AC_4
-      - AC_ESS
-      - AC_ESS_SCHED
-      - AC_247XP
-      - DC_1
-      - DC_2
-      - DC_ESS
-      - DC_247PP
-      - DC_HOT_1
-      - DC_HOT_2
-      - DC_HOT_3
-      - DC_HOT_4
-      - DC_GND_FLT_SVC
+        - AC_1
+        - AC_2
+        - AC_3
+        - AC_4
+        - AC_ESS
+        - AC_ESS_SCHED
+        - AC_247XP
+        - DC_1
+        - DC_2
+        - DC_ESS
+        - DC_247PP
+        - DC_HOT_1
+        - DC_HOT_2
+        - DC_HOT_3
+        - DC_HOT_4
+        - DC_GND_FLT_SVC
 
 - A32NX_ELEC_{name}_POTENTIAL
     - Volts
     - The electric potential of the given element
     - {name}
-      - APU_GEN_1
-      - APU_GEN_2
-      - ENG_GEN_1
-      - ENG_GEN_2
-      - ENG_GEN_3
-      - ENG_GEN_4
-      - EXT_PWR
-      - STAT_INV
-      - EMER_GEN
-      - TR_1
-      - TR_2
-      - TR_3: TR ESS
-      - TR_4: TR APU
-      - BAT_1
-      - BAT_2
-      - BAT_3: BAT ESS
-      - BAT_4: BAT APU
+        - APU_GEN_1
+        - APU_GEN_2
+        - ENG_GEN_1
+        - ENG_GEN_2
+        - ENG_GEN_3
+        - ENG_GEN_4
+        - EXT_PWR
+        - STAT_INV
+        - EMER_GEN
+        - TR_1
+        - TR_2
+        - TR_3: TR ESS
+        - TR_4: TR APU
+        - BAT_1
+        - BAT_2
+        - BAT_3: BAT ESS
+        - BAT_4: BAT APU
 
 - A32NX_ELEC_{name}_POTENTIAL_NORMAL
     - Bool
@@ -666,7 +665,7 @@
     - Arinc429<Discrete>
     - Discrete Data word of the Fire Detection Unit (assumed)
     - | Bit |                      Description                     |
-      |:---:|:----------------------------------------------------:|
+            |:---:|:----------------------------------------------------:|
       | 11  | Fire detected ENG 1                                  |
       | 12  | Fire detected ENG 2                                  |
       | 13  | Fire detected ENG 3                                  |
@@ -767,7 +766,6 @@
     - Bool
     - True when the overhead fire test pushbutton is pressed
 
-
 ## Flaps / Slats (ATA 27)
 
 - A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD
@@ -775,7 +773,7 @@
     - Arinc429<Discrete>
     - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - | Bit |      Description A380X, if different     |
-      |:---:|:----------------------------------------:|
+            |:---:|:----------------------------------------:|
       | 11  | Slat Data Valid                          |
       | 12  | Slats Retracted 0° (6.2° > FPPU > -5°)   |
       | 13  | Slats >= 19° (337° > FPPU > 234.7°)      |
@@ -797,71 +795,71 @@
       | 29  | Flap System Jam                          |
 
 - A32NX_FLAPS_CONF_INDEX
-  - Number
-  - Indicates the desired flap configuration index according to the table
-  - Value | Meaning
-            --- | ---
-      0 | Conf0
-      1 | Conf1
-      2 | Conf1F
-      3 | Conf2
-      4 | Conf2S
-      5 | Conf3
-      6 | Conf4
+    - Number
+    - Indicates the desired flap configuration index according to the table
+    - Value | Meaning
+                  --- | ---
+        0 | Conf0
+        1 | Conf1
+        2 | Conf1F
+        3 | Conf2
+        4 | Conf2S
+        5 | Conf3
+        6 | Conf4
 
 ## Indicating-Recording ATA 31
 
 - A32NX_CDS_CAN_BUS_1_1_AVAIL
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the captain's side is available
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the captain's side is available
 
 - A32NX_CDS_CAN_BUS_1_2_AVAIL
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the captain's side is available
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the captain's side is available
 
 - A32NX_CDS_CAN_BUS_2_1_AVAIL
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the first officer's side is available
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the first officer's side is available
 
 - A32NX_CDS_CAN_BUS_2_2_AVAIL
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the first officer's side is available
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the first officer's side is available
 
 - A32NX_CDS_CAN_BUS_1_1_FAILURE
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_1_2_FAILURE
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_2_1_FAILURE
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_2_2_FAILURE
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_1_1_<FUNCTION_ID>_RECEIVED
-  - Bool
-  - Indicates if the system per function ID in the CDS bus received the last sent message
+    - Bool
+    - Indicates if the system per function ID in the CDS bus received the last sent message
 
 - A32NX_CDS_CAN_BUS_1_1
-  - ArincWord852<>
-  - First CAN bus of the CDS on the captain's side
+    - ArincWord852<>
+    - First CAN bus of the CDS on the captain's side
 
 - A32NX_CDS_CAN_BUS_1_2
-  - ArincWord852<>
-  - Second CAN bus of the CDS on the captain's side
+    - ArincWord852<>
+    - Second CAN bus of the CDS on the captain's side
 
 - A32NX_CDS_CAN_BUS_2_1
-  - ArincWord852<>
-  - First CAN bus of the CDS on the first officer's side
+    - ArincWord852<>
+    - First CAN bus of the CDS on the first officer's side
 
 - A32NX_CDS_CAN_BUS_2_2
-  - ArincWord852<>
-  - Second CAN bus of the CDS on the first officer's side
+    - ArincWord852<>
+    - Second CAN bus of the CDS on the first officer's side
 
 ## ECAM Control Panel ATA 31
 
@@ -884,11 +882,11 @@
         - TOCONFIG
         - UP
 
-- A380X_ECAM_CP_SELECTED_PAGE
+- A32NX_ECAM_SD_CURRENT_PAGE_INDEX
     - Enum
 - Currently requested page on the ECAM CP
     - | State | Value |
-      |-------|-------|
+            |-------|-------|
       | ENG   | 0     |
       | APU   | 1     |
       | BLEED | 2     |
@@ -905,7 +903,6 @@
       | CRZ   | 13    |
       | STS   | 14    |
       | VIDEO | 15    |
-
 
 ## EFIS Control Panel ATA 31
 
@@ -929,7 +926,7 @@
     - Indicates which waypoint filter is selected
     - {side} = L or R
     - | State | Value |
-      |-------|-------|
+            |-------|-------|
       | WPT   | 1     |
       | VORD  | 2     |
       | NDB   | 3     |
@@ -939,7 +936,7 @@
     - Indicates which waypoint filter is selected
     - {side} = L or R
     - | State | Value |
-      |-------|-------|
+            |-------|-------|
       | WX    | 0     |
       | TERR  | 1     |
 
@@ -961,53 +958,55 @@
 ## Bleed Air ATA 36
 
 - A32NX_PNEU_ENG_{number}_INTERMEDIATE_TRANSDUCER_PRESSURE
-  - Psi
-  - Pressure measured at the intermediate pressure transducer at engine {number}, -1 if no output
+    - Psi
+    - Pressure measured at the intermediate pressure transducer at engine {number}, -1 if no output
 
 ## Integrated Modular Avionics ATA 42
 
 -A32NX_AFDX_<SOURCE_ID>_<DESTINATION_ID>_REACHABLE
-  - Bool
-  - Indicates if the AFDX switch with the source id can reach the switch with the destination id
+
+- Bool
+- Indicates if the AFDX switch with the source id can reach the switch with the destination id
 
 - A32NX_AFDX_SWITCH_<ID>_FAILURE
-  - Bool
-  - Indicates if a specific AFDX switch is in a failure mode
+    - Bool
+    - Indicates if a specific AFDX switch is in a failure mode
 
 - A32NX_AFDX_SWITCH_<ID>_AVAIL
-  - Bool
-  - Indicates if a specific AFDX switch is available
+    - Bool
+    - Indicates if a specific AFDX switch is available
 
 - A32NX_CPIOM_<NAME>_FAILURE
-  - Bool
-  - Indicates if a specific CPIOM system is in a failure mode
+    - Bool
+    - Indicates if a specific CPIOM system is in a failure mode
 
 - A32NX_CPIOM_<NAME>_AVAIL
-  - Bool
-  - Indicates if a specific CPIOM system is available
+    - Bool
+    - Indicates if a specific CPIOM system is available
 
 - A32NX_IOM_<NAME>_FAILURE
-  - Bool
-  - Indicates if a specific IOM system is in a failure mode
+    - Bool
+    - Indicates if a specific IOM system is in a failure mode
 
 - A32NX_IOM_<NAME>_AVAIL
-  - Bool
-  - Indicates if a specific IOM system is available
+    - Bool
+    - Indicates if a specific IOM system is available
 
 ## Auxiliary Power Unit ATA 49
 
 - A32NX_APU_N2
-  - `Arinc429Word<Percent>`
-  - The APU's N2 rotations per minute in percentage of the maximum RPM
+    - `Arinc429Word<Percent>`
+    - The APU's N2 rotations per minute in percentage of the maximum RPM
 
 - A32NX_APU_FUEL_USED
-  - `Arinc429Word<Mass>`
-  - The APU fuel used, in kilograms
+    - `Arinc429Word<Mass>`
+    - The APU fuel used, in kilograms
 
 ## Engines ATA 70
-  - L:A32NX_OVHD_FADEC_{ENG}
-  - The powered status of the associated engine's FADEC dependant on the button on the OVHD
-  - {ENG} = 1, 2, 3, 4
+
+- L:A32NX_OVHD_FADEC_{ENG}
+- The powered status of the associated engine's FADEC dependant on the button on the OVHD
+- {ENG} = 1, 2, 3, 4
 
 ## Hydraulics
 
@@ -1038,7 +1037,7 @@
     - Number
     - Indicates position of the autobrake selection knob
     -   | State  | Number |
-        |--------|--------|
+                |--------|--------|
         | DISARM | 0      |
         | BTV    | 1      |
         | LOW    | 2      |
@@ -1050,7 +1049,7 @@
     - Number
     - Indicates actual armed mode of autobrake system
     -   | State  | Number |
-        |--------|--------|
+                |--------|--------|
         | DISARM | 0      |
         | BTV    | 1      |
         | LOW    | 2      |
@@ -1070,9 +1069,9 @@
 ## Non-Systems Related
 
 - `L:FBW_PILOT_SEAT`
-  - Enum
-  - Which seat the user/pilot occupies in the flight deck.
-  - | Value | Description |
-    |-------|-------------|
-    | 0     | Left Seat   |
-    | 1     | Right Seat  |
+    - Enum
+    - Which seat the user/pilot occupies in the flight deck.
+    - | Value | Description |
+          |-------|-------------|
+      | 0     | Left Seat   |
+      | 1     | Right Seat  |

--- a/fbw-a380x/docs/a380-simvars.md
+++ b/fbw-a380x/docs/a380-simvars.md
@@ -3,25 +3,25 @@
 ## Contents
 
 - [A380 Local SimVars](#a380-local-simvars)
-    - [Contents](#contents)
-    - [Uncategorized](#uncategorized)
-    - [Air Conditioning Pressurisation Ventilation ATA 21](#air-conditioning-pressurisation-ventilation-ata-21)
-    - [Auto Flight System ATA 22](#auto-flight-system-ata-22)
-    - [Flight Management System ATA 22](#flight-management-system-ata-22)
-    - [Electrical ATA 24](#electrical-ata-24)
-    - [Fire and Smoke Protection ATA 26](#fire-and-smoke-protection-ata-26)
-    - [Flaps / Slats (ATA 27)](#flaps--slats-ata-27)
-    - [Indicating-Recording ATA 31](#indicating-recording-ata-31)
-    - [ECAM Control Panel ATA 31](#ecam-control-panel-ata-31)
-    - [EFIS Control Panel ATA 31](#efis-control-panel-ata-31)
-    - [Bleed Air ATA 36](#bleed-air-ata-36)
-    - [Integrated Modular Avionics ATA 42](#integrated-modular-avionics-ata-42)
-    - [Auxiliary Power Unit ATA 49](#auxiliary-power-unit-ata-49)
-    - [Engines ATA 70](#engines-ata-70)
-    - [Hydraulics](#hydraulics)
-    - [Sound Variables](#sound-variables)
-    - [Autobrakes](#autobrakes)
-    - [Non-Systems Related](#non-systems-related)
+  - [Contents](#contents)
+  - [Uncategorized](#uncategorized)
+  - [Air Conditioning Pressurisation Ventilation ATA 21](#air-conditioning-pressurisation-ventilation-ata-21)
+  - [Auto Flight System ATA 22](#auto-flight-system-ata-22)
+  - [Flight Management System ATA 22](#flight-management-system-ata-22)
+  - [Electrical ATA 24](#electrical-ata-24)
+  - [Fire and Smoke Protection ATA 26](#fire-and-smoke-protection-ata-26)
+  - [Flaps / Slats (ATA 27)](#flaps--slats-ata-27)
+  - [Indicating-Recording ATA 31](#indicating-recording-ata-31)
+  - [ECAM Control Panel ATA 31](#ecam-control-panel-ata-31)
+  - [EFIS Control Panel ATA 31](#efis-control-panel-ata-31)
+  - [Bleed Air ATA 36](#bleed-air-ata-36)
+  - [Integrated Modular Avionics ATA 42](#integrated-modular-avionics-ata-42)
+  - [Auxiliary Power Unit ATA 49](#auxiliary-power-unit-ata-49)
+  - [Engines ATA 70](#engines-ata-70)
+  - [Hydraulics](#hydraulics)
+  - [Sound Variables](#sound-variables)
+  - [Autobrakes](#autobrakes)
+  - [Non-Systems Related](#non-systems-related)
 
 ## Uncategorized
 
@@ -29,7 +29,7 @@
     - Enum
     - Represents the state of the ANN LT switch
     - | State | Value |
-                                                      |-------|-------|
+      |-------|-------|
       | TEST  | 0     |
       | BRT   | 1     |
       | DIM   | 2     |
@@ -136,7 +136,7 @@
     - Will be reset to 0 after loading is done
     - When set to 0 during loading will stop and cancel the loading process
     - | Value | Meaning            |
-                                                            |-------|--------------------|
+            |-------|--------------------|
       | 1     | Cold & Dark        |
       | 2     | Powered            |
       | 3     | Ready for Pushback |
@@ -170,6 +170,7 @@
     - Turn factor for pushback
     - -1.0 is full left, 0.0 is straight, 1.0 is full right
 
+
 ## Air Conditioning Pressurisation Ventilation ATA 21
 
 - A32NX_COND_CPIOM_B{id}_AGS_DISCRETE_WORD
@@ -177,7 +178,7 @@
     - Discrete Data word of the AGS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-                                                      |:---:|:----------------------------------------------------:|
+      |:---:|:----------------------------------------------------:|
       | 11  | AGS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | Pack 1 operating                                     |
@@ -188,7 +189,7 @@
     - Discrete Data word of the TCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-                                                      |:---:|:----------------------------------------------------:|
+      |:---:|:----------------------------------------------------:|
       | 11  | TCS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | Hot Air 1 position disagrees                         |
@@ -201,7 +202,7 @@
     - Discrete Data word of the VCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-                                                      |:---:|:----------------------------------------------------:|
+      |:---:|:----------------------------------------------------:|
       | 11  | VCS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | FWD Extraction fan is on                             |
@@ -222,7 +223,7 @@
     - Discrete Data word of the CPCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-                                                      |:---:|:----------------------------------------------------:|
+      |:---:|:----------------------------------------------------:|
       | 11  | CPCS Application INOP                                |
       | 12  | Unused                                               |
       | 13  | Excessive cabin altitude - warn                      |
@@ -384,7 +385,7 @@
 - A32NX_OVHD_COND_RAM_AIR_PB_IS_ON
     - Bool
     - True if the ram air pushbutton is pressed in the on position
-      (on light iluminates)
+  (on light iluminates)
 
 - A32NX_OVHD_CARGO_AIR_{id}_SELECTOR_KNOB
     - Number (0 to 300)
@@ -504,44 +505,44 @@
     - Bool
     - True when the given bus is powered
     - {name}
-        - AC_1
-        - AC_2
-        - AC_3
-        - AC_4
-        - AC_ESS
-        - AC_ESS_SCHED
-        - AC_247XP
-        - DC_1
-        - DC_2
-        - DC_ESS
-        - DC_247PP
-        - DC_HOT_1
-        - DC_HOT_2
-        - DC_HOT_3
-        - DC_HOT_4
-        - DC_GND_FLT_SVC
+      - AC_1
+      - AC_2
+      - AC_3
+      - AC_4
+      - AC_ESS
+      - AC_ESS_SCHED
+      - AC_247XP
+      - DC_1
+      - DC_2
+      - DC_ESS
+      - DC_247PP
+      - DC_HOT_1
+      - DC_HOT_2
+      - DC_HOT_3
+      - DC_HOT_4
+      - DC_GND_FLT_SVC
 
 - A32NX_ELEC_{name}_POTENTIAL
     - Volts
     - The electric potential of the given element
     - {name}
-        - APU_GEN_1
-        - APU_GEN_2
-        - ENG_GEN_1
-        - ENG_GEN_2
-        - ENG_GEN_3
-        - ENG_GEN_4
-        - EXT_PWR
-        - STAT_INV
-        - EMER_GEN
-        - TR_1
-        - TR_2
-        - TR_3: TR ESS
-        - TR_4: TR APU
-        - BAT_1
-        - BAT_2
-        - BAT_3: BAT ESS
-        - BAT_4: BAT APU
+      - APU_GEN_1
+      - APU_GEN_2
+      - ENG_GEN_1
+      - ENG_GEN_2
+      - ENG_GEN_3
+      - ENG_GEN_4
+      - EXT_PWR
+      - STAT_INV
+      - EMER_GEN
+      - TR_1
+      - TR_2
+      - TR_3: TR ESS
+      - TR_4: TR APU
+      - BAT_1
+      - BAT_2
+      - BAT_3: BAT ESS
+      - BAT_4: BAT APU
 
 - A32NX_ELEC_{name}_POTENTIAL_NORMAL
     - Bool
@@ -665,7 +666,7 @@
     - Arinc429<Discrete>
     - Discrete Data word of the Fire Detection Unit (assumed)
     - | Bit |                      Description                     |
-                                                      |:---:|:----------------------------------------------------:|
+      |:---:|:----------------------------------------------------:|
       | 11  | Fire detected ENG 1                                  |
       | 12  | Fire detected ENG 2                                  |
       | 13  | Fire detected ENG 3                                  |
@@ -766,6 +767,7 @@
     - Bool
     - True when the overhead fire test pushbutton is pressed
 
+
 ## Flaps / Slats (ATA 27)
 
 - A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD
@@ -773,7 +775,7 @@
     - Arinc429<Discrete>
     - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - | Bit |      Description A380X, if different     |
-                                                      |:---:|:----------------------------------------:|
+      |:---:|:----------------------------------------:|
       | 11  | Slat Data Valid                          |
       | 12  | Slats Retracted 0° (6.2° > FPPU > -5°)   |
       | 13  | Slats >= 19° (337° > FPPU > 234.7°)      |
@@ -795,71 +797,71 @@
       | 29  | Flap System Jam                          |
 
 - A32NX_FLAPS_CONF_INDEX
-    - Number
-    - Indicates the desired flap configuration index according to the table
-    - Value | Meaning
-                                                            --- | ---
-        0 | Conf0
-        1 | Conf1
-        2 | Conf1F
-        3 | Conf2
-        4 | Conf2S
-        5 | Conf3
-        6 | Conf4
+  - Number
+  - Indicates the desired flap configuration index according to the table
+  - Value | Meaning
+            --- | ---
+      0 | Conf0
+      1 | Conf1
+      2 | Conf1F
+      3 | Conf2
+      4 | Conf2S
+      5 | Conf3
+      6 | Conf4
 
 ## Indicating-Recording ATA 31
 
 - A32NX_CDS_CAN_BUS_1_1_AVAIL
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the captain's side is available
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the captain's side is available
 
 - A32NX_CDS_CAN_BUS_1_2_AVAIL
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the captain's side is available
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the captain's side is available
 
 - A32NX_CDS_CAN_BUS_2_1_AVAIL
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the first officer's side is available
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the first officer's side is available
 
 - A32NX_CDS_CAN_BUS_2_2_AVAIL
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the first officer's side is available
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the first officer's side is available
 
 - A32NX_CDS_CAN_BUS_1_1_FAILURE
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_1_2_FAILURE
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_2_1_FAILURE
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_2_2_FAILURE
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_1_1_<FUNCTION_ID>_RECEIVED
-    - Bool
-    - Indicates if the system per function ID in the CDS bus received the last sent message
+  - Bool
+  - Indicates if the system per function ID in the CDS bus received the last sent message
 
 - A32NX_CDS_CAN_BUS_1_1
-    - ArincWord852<>
-    - First CAN bus of the CDS on the captain's side
+  - ArincWord852<>
+  - First CAN bus of the CDS on the captain's side
 
 - A32NX_CDS_CAN_BUS_1_2
-    - ArincWord852<>
-    - Second CAN bus of the CDS on the captain's side
+  - ArincWord852<>
+  - Second CAN bus of the CDS on the captain's side
 
 - A32NX_CDS_CAN_BUS_2_1
-    - ArincWord852<>
-    - First CAN bus of the CDS on the first officer's side
+  - ArincWord852<>
+  - First CAN bus of the CDS on the first officer's side
 
 - A32NX_CDS_CAN_BUS_2_2
-    - ArincWord852<>
-    - Second CAN bus of the CDS on the first officer's side
+  - ArincWord852<>
+  - Second CAN bus of the CDS on the first officer's side
 
 ## ECAM Control Panel ATA 31
 
@@ -886,7 +888,7 @@
     - Enum
 - Currently requested page on the ECAM CP
     - | State | Value |
-                  |-------|-------|
+      |-------|-------|
       | ENG   | 0     |
       | APU   | 1     |
       | BLEED | 2     |
@@ -900,9 +902,10 @@
       | HYD   | 10    |
       | F/CTL | 11    |
       | C/B   | 12    |
-      | CRZ   | 13    |    
+      | CRZ   | 13    |
       | STS   | 14    |
       | VIDEO | 15    |
+
 
 ## EFIS Control Panel ATA 31
 
@@ -926,7 +929,7 @@
     - Indicates which waypoint filter is selected
     - {side} = L or R
     - | State | Value |
-                                                      |-------|-------|
+      |-------|-------|
       | WPT   | 1     |
       | VORD  | 2     |
       | NDB   | 3     |
@@ -936,7 +939,7 @@
     - Indicates which waypoint filter is selected
     - {side} = L or R
     - | State | Value |
-                                                      |-------|-------|
+      |-------|-------|
       | WX    | 0     |
       | TERR  | 1     |
 
@@ -958,55 +961,53 @@
 ## Bleed Air ATA 36
 
 - A32NX_PNEU_ENG_{number}_INTERMEDIATE_TRANSDUCER_PRESSURE
-    - Psi
-    - Pressure measured at the intermediate pressure transducer at engine {number}, -1 if no output
+  - Psi
+  - Pressure measured at the intermediate pressure transducer at engine {number}, -1 if no output
 
 ## Integrated Modular Avionics ATA 42
 
 -A32NX_AFDX_<SOURCE_ID>_<DESTINATION_ID>_REACHABLE
-
-- Bool
-- Indicates if the AFDX switch with the source id can reach the switch with the destination id
+  - Bool
+  - Indicates if the AFDX switch with the source id can reach the switch with the destination id
 
 - A32NX_AFDX_SWITCH_<ID>_FAILURE
-    - Bool
-    - Indicates if a specific AFDX switch is in a failure mode
+  - Bool
+  - Indicates if a specific AFDX switch is in a failure mode
 
 - A32NX_AFDX_SWITCH_<ID>_AVAIL
-    - Bool
-    - Indicates if a specific AFDX switch is available
+  - Bool
+  - Indicates if a specific AFDX switch is available
 
 - A32NX_CPIOM_<NAME>_FAILURE
-    - Bool
-    - Indicates if a specific CPIOM system is in a failure mode
+  - Bool
+  - Indicates if a specific CPIOM system is in a failure mode
 
 - A32NX_CPIOM_<NAME>_AVAIL
-    - Bool
-    - Indicates if a specific CPIOM system is available
+  - Bool
+  - Indicates if a specific CPIOM system is available
 
 - A32NX_IOM_<NAME>_FAILURE
-    - Bool
-    - Indicates if a specific IOM system is in a failure mode
+  - Bool
+  - Indicates if a specific IOM system is in a failure mode
 
 - A32NX_IOM_<NAME>_AVAIL
-    - Bool
-    - Indicates if a specific IOM system is available
+  - Bool
+  - Indicates if a specific IOM system is available
 
 ## Auxiliary Power Unit ATA 49
 
 - A32NX_APU_N2
-    - `Arinc429Word<Percent>`
-    - The APU's N2 rotations per minute in percentage of the maximum RPM
+  - `Arinc429Word<Percent>`
+  - The APU's N2 rotations per minute in percentage of the maximum RPM
 
 - A32NX_APU_FUEL_USED
-    - `Arinc429Word<Mass>`
-    - The APU fuel used, in kilograms
+  - `Arinc429Word<Mass>`
+  - The APU fuel used, in kilograms
 
 ## Engines ATA 70
-
-- L:A32NX_OVHD_FADEC_{ENG}
-- The powered status of the associated engine's FADEC dependant on the button on the OVHD
-- {ENG} = 1, 2, 3, 4
+  - L:A32NX_OVHD_FADEC_{ENG}
+  - The powered status of the associated engine's FADEC dependant on the button on the OVHD
+  - {ENG} = 1, 2, 3, 4
 
 ## Hydraulics
 
@@ -1037,7 +1038,7 @@
     - Number
     - Indicates position of the autobrake selection knob
     -   | State  | Number |
-                                                                        |--------|--------|
+        |--------|--------|
         | DISARM | 0      |
         | BTV    | 1      |
         | LOW    | 2      |
@@ -1049,7 +1050,7 @@
     - Number
     - Indicates actual armed mode of autobrake system
     -   | State  | Number |
-                                                                        |--------|--------|
+        |--------|--------|
         | DISARM | 0      |
         | BTV    | 1      |
         | LOW    | 2      |
@@ -1069,9 +1070,9 @@
 ## Non-Systems Related
 
 - `L:FBW_PILOT_SEAT`
-    - Enum
-    - Which seat the user/pilot occupies in the flight deck.
-    - | Value | Description |
-                                                    |-------|-------------|
-      | 0     | Left Seat   |
-      | 1     | Right Seat  |
+  - Enum
+  - Which seat the user/pilot occupies in the flight deck.
+  - | Value | Description |
+    |-------|-------------|
+    | 0     | Left Seat   |
+    | 1     | Right Seat  |

--- a/fbw-a380x/docs/a380-simvars.md
+++ b/fbw-a380x/docs/a380-simvars.md
@@ -3,25 +3,25 @@
 ## Contents
 
 - [A380 Local SimVars](#a380-local-simvars)
-  - [Contents](#contents)
-  - [Uncategorized](#uncategorized)
-  - [Air Conditioning Pressurisation Ventilation ATA 21](#air-conditioning-pressurisation-ventilation-ata-21)
-  - [Auto Flight System ATA 22](#auto-flight-system-ata-22)
-  - [Flight Management System ATA 22](#flight-management-system-ata-22)
-  - [Electrical ATA 24](#electrical-ata-24)
-  - [Fire and Smoke Protection ATA 26](#fire-and-smoke-protection-ata-26)
-  - [Flaps / Slats (ATA 27)](#flaps--slats-ata-27)
-  - [Indicating-Recording ATA 31](#indicating-recording-ata-31)
-  - [ECAM Control Panel ATA 31](#ecam-control-panel-ata-31)
-  - [EFIS Control Panel ATA 31](#efis-control-panel-ata-31)
-  - [Bleed Air ATA 36](#bleed-air-ata-36)
-  - [Integrated Modular Avionics ATA 42](#integrated-modular-avionics-ata-42)
-  - [Auxiliary Power Unit ATA 49](#auxiliary-power-unit-ata-49)
-  - [Engines ATA 70](#engines-ata-70)
-  - [Hydraulics](#hydraulics)
-  - [Sound Variables](#sound-variables)
-  - [Autobrakes](#autobrakes)
-  - [Non-Systems Related](#non-systems-related)
+    - [Contents](#contents)
+    - [Uncategorized](#uncategorized)
+    - [Air Conditioning Pressurisation Ventilation ATA 21](#air-conditioning-pressurisation-ventilation-ata-21)
+    - [Auto Flight System ATA 22](#auto-flight-system-ata-22)
+    - [Flight Management System ATA 22](#flight-management-system-ata-22)
+    - [Electrical ATA 24](#electrical-ata-24)
+    - [Fire and Smoke Protection ATA 26](#fire-and-smoke-protection-ata-26)
+    - [Flaps / Slats (ATA 27)](#flaps--slats-ata-27)
+    - [Indicating-Recording ATA 31](#indicating-recording-ata-31)
+    - [ECAM Control Panel ATA 31](#ecam-control-panel-ata-31)
+    - [EFIS Control Panel ATA 31](#efis-control-panel-ata-31)
+    - [Bleed Air ATA 36](#bleed-air-ata-36)
+    - [Integrated Modular Avionics ATA 42](#integrated-modular-avionics-ata-42)
+    - [Auxiliary Power Unit ATA 49](#auxiliary-power-unit-ata-49)
+    - [Engines ATA 70](#engines-ata-70)
+    - [Hydraulics](#hydraulics)
+    - [Sound Variables](#sound-variables)
+    - [Autobrakes](#autobrakes)
+    - [Non-Systems Related](#non-systems-related)
 
 ## Uncategorized
 
@@ -29,7 +29,7 @@
     - Enum
     - Represents the state of the ANN LT switch
     - | State | Value |
-      |-------|-------|
+                  |-------|-------|
       | TEST  | 0     |
       | BRT   | 1     |
       | DIM   | 2     |
@@ -136,7 +136,7 @@
     - Will be reset to 0 after loading is done
     - When set to 0 during loading will stop and cancel the loading process
     - | Value | Meaning            |
-            |-------|--------------------|
+                        |-------|--------------------|
       | 1     | Cold & Dark        |
       | 2     | Powered            |
       | 3     | Ready for Pushback |
@@ -170,7 +170,6 @@
     - Turn factor for pushback
     - -1.0 is full left, 0.0 is straight, 1.0 is full right
 
-
 ## Air Conditioning Pressurisation Ventilation ATA 21
 
 - A32NX_COND_CPIOM_B{id}_AGS_DISCRETE_WORD
@@ -178,7 +177,7 @@
     - Discrete Data word of the AGS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-      |:---:|:----------------------------------------------------:|
+                  |:---:|:----------------------------------------------------:|
       | 11  | AGS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | Pack 1 operating                                     |
@@ -189,7 +188,7 @@
     - Discrete Data word of the TCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-      |:---:|:----------------------------------------------------:|
+                  |:---:|:----------------------------------------------------:|
       | 11  | TCS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | Hot Air 1 position disagrees                         |
@@ -202,7 +201,7 @@
     - Discrete Data word of the VCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-      |:---:|:----------------------------------------------------:|
+                  |:---:|:----------------------------------------------------:|
       | 11  | VCS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | FWD Extraction fan is on                             |
@@ -223,7 +222,7 @@
     - Discrete Data word of the CPCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-      |:---:|:----------------------------------------------------:|
+                  |:---:|:----------------------------------------------------:|
       | 11  | CPCS Application INOP                                |
       | 12  | Unused                                               |
       | 13  | Excessive cabin altitude - warn                      |
@@ -385,7 +384,7 @@
 - A32NX_OVHD_COND_RAM_AIR_PB_IS_ON
     - Bool
     - True if the ram air pushbutton is pressed in the on position
-  (on light iluminates)
+      (on light iluminates)
 
 - A32NX_OVHD_CARGO_AIR_{id}_SELECTOR_KNOB
     - Number (0 to 300)
@@ -505,44 +504,44 @@
     - Bool
     - True when the given bus is powered
     - {name}
-      - AC_1
-      - AC_2
-      - AC_3
-      - AC_4
-      - AC_ESS
-      - AC_ESS_SCHED
-      - AC_247XP
-      - DC_1
-      - DC_2
-      - DC_ESS
-      - DC_247PP
-      - DC_HOT_1
-      - DC_HOT_2
-      - DC_HOT_3
-      - DC_HOT_4
-      - DC_GND_FLT_SVC
+        - AC_1
+        - AC_2
+        - AC_3
+        - AC_4
+        - AC_ESS
+        - AC_ESS_SCHED
+        - AC_247XP
+        - DC_1
+        - DC_2
+        - DC_ESS
+        - DC_247PP
+        - DC_HOT_1
+        - DC_HOT_2
+        - DC_HOT_3
+        - DC_HOT_4
+        - DC_GND_FLT_SVC
 
 - A32NX_ELEC_{name}_POTENTIAL
     - Volts
     - The electric potential of the given element
     - {name}
-      - APU_GEN_1
-      - APU_GEN_2
-      - ENG_GEN_1
-      - ENG_GEN_2
-      - ENG_GEN_3
-      - ENG_GEN_4
-      - EXT_PWR
-      - STAT_INV
-      - EMER_GEN
-      - TR_1
-      - TR_2
-      - TR_3: TR ESS
-      - TR_4: TR APU
-      - BAT_1
-      - BAT_2
-      - BAT_3: BAT ESS
-      - BAT_4: BAT APU
+        - APU_GEN_1
+        - APU_GEN_2
+        - ENG_GEN_1
+        - ENG_GEN_2
+        - ENG_GEN_3
+        - ENG_GEN_4
+        - EXT_PWR
+        - STAT_INV
+        - EMER_GEN
+        - TR_1
+        - TR_2
+        - TR_3: TR ESS
+        - TR_4: TR APU
+        - BAT_1
+        - BAT_2
+        - BAT_3: BAT ESS
+        - BAT_4: BAT APU
 
 - A32NX_ELEC_{name}_POTENTIAL_NORMAL
     - Bool
@@ -666,7 +665,7 @@
     - Arinc429<Discrete>
     - Discrete Data word of the Fire Detection Unit (assumed)
     - | Bit |                      Description                     |
-      |:---:|:----------------------------------------------------:|
+                  |:---:|:----------------------------------------------------:|
       | 11  | Fire detected ENG 1                                  |
       | 12  | Fire detected ENG 2                                  |
       | 13  | Fire detected ENG 3                                  |
@@ -767,7 +766,6 @@
     - Bool
     - True when the overhead fire test pushbutton is pressed
 
-
 ## Flaps / Slats (ATA 27)
 
 - A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD
@@ -775,7 +773,7 @@
     - Arinc429<Discrete>
     - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - | Bit |      Description A380X, if different     |
-      |:---:|:----------------------------------------:|
+                  |:---:|:----------------------------------------:|
       | 11  | Slat Data Valid                          |
       | 12  | Slats Retracted 0° (6.2° > FPPU > -5°)   |
       | 13  | Slats >= 19° (337° > FPPU > 234.7°)      |
@@ -797,71 +795,71 @@
       | 29  | Flap System Jam                          |
 
 - A32NX_FLAPS_CONF_INDEX
-  - Number
-  - Indicates the desired flap configuration index according to the table
-  - Value | Meaning
-            --- | ---
-      0 | Conf0
-      1 | Conf1
-      2 | Conf1F
-      3 | Conf2
-      4 | Conf2S
-      5 | Conf3
-      6 | Conf4
+    - Number
+    - Indicates the desired flap configuration index according to the table
+    - Value | Meaning
+                        --- | ---
+        0 | Conf0
+        1 | Conf1
+        2 | Conf1F
+        3 | Conf2
+        4 | Conf2S
+        5 | Conf3
+        6 | Conf4
 
 ## Indicating-Recording ATA 31
 
 - A32NX_CDS_CAN_BUS_1_1_AVAIL
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the captain's side is available
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the captain's side is available
 
 - A32NX_CDS_CAN_BUS_1_2_AVAIL
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the captain's side is available
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the captain's side is available
 
 - A32NX_CDS_CAN_BUS_2_1_AVAIL
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the first officer's side is available
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the first officer's side is available
 
 - A32NX_CDS_CAN_BUS_2_2_AVAIL
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the first officer's side is available
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the first officer's side is available
 
 - A32NX_CDS_CAN_BUS_1_1_FAILURE
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_1_2_FAILURE
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_2_1_FAILURE
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_2_2_FAILURE
-  - Bool
-  - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
+    - Bool
+    - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_1_1_<FUNCTION_ID>_RECEIVED
-  - Bool
-  - Indicates if the system per function ID in the CDS bus received the last sent message
+    - Bool
+    - Indicates if the system per function ID in the CDS bus received the last sent message
 
 - A32NX_CDS_CAN_BUS_1_1
-  - ArincWord852<>
-  - First CAN bus of the CDS on the captain's side
+    - ArincWord852<>
+    - First CAN bus of the CDS on the captain's side
 
 - A32NX_CDS_CAN_BUS_1_2
-  - ArincWord852<>
-  - Second CAN bus of the CDS on the captain's side
+    - ArincWord852<>
+    - Second CAN bus of the CDS on the captain's side
 
 - A32NX_CDS_CAN_BUS_2_1
-  - ArincWord852<>
-  - First CAN bus of the CDS on the first officer's side
+    - ArincWord852<>
+    - First CAN bus of the CDS on the first officer's side
 
 - A32NX_CDS_CAN_BUS_2_2
-  - ArincWord852<>
-  - Second CAN bus of the CDS on the first officer's side
+    - ArincWord852<>
+    - Second CAN bus of the CDS on the first officer's side
 
 ## ECAM Control Panel ATA 31
 
@@ -869,20 +867,20 @@
     - Enum
     - Currently requested page on the ECAM CP
     - | State | Value |
-      |-------|-------|
+            |-------|-------|
       | ENG   | 0     |
-      | BLEED | 1     |
-      | PRESS | 2     |
-      | EL/AC | 3     |
-      | FUEL  | 4     |
-      | HYD   | 5     |
-      | C/B   | 6     |
-      | APU   | 7     |
-      | COND  | 8     |
-      | DOOR  | 9     |
-      | EL/DC | 10    |
-      | WHEEL | 11    |
-      | F/CTL | 12    |
+      | APU   | 1     |
+      | BLEED | 2     |
+      | COND  | 3     |
+      | PRESS | 4     |
+      | DOOR  | 5     |
+      | EL/AC | 6     |
+      | EL/DC | 7     |
+      | FUEL  | 8     |
+      | WHEEL | 9     |
+      | HYD   | 10    |
+      | F/CTL | 11    |
+      | C/B   | 12    |
       | VIDEO | 13    |
 
 ## EFIS Control Panel ATA 31
@@ -907,7 +905,7 @@
     - Indicates which waypoint filter is selected
     - {side} = L or R
     - | State | Value |
-      |-------|-------|
+                  |-------|-------|
       | WPT   | 1     |
       | VORD  | 2     |
       | NDB   | 3     |
@@ -917,7 +915,7 @@
     - Indicates which waypoint filter is selected
     - {side} = L or R
     - | State | Value |
-      |-------|-------|
+                  |-------|-------|
       | WX    | 0     |
       | TERR  | 1     |
 
@@ -939,53 +937,55 @@
 ## Bleed Air ATA 36
 
 - A32NX_PNEU_ENG_{number}_INTERMEDIATE_TRANSDUCER_PRESSURE
-  - Psi
-  - Pressure measured at the intermediate pressure transducer at engine {number}, -1 if no output
+    - Psi
+    - Pressure measured at the intermediate pressure transducer at engine {number}, -1 if no output
 
 ## Integrated Modular Avionics ATA 42
 
 -A32NX_AFDX_<SOURCE_ID>_<DESTINATION_ID>_REACHABLE
-  - Bool
-  - Indicates if the AFDX switch with the source id can reach the switch with the destination id
+
+- Bool
+- Indicates if the AFDX switch with the source id can reach the switch with the destination id
 
 - A32NX_AFDX_SWITCH_<ID>_FAILURE
-  - Bool
-  - Indicates if a specific AFDX switch is in a failure mode
+    - Bool
+    - Indicates if a specific AFDX switch is in a failure mode
 
 - A32NX_AFDX_SWITCH_<ID>_AVAIL
-  - Bool
-  - Indicates if a specific AFDX switch is available
+    - Bool
+    - Indicates if a specific AFDX switch is available
 
 - A32NX_CPIOM_<NAME>_FAILURE
-  - Bool
-  - Indicates if a specific CPIOM system is in a failure mode
+    - Bool
+    - Indicates if a specific CPIOM system is in a failure mode
 
 - A32NX_CPIOM_<NAME>_AVAIL
-  - Bool
-  - Indicates if a specific CPIOM system is available
+    - Bool
+    - Indicates if a specific CPIOM system is available
 
 - A32NX_IOM_<NAME>_FAILURE
-  - Bool
-  - Indicates if a specific IOM system is in a failure mode
+    - Bool
+    - Indicates if a specific IOM system is in a failure mode
 
 - A32NX_IOM_<NAME>_AVAIL
-  - Bool
-  - Indicates if a specific IOM system is available
+    - Bool
+    - Indicates if a specific IOM system is available
 
 ## Auxiliary Power Unit ATA 49
 
 - A32NX_APU_N2
-  - `Arinc429Word<Percent>`
-  - The APU's N2 rotations per minute in percentage of the maximum RPM
+    - `Arinc429Word<Percent>`
+    - The APU's N2 rotations per minute in percentage of the maximum RPM
 
 - A32NX_APU_FUEL_USED
-  - `Arinc429Word<Mass>`
-  - The APU fuel used, in kilograms
+    - `Arinc429Word<Mass>`
+    - The APU fuel used, in kilograms
 
 ## Engines ATA 70
-  - L:A32NX_OVHD_FADEC_{ENG}
-  - The powered status of the associated engine's FADEC dependant on the button on the OVHD
-  - {ENG} = 1, 2, 3, 4
+
+- L:A32NX_OVHD_FADEC_{ENG}
+- The powered status of the associated engine's FADEC dependant on the button on the OVHD
+- {ENG} = 1, 2, 3, 4
 
 ## Hydraulics
 
@@ -1016,7 +1016,7 @@
     - Number
     - Indicates position of the autobrake selection knob
     -   | State  | Number |
-        |--------|--------|
+                        |--------|--------|
         | DISARM | 0      |
         | BTV    | 1      |
         | LOW    | 2      |
@@ -1028,7 +1028,7 @@
     - Number
     - Indicates actual armed mode of autobrake system
     -   | State  | Number |
-        |--------|--------|
+                        |--------|--------|
         | DISARM | 0      |
         | BTV    | 1      |
         | LOW    | 2      |
@@ -1048,9 +1048,9 @@
 ## Non-Systems Related
 
 - `L:FBW_PILOT_SEAT`
-  - Enum
-  - Which seat the user/pilot occupies in the flight deck.
-  - | Value | Description |
-    |-------|-------------|
-    | 0     | Left Seat   |
-    | 1     | Right Seat  |
+    - Enum
+    - Which seat the user/pilot occupies in the flight deck.
+    - | Value | Description |
+                |-------|-------------|
+      | 0     | Left Seat   |
+      | 1     | Right Seat  |

--- a/fbw-a380x/docs/a380-simvars.md
+++ b/fbw-a380x/docs/a380-simvars.md
@@ -29,7 +29,7 @@
     - Enum
     - Represents the state of the ANN LT switch
     - | State | Value |
-                  |-------|-------|
+                                                      |-------|-------|
       | TEST  | 0     |
       | BRT   | 1     |
       | DIM   | 2     |
@@ -136,7 +136,7 @@
     - Will be reset to 0 after loading is done
     - When set to 0 during loading will stop and cancel the loading process
     - | Value | Meaning            |
-                        |-------|--------------------|
+                                                            |-------|--------------------|
       | 1     | Cold & Dark        |
       | 2     | Powered            |
       | 3     | Ready for Pushback |
@@ -177,7 +177,7 @@
     - Discrete Data word of the AGS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-                  |:---:|:----------------------------------------------------:|
+                                                      |:---:|:----------------------------------------------------:|
       | 11  | AGS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | Pack 1 operating                                     |
@@ -188,7 +188,7 @@
     - Discrete Data word of the TCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-                  |:---:|:----------------------------------------------------:|
+                                                      |:---:|:----------------------------------------------------:|
       | 11  | TCS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | Hot Air 1 position disagrees                         |
@@ -201,7 +201,7 @@
     - Discrete Data word of the VCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-                  |:---:|:----------------------------------------------------:|
+                                                      |:---:|:----------------------------------------------------:|
       | 11  | VCS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | FWD Extraction fan is on                             |
@@ -222,7 +222,7 @@
     - Discrete Data word of the CPCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-                  |:---:|:----------------------------------------------------:|
+                                                      |:---:|:----------------------------------------------------:|
       | 11  | CPCS Application INOP                                |
       | 12  | Unused                                               |
       | 13  | Excessive cabin altitude - warn                      |
@@ -665,7 +665,7 @@
     - Arinc429<Discrete>
     - Discrete Data word of the Fire Detection Unit (assumed)
     - | Bit |                      Description                     |
-                  |:---:|:----------------------------------------------------:|
+                                                      |:---:|:----------------------------------------------------:|
       | 11  | Fire detected ENG 1                                  |
       | 12  | Fire detected ENG 2                                  |
       | 13  | Fire detected ENG 3                                  |
@@ -773,7 +773,7 @@
     - Arinc429<Discrete>
     - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - | Bit |      Description A380X, if different     |
-                  |:---:|:----------------------------------------:|
+                                                      |:---:|:----------------------------------------:|
       | 11  | Slat Data Valid                          |
       | 12  | Slats Retracted 0° (6.2° > FPPU > -5°)   |
       | 13  | Slats >= 19° (337° > FPPU > 234.7°)      |
@@ -798,7 +798,7 @@
     - Number
     - Indicates the desired flap configuration index according to the table
     - Value | Meaning
-                        --- | ---
+                                                            --- | ---
         0 | Conf0
         1 | Conf1
         2 | Conf1F
@@ -863,11 +863,30 @@
 
 ## ECAM Control Panel ATA 31
 
+- A32NX_BTN_{button_name}
+    - Number
+    - Button state of the ECAM CP buttons
+        - 0: Not pressed, 1: Pressed
+    - {button_name}
+        - ALL
+        - ABNPROC
+        - CHECK_LH
+        - CHECK_RH
+        - CL
+        - CLR
+        - CLR2
+        - DOWN
+        - EMERCANC
+        - MORE
+        - RCL
+        - TOCONFIG
+        - UP
+
 - A380X_ECAM_CP_SELECTED_PAGE
     - Enum
-    - Currently requested page on the ECAM CP
+- Currently requested page on the ECAM CP
     - | State | Value |
-            |-------|-------|
+                  |-------|-------|
       | ENG   | 0     |
       | APU   | 1     |
       | BLEED | 2     |
@@ -881,7 +900,9 @@
       | HYD   | 10    |
       | F/CTL | 11    |
       | C/B   | 12    |
-      | VIDEO | 13    |
+      | CRZ   | 13    |    
+      | STS   | 14    |
+      | VIDEO | 15    |
 
 ## EFIS Control Panel ATA 31
 
@@ -905,7 +926,7 @@
     - Indicates which waypoint filter is selected
     - {side} = L or R
     - | State | Value |
-                  |-------|-------|
+                                                      |-------|-------|
       | WPT   | 1     |
       | VORD  | 2     |
       | NDB   | 3     |
@@ -915,7 +936,7 @@
     - Indicates which waypoint filter is selected
     - {side} = L or R
     - | State | Value |
-                  |-------|-------|
+                                                      |-------|-------|
       | WX    | 0     |
       | TERR  | 1     |
 
@@ -1016,7 +1037,7 @@
     - Number
     - Indicates position of the autobrake selection knob
     -   | State  | Number |
-                        |--------|--------|
+                                                                        |--------|--------|
         | DISARM | 0      |
         | BTV    | 1      |
         | LOW    | 2      |
@@ -1028,7 +1049,7 @@
     - Number
     - Indicates actual armed mode of autobrake system
     -   | State  | Number |
-                        |--------|--------|
+                                                                        |--------|--------|
         | DISARM | 0      |
         | BTV    | 1      |
         | LOW    | 2      |
@@ -1051,6 +1072,6 @@
     - Enum
     - Which seat the user/pilot occupies in the flight deck.
     - | Value | Description |
-                |-------|-------------|
+                                                    |-------|-------------|
       | 0     | Left Seat   |
       | 1     | Right Seat  |

--- a/fbw-a380x/docs/a380-simvars.md
+++ b/fbw-a380x/docs/a380-simvars.md
@@ -3,25 +3,25 @@
 ## Contents
 
 - [A380 Local SimVars](#a380-local-simvars)
-    - [Contents](#contents)
-    - [Uncategorized](#uncategorized)
-    - [Air Conditioning Pressurisation Ventilation ATA 21](#air-conditioning-pressurisation-ventilation-ata-21)
-    - [Auto Flight System ATA 22](#auto-flight-system-ata-22)
-    - [Flight Management System ATA 22](#flight-management-system-ata-22)
-    - [Electrical ATA 24](#electrical-ata-24)
-    - [Fire and Smoke Protection ATA 26](#fire-and-smoke-protection-ata-26)
-    - [Flaps / Slats (ATA 27)](#flaps--slats-ata-27)
-    - [Indicating-Recording ATA 31](#indicating-recording-ata-31)
-    - [ECAM Control Panel ATA 31](#ecam-control-panel-ata-31)
-    - [EFIS Control Panel ATA 31](#efis-control-panel-ata-31)
-    - [Bleed Air ATA 36](#bleed-air-ata-36)
-    - [Integrated Modular Avionics ATA 42](#integrated-modular-avionics-ata-42)
-    - [Auxiliary Power Unit ATA 49](#auxiliary-power-unit-ata-49)
-    - [Engines ATA 70](#engines-ata-70)
-    - [Hydraulics](#hydraulics)
-    - [Sound Variables](#sound-variables)
-    - [Autobrakes](#autobrakes)
-    - [Non-Systems Related](#non-systems-related)
+  - [Contents](#contents)
+  - [Uncategorized](#uncategorized)
+  - [Air Conditioning Pressurisation Ventilation ATA 21](#air-conditioning-pressurisation-ventilation-ata-21)
+  - [Auto Flight System ATA 22](#auto-flight-system-ata-22)
+  - [Flight Management System ATA 22](#flight-management-system-ata-22)
+  - [Electrical ATA 24](#electrical-ata-24)
+  - [Fire and Smoke Protection ATA 26](#fire-and-smoke-protection-ata-26)
+  - [Flaps / Slats (ATA 27)](#flaps--slats-ata-27)
+  - [Indicating-Recording ATA 31](#indicating-recording-ata-31)
+  - [ECAM Control Panel ATA 31](#ecam-control-panel-ata-31)
+  - [EFIS Control Panel ATA 31](#efis-control-panel-ata-31)
+  - [Bleed Air ATA 36](#bleed-air-ata-36)
+  - [Integrated Modular Avionics ATA 42](#integrated-modular-avionics-ata-42)
+  - [Auxiliary Power Unit ATA 49](#auxiliary-power-unit-ata-49)
+  - [Engines ATA 70](#engines-ata-70)
+  - [Hydraulics](#hydraulics)
+  - [Sound Variables](#sound-variables)
+  - [Autobrakes](#autobrakes)
+  - [Non-Systems Related](#non-systems-related)
 
 ## Uncategorized
 
@@ -29,7 +29,7 @@
     - Enum
     - Represents the state of the ANN LT switch
     - | State | Value |
-            |-------|-------|
+      |-------|-------|
       | TEST  | 0     |
       | BRT   | 1     |
       | DIM   | 2     |
@@ -136,7 +136,7 @@
     - Will be reset to 0 after loading is done
     - When set to 0 during loading will stop and cancel the loading process
     - | Value | Meaning            |
-                  |-------|--------------------|
+            |-------|--------------------|
       | 1     | Cold & Dark        |
       | 2     | Powered            |
       | 3     | Ready for Pushback |
@@ -170,6 +170,7 @@
     - Turn factor for pushback
     - -1.0 is full left, 0.0 is straight, 1.0 is full right
 
+
 ## Air Conditioning Pressurisation Ventilation ATA 21
 
 - A32NX_COND_CPIOM_B{id}_AGS_DISCRETE_WORD
@@ -177,7 +178,7 @@
     - Discrete Data word of the AGS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-            |:---:|:----------------------------------------------------:|
+      |:---:|:----------------------------------------------------:|
       | 11  | AGS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | Pack 1 operating                                     |
@@ -188,7 +189,7 @@
     - Discrete Data word of the TCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-            |:---:|:----------------------------------------------------:|
+      |:---:|:----------------------------------------------------:|
       | 11  | TCS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | Hot Air 1 position disagrees                         |
@@ -201,7 +202,7 @@
     - Discrete Data word of the VCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-            |:---:|:----------------------------------------------------:|
+      |:---:|:----------------------------------------------------:|
       | 11  | VCS Application INOP                                 |
       | 12  | Unused                                               |
       | 13  | FWD Extraction fan is on                             |
@@ -222,7 +223,7 @@
     - Discrete Data word of the CPCS Application in the CPIOM B (assumed)
     - {id} 1, 2, 3 or 4
     - | Bit |                      Description                     |
-            |:---:|:----------------------------------------------------:|
+      |:---:|:----------------------------------------------------:|
       | 11  | CPCS Application INOP                                |
       | 12  | Unused                                               |
       | 13  | Excessive cabin altitude - warn                      |
@@ -384,7 +385,7 @@
 - A32NX_OVHD_COND_RAM_AIR_PB_IS_ON
     - Bool
     - True if the ram air pushbutton is pressed in the on position
-      (on light iluminates)
+  (on light iluminates)
 
 - A32NX_OVHD_CARGO_AIR_{id}_SELECTOR_KNOB
     - Number (0 to 300)
@@ -504,44 +505,44 @@
     - Bool
     - True when the given bus is powered
     - {name}
-        - AC_1
-        - AC_2
-        - AC_3
-        - AC_4
-        - AC_ESS
-        - AC_ESS_SCHED
-        - AC_247XP
-        - DC_1
-        - DC_2
-        - DC_ESS
-        - DC_247PP
-        - DC_HOT_1
-        - DC_HOT_2
-        - DC_HOT_3
-        - DC_HOT_4
-        - DC_GND_FLT_SVC
+      - AC_1
+      - AC_2
+      - AC_3
+      - AC_4
+      - AC_ESS
+      - AC_ESS_SCHED
+      - AC_247XP
+      - DC_1
+      - DC_2
+      - DC_ESS
+      - DC_247PP
+      - DC_HOT_1
+      - DC_HOT_2
+      - DC_HOT_3
+      - DC_HOT_4
+      - DC_GND_FLT_SVC
 
 - A32NX_ELEC_{name}_POTENTIAL
     - Volts
     - The electric potential of the given element
     - {name}
-        - APU_GEN_1
-        - APU_GEN_2
-        - ENG_GEN_1
-        - ENG_GEN_2
-        - ENG_GEN_3
-        - ENG_GEN_4
-        - EXT_PWR
-        - STAT_INV
-        - EMER_GEN
-        - TR_1
-        - TR_2
-        - TR_3: TR ESS
-        - TR_4: TR APU
-        - BAT_1
-        - BAT_2
-        - BAT_3: BAT ESS
-        - BAT_4: BAT APU
+      - APU_GEN_1
+      - APU_GEN_2
+      - ENG_GEN_1
+      - ENG_GEN_2
+      - ENG_GEN_3
+      - ENG_GEN_4
+      - EXT_PWR
+      - STAT_INV
+      - EMER_GEN
+      - TR_1
+      - TR_2
+      - TR_3: TR ESS
+      - TR_4: TR APU
+      - BAT_1
+      - BAT_2
+      - BAT_3: BAT ESS
+      - BAT_4: BAT APU
 
 - A32NX_ELEC_{name}_POTENTIAL_NORMAL
     - Bool
@@ -665,7 +666,7 @@
     - Arinc429<Discrete>
     - Discrete Data word of the Fire Detection Unit (assumed)
     - | Bit |                      Description                     |
-            |:---:|:----------------------------------------------------:|
+      |:---:|:----------------------------------------------------:|
       | 11  | Fire detected ENG 1                                  |
       | 12  | Fire detected ENG 2                                  |
       | 13  | Fire detected ENG 3                                  |
@@ -766,6 +767,7 @@
     - Bool
     - True when the overhead fire test pushbutton is pressed
 
+
 ## Flaps / Slats (ATA 27)
 
 - A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD
@@ -773,7 +775,7 @@
     - Arinc429<Discrete>
     - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - | Bit |      Description A380X, if different     |
-            |:---:|:----------------------------------------:|
+      |:---:|:----------------------------------------:|
       | 11  | Slat Data Valid                          |
       | 12  | Slats Retracted 0° (6.2° > FPPU > -5°)   |
       | 13  | Slats >= 19° (337° > FPPU > 234.7°)      |
@@ -795,71 +797,71 @@
       | 29  | Flap System Jam                          |
 
 - A32NX_FLAPS_CONF_INDEX
-    - Number
-    - Indicates the desired flap configuration index according to the table
-    - Value | Meaning
-                  --- | ---
-        0 | Conf0
-        1 | Conf1
-        2 | Conf1F
-        3 | Conf2
-        4 | Conf2S
-        5 | Conf3
-        6 | Conf4
+  - Number
+  - Indicates the desired flap configuration index according to the table
+  - Value | Meaning
+            --- | ---
+      0 | Conf0
+      1 | Conf1
+      2 | Conf1F
+      3 | Conf2
+      4 | Conf2S
+      5 | Conf3
+      6 | Conf4
 
 ## Indicating-Recording ATA 31
 
 - A32NX_CDS_CAN_BUS_1_1_AVAIL
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the captain's side is available
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the captain's side is available
 
 - A32NX_CDS_CAN_BUS_1_2_AVAIL
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the captain's side is available
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the captain's side is available
 
 - A32NX_CDS_CAN_BUS_2_1_AVAIL
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the first officer's side is available
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the first officer's side is available
 
 - A32NX_CDS_CAN_BUS_2_2_AVAIL
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the first officer's side is available
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the first officer's side is available
 
 - A32NX_CDS_CAN_BUS_1_1_FAILURE
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_1_2_FAILURE
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the captain's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_2_1_FAILURE
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_2_2_FAILURE
-    - Bool
-    - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
+  - Bool
+  - Indicates if the first CAN bus of the CDS on the first officer's side simulates a failure
 
 - A32NX_CDS_CAN_BUS_1_1_<FUNCTION_ID>_RECEIVED
-    - Bool
-    - Indicates if the system per function ID in the CDS bus received the last sent message
+  - Bool
+  - Indicates if the system per function ID in the CDS bus received the last sent message
 
 - A32NX_CDS_CAN_BUS_1_1
-    - ArincWord852<>
-    - First CAN bus of the CDS on the captain's side
+  - ArincWord852<>
+  - First CAN bus of the CDS on the captain's side
 
 - A32NX_CDS_CAN_BUS_1_2
-    - ArincWord852<>
-    - Second CAN bus of the CDS on the captain's side
+  - ArincWord852<>
+  - Second CAN bus of the CDS on the captain's side
 
 - A32NX_CDS_CAN_BUS_2_1
-    - ArincWord852<>
-    - First CAN bus of the CDS on the first officer's side
+  - ArincWord852<>
+  - First CAN bus of the CDS on the first officer's side
 
 - A32NX_CDS_CAN_BUS_2_2
-    - ArincWord852<>
-    - Second CAN bus of the CDS on the first officer's side
+  - ArincWord852<>
+  - Second CAN bus of the CDS on the first officer's side
 
 ## ECAM Control Panel ATA 31
 
@@ -886,7 +888,7 @@
     - Enum
 - Currently requested page on the ECAM CP
     - | State | Value |
-            |-------|-------|
+      |-------|-------|
       | ENG   | 0     |
       | APU   | 1     |
       | BLEED | 2     |
@@ -903,6 +905,7 @@
       | CRZ   | 13    |
       | STS   | 14    |
       | VIDEO | 15    |
+
 
 ## EFIS Control Panel ATA 31
 
@@ -926,7 +929,7 @@
     - Indicates which waypoint filter is selected
     - {side} = L or R
     - | State | Value |
-            |-------|-------|
+      |-------|-------|
       | WPT   | 1     |
       | VORD  | 2     |
       | NDB   | 3     |
@@ -936,7 +939,7 @@
     - Indicates which waypoint filter is selected
     - {side} = L or R
     - | State | Value |
-            |-------|-------|
+      |-------|-------|
       | WX    | 0     |
       | TERR  | 1     |
 
@@ -958,55 +961,53 @@
 ## Bleed Air ATA 36
 
 - A32NX_PNEU_ENG_{number}_INTERMEDIATE_TRANSDUCER_PRESSURE
-    - Psi
-    - Pressure measured at the intermediate pressure transducer at engine {number}, -1 if no output
+  - Psi
+  - Pressure measured at the intermediate pressure transducer at engine {number}, -1 if no output
 
 ## Integrated Modular Avionics ATA 42
 
 -A32NX_AFDX_<SOURCE_ID>_<DESTINATION_ID>_REACHABLE
-
-- Bool
-- Indicates if the AFDX switch with the source id can reach the switch with the destination id
+  - Bool
+  - Indicates if the AFDX switch with the source id can reach the switch with the destination id
 
 - A32NX_AFDX_SWITCH_<ID>_FAILURE
-    - Bool
-    - Indicates if a specific AFDX switch is in a failure mode
+  - Bool
+  - Indicates if a specific AFDX switch is in a failure mode
 
 - A32NX_AFDX_SWITCH_<ID>_AVAIL
-    - Bool
-    - Indicates if a specific AFDX switch is available
+  - Bool
+  - Indicates if a specific AFDX switch is available
 
 - A32NX_CPIOM_<NAME>_FAILURE
-    - Bool
-    - Indicates if a specific CPIOM system is in a failure mode
+  - Bool
+  - Indicates if a specific CPIOM system is in a failure mode
 
 - A32NX_CPIOM_<NAME>_AVAIL
-    - Bool
-    - Indicates if a specific CPIOM system is available
+  - Bool
+  - Indicates if a specific CPIOM system is available
 
 - A32NX_IOM_<NAME>_FAILURE
-    - Bool
-    - Indicates if a specific IOM system is in a failure mode
+  - Bool
+  - Indicates if a specific IOM system is in a failure mode
 
 - A32NX_IOM_<NAME>_AVAIL
-    - Bool
-    - Indicates if a specific IOM system is available
+  - Bool
+  - Indicates if a specific IOM system is available
 
 ## Auxiliary Power Unit ATA 49
 
 - A32NX_APU_N2
-    - `Arinc429Word<Percent>`
-    - The APU's N2 rotations per minute in percentage of the maximum RPM
+  - `Arinc429Word<Percent>`
+  - The APU's N2 rotations per minute in percentage of the maximum RPM
 
 - A32NX_APU_FUEL_USED
-    - `Arinc429Word<Mass>`
-    - The APU fuel used, in kilograms
+  - `Arinc429Word<Mass>`
+  - The APU fuel used, in kilograms
 
 ## Engines ATA 70
-
-- L:A32NX_OVHD_FADEC_{ENG}
-- The powered status of the associated engine's FADEC dependant on the button on the OVHD
-- {ENG} = 1, 2, 3, 4
+  - L:A32NX_OVHD_FADEC_{ENG}
+  - The powered status of the associated engine's FADEC dependant on the button on the OVHD
+  - {ENG} = 1, 2, 3, 4
 
 ## Hydraulics
 
@@ -1037,7 +1038,7 @@
     - Number
     - Indicates position of the autobrake selection knob
     -   | State  | Number |
-                |--------|--------|
+        |--------|--------|
         | DISARM | 0      |
         | BTV    | 1      |
         | LOW    | 2      |
@@ -1049,7 +1050,7 @@
     - Number
     - Indicates actual armed mode of autobrake system
     -   | State  | Number |
-                |--------|--------|
+        |--------|--------|
         | DISARM | 0      |
         | BTV    | 1      |
         | LOW    | 2      |
@@ -1069,9 +1070,9 @@
 ## Non-Systems Related
 
 - `L:FBW_PILOT_SEAT`
-    - Enum
-    - Which seat the user/pilot occupies in the flight deck.
-    - | Value | Description |
-          |-------|-------------|
-      | 0     | Left Seat   |
-      | 1     | Right Seat  |
+  - Enum
+  - Which seat the user/pilot occupies in the flight deck.
+  - | Value | Description |
+    |-------|-------------|
+    | 0     | Left Seat   |
+    | 1     | Right Seat  |

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/ecam-cp.xml
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/ecam-cp.xml
@@ -445,6 +445,16 @@
             <SIMVAR>A32NX_BTN_MORE</SIMVAR>
         </UseTemplate>
 
+        <!-- ECAM ALL -->
+        <UseTemplate Name="FBW_Anim_Interactions">
+            <ANIM_TYPE>BUTTON_HELD</ANIM_TYPE>
+            <ANIM_TEMPLATE>FBW_ECAM_BUTTON_Template</ANIM_TEMPLATE>
+            <BASE_NAME>ALL</BASE_NAME>
+            <PART_ID>ECAM_ALL</PART_ID>
+            <TOOLTIPID>Cycle through ECAM pages</TOOLTIPID>
+            <SIMVAR>A32NX_BTN_ALL</SIMVAR>
+        </UseTemplate>
+
         <!-- EWD POTENTIOMETER -->
         <UseTemplate Name="FBW_Stepless_Potentiometer">
             <NODE_ID>KNOB_EFIS_EWD</NODE_ID> <!-- TODO TYPO REPSOL -->

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/ecam-cp.xml
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/ecam-cp.xml
@@ -40,9 +40,9 @@
             <ANIM_NAME>#NODE_ID#</ANIM_NAME>
             <LEFT_SINGLE_CODE>
                 (#STATE_SIMVAR#) #STATE_ID# != if{
-                #STATE_ID# (&gt;#STATE_SIMVAR#)
+                    #STATE_ID# (&gt;#STATE_SIMVAR#)
                 } els{
-                -1 (&gt;#STATE_SIMVAR#)
+                    -1 (&gt;#STATE_SIMVAR#)
                 }
                 (&gt;H:A32NX_SD_PAGE_CHANGED)
             </LEFT_SINGLE_CODE>

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/ecam-cp.xml
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/ecam-cp.xml
@@ -39,13 +39,13 @@
         <UseTemplate Name="ASOBO_GT_Push_Button_Airliner">
             <ANIM_NAME>#NODE_ID#</ANIM_NAME>
             <LEFT_SINGLE_CODE>
-                 (#STATE_SIMVAR#) #STATE_ID# != if{
-                    #STATE_ID# (&gt;#STATE_SIMVAR#)
+                (#STATE_SIMVAR#) #STATE_ID# != if{
+                #STATE_ID# (&gt;#STATE_SIMVAR#)
                 } els{
-                    -1 (&gt;#STATE_SIMVAR#)
+                -1 (&gt;#STATE_SIMVAR#)
                 }
                 (&gt;H:A32NX_SD_PAGE_CHANGED)
-                </LEFT_SINGLE_CODE>
+            </LEFT_SINGLE_CODE>
             <SEQ2_EMISSIVE_CODE>(#STATE_SIMVAR#) #STATE_ID# ==</SEQ2_EMISSIVE_CODE>
             <CURSOR>Hand</CURSOR>
         </UseTemplate>
@@ -139,9 +139,9 @@
         <Component ID="#LED_NODE_ID#" Node="#LED_NODE_ID#">
             <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
                 <EMISSIVE_CODE>
-                (L:A32NX_ECAM_SFAIL) -1 &gt;
-                (L:A32NX_OVHD_INTLT_ANN) 0 == (L:A32NX_ELEC_DC_ESS_BUS_IS_POWERED, Bool) and or
-                #SEQ1_POWERED# and
+                    (L:A32NX_ECAM_SFAIL) -1 &gt;
+                    (L:A32NX_OVHD_INTLT_ANN) 0 == (L:A32NX_ELEC_DC_ESS_BUS_IS_POWERED, Bool) and or
+                    #SEQ1_POWERED# and
                 </EMISSIVE_CODE>
             </UseTemplate>
         </Component>
@@ -279,76 +279,10 @@
             <TOOLTIPID>SELECT ENGINE PAGE ON SYSTEM DISPLAY</TOOLTIPID>
         </UseTemplate>
 
-        <!-- SD BLEED -->
-        <UseTemplate Name="FBW_Anim_Interactions">
-            <NODE_ID>PUSH_ECAM_BLEED</NODE_ID>
-            <STATE_ID>1</STATE_ID>
-
-            <ANIM_TYPE>BUTTON</ANIM_TYPE>
-            <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
-
-            <TOOLTIPID>SELECT BLEED PAGE ON SYSTEM DISPLAY</TOOLTIPID>
-        </UseTemplate>
-
-        <!-- SD PRESS -->
-        <UseTemplate Name="FBW_Anim_Interactions">
-            <NODE_ID>PUSH_ECAM_PRESS</NODE_ID>
-            <STATE_ID>2</STATE_ID>
-
-            <ANIM_TYPE>BUTTON</ANIM_TYPE>
-            <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
-
-            <TOOLTIPID>SELECT CAB PRESS PAGE ON SYSTEM DISPLAY</TOOLTIPID>
-        </UseTemplate>
-
-        <!-- SD EL/AC -->
-        <UseTemplate Name="FBW_Anim_Interactions">
-            <NODE_ID>PUSH_ECAM_ELAC</NODE_ID>
-            <STATE_ID>3</STATE_ID>
-
-            <ANIM_TYPE>BUTTON</ANIM_TYPE>
-            <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
-
-            <TOOLTIPID>SELECT ELEC AC PAGE ON SYSTEM DISPLAY</TOOLTIPID>
-        </UseTemplate>
-
-        <!-- SD FUEL -->
-        <UseTemplate Name="FBW_Anim_Interactions">
-            <NODE_ID>PUSH_ECAM_FUEL</NODE_ID>
-            <STATE_ID>4</STATE_ID>
-
-            <ANIM_TYPE>BUTTON</ANIM_TYPE>
-            <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
-
-            <TOOLTIPID>SELECT FUEL PAGE ON SYSTEM DISPLAY</TOOLTIPID>
-        </UseTemplate>
-
-        <!-- SD HYD -->
-        <UseTemplate Name="FBW_Anim_Interactions">
-            <NODE_ID>PUSH_ECAM_HYD</NODE_ID>
-            <STATE_ID>5</STATE_ID>
-
-            <ANIM_TYPE>BUTTON</ANIM_TYPE>
-            <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
-
-            <TOOLTIPID>SELECT HYD PAGE ON SYSTEM DISPLAY</TOOLTIPID>
-        </UseTemplate>
-
-        <!-- SD CB -->
-        <UseTemplate Name="FBW_Anim_Interactions">
-            <NODE_ID>PUSH_ECAM_CB</NODE_ID>
-            <STATE_ID>14</STATE_ID>
-
-            <ANIM_TYPE>BUTTON</ANIM_TYPE>
-            <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
-
-            <TOOLTIPID>SELECT CB PAGE ON SYSTEM DISPLAY</TOOLTIPID>
-        </UseTemplate>
-
         <!-- SD APU -->
         <UseTemplate Name="FBW_Anim_Interactions">
             <NODE_ID>PUSH_ECAM_APU</NODE_ID>
-            <STATE_ID>7</STATE_ID>
+            <STATE_ID>1</STATE_ID>
 
             <ANIM_TYPE>BUTTON</ANIM_TYPE>
             <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
@@ -356,10 +290,21 @@
             <TOOLTIPID>SELECT APU PAGE ON SYSTEM DISPLAY</TOOLTIPID>
         </UseTemplate>
 
+        <!-- SD BLEED -->
+        <UseTemplate Name="FBW_Anim_Interactions">
+            <NODE_ID>PUSH_ECAM_BLEED</NODE_ID>
+            <STATE_ID>2</STATE_ID>
+
+            <ANIM_TYPE>BUTTON</ANIM_TYPE>
+            <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
+
+            <TOOLTIPID>SELECT BLEED PAGE ON SYSTEM DISPLAY</TOOLTIPID>
+        </UseTemplate>
+
         <!-- SD COND -->
         <UseTemplate Name="FBW_Anim_Interactions">
             <NODE_ID>PUSH_ECAM_COND</NODE_ID>
-            <STATE_ID>8</STATE_ID>
+            <STATE_ID>3</STATE_ID>
 
             <ANIM_TYPE>BUTTON</ANIM_TYPE>
             <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
@@ -367,10 +312,21 @@
             <TOOLTIPID>SELECT COND PAGE ON SYSTEM DISPLAY</TOOLTIPID>
         </UseTemplate>
 
+        <!-- SD PRESS -->
+        <UseTemplate Name="FBW_Anim_Interactions">
+            <NODE_ID>PUSH_ECAM_PRESS</NODE_ID>
+            <STATE_ID>4</STATE_ID>
+
+            <ANIM_TYPE>BUTTON</ANIM_TYPE>
+            <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
+
+            <TOOLTIPID>SELECT CAB PRESS PAGE ON SYSTEM DISPLAY</TOOLTIPID>
+        </UseTemplate>
+
         <!-- SD DOOR -->
         <UseTemplate Name="FBW_Anim_Interactions">
             <NODE_ID>PUSH_ECAM_DOOR</NODE_ID>
-            <STATE_ID>9</STATE_ID>
+            <STATE_ID>5</STATE_ID>
 
             <ANIM_TYPE>BUTTON</ANIM_TYPE>
             <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
@@ -378,10 +334,21 @@
             <TOOLTIPID>SELECT DOOR - OXYGEN PAGE ON SYSTEM DISPLAY</TOOLTIPID>
         </UseTemplate>
 
+        <!-- SD EL/AC -->
+        <UseTemplate Name="FBW_Anim_Interactions">
+            <NODE_ID>PUSH_ECAM_ELAC</NODE_ID>
+            <STATE_ID>6</STATE_ID>
+
+            <ANIM_TYPE>BUTTON</ANIM_TYPE>
+            <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
+
+            <TOOLTIPID>SELECT ELEC AC PAGE ON SYSTEM DISPLAY</TOOLTIPID>
+        </UseTemplate>
+
         <!-- SD EL/DC -->
         <UseTemplate Name="FBW_Anim_Interactions">
             <NODE_ID>PUSH_ECAM_ELDC</NODE_ID>
-            <STATE_ID>10</STATE_ID>
+            <STATE_ID>7</STATE_ID>
 
             <ANIM_TYPE>BUTTON</ANIM_TYPE>
             <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
@@ -389,10 +356,21 @@
             <TOOLTIPID>SELECT ELEC EC PAGE ON SYSTEM DISPLAY</TOOLTIPID>
         </UseTemplate>
 
+        <!-- SD FUEL -->
+        <UseTemplate Name="FBW_Anim_Interactions">
+            <NODE_ID>PUSH_ECAM_FUEL</NODE_ID>
+            <STATE_ID>8</STATE_ID>
+
+            <ANIM_TYPE>BUTTON</ANIM_TYPE>
+            <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
+
+            <TOOLTIPID>SELECT FUEL PAGE ON SYSTEM DISPLAY</TOOLTIPID>
+        </UseTemplate>
+
         <!-- SD WHEEL -->
         <UseTemplate Name="FBW_Anim_Interactions">
             <NODE_ID>PUSH_ECAM_WHEEL</NODE_ID>
-            <STATE_ID>11</STATE_ID>
+            <STATE_ID>9</STATE_ID>
 
             <ANIM_TYPE>BUTTON</ANIM_TYPE>
             <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
@@ -400,10 +378,21 @@
             <TOOLTIPID>SELECT WHEEL PAGE ON SYSTEM DISPLAY</TOOLTIPID>
         </UseTemplate>
 
+        <!-- SD HYD -->
+        <UseTemplate Name="FBW_Anim_Interactions">
+            <NODE_ID>PUSH_ECAM_HYD</NODE_ID>
+            <STATE_ID>10</STATE_ID>
+
+            <ANIM_TYPE>BUTTON</ANIM_TYPE>
+            <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
+
+            <TOOLTIPID>SELECT HYD PAGE ON SYSTEM DISPLAY</TOOLTIPID>
+        </UseTemplate>
+
         <!-- SD F/CTL -->
         <UseTemplate Name="FBW_Anim_Interactions">
             <NODE_ID>PUSH_ECAM_FCTL</NODE_ID>
-            <STATE_ID>12</STATE_ID>
+            <STATE_ID>11</STATE_ID>
 
             <ANIM_TYPE>BUTTON</ANIM_TYPE>
             <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
@@ -411,26 +400,39 @@
             <TOOLTIPID>SELECT F/CTL PAGE ON SYSTEM DISPLAY</TOOLTIPID>
         </UseTemplate>
 
-        <!-- SD VIDEO -->
+        <!-- SD CB -->
         <UseTemplate Name="FBW_Anim_Interactions">
-            <NODE_ID>PUSH_ECAM_VIDEO</NODE_ID>
-            <STATE_ID>13</STATE_ID>
+            <NODE_ID>PUSH_ECAM_CB</NODE_ID>
+            <STATE_ID>12</STATE_ID>
 
             <ANIM_TYPE>BUTTON</ANIM_TYPE>
             <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
 
-            <TOOLTIPID>SELECT VIDEO PAGE ON SYSTEM DISPLAY</TOOLTIPID>
+            <TOOLTIPID>SELECT CB PAGE ON SYSTEM DISPLAY</TOOLTIPID>
         </UseTemplate>
+
+        <!-- SD CRUISE index 13 no button  -->
 
         <!-- SD STS -->
         <UseTemplate Name="FBW_Anim_Interactions">
             <NODE_ID>PUSH_ECAM_STS</NODE_ID>
-            <STATE_ID>15</STATE_ID>
+            <STATE_ID>14</STATE_ID>
 
             <ANIM_TYPE>BUTTON</ANIM_TYPE>
             <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
 
             <TOOLTIPID>SELECT STS PAGE ON SYSTEM DISPLAY</TOOLTIPID>
+        </UseTemplate>
+
+        <!-- SD VIDEO -->
+        <UseTemplate Name="FBW_Anim_Interactions">
+            <NODE_ID>PUSH_ECAM_VIDEO</NODE_ID>
+            <STATE_ID>15</STATE_ID>
+
+            <ANIM_TYPE>BUTTON</ANIM_TYPE>
+            <ANIM_TEMPLATE>FBW_A380X_ECAM_CP_Button_Template</ANIM_TEMPLATE>
+
+            <TOOLTIPID>SELECT VIDEO PAGE ON SYSTEM DISPLAY</TOOLTIPID>
         </UseTemplate>
 
         <!-- ECAM MORE -->

--- a/fbw-a380x/src/systems/instruments/src/SD/SystemDisplay.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/SystemDisplay.tsx
@@ -7,6 +7,7 @@ import { useSimVar } from '@instruments/common/simVars';
 import { DisplayUnitID, LegacyCdsDisplayUnit } from '@instruments/common/LegacyCdsDisplayUnit';
 
 // import { getSimVar } from '../util';
+import { SdPages } from '@shared/EcamSystemPages';
 import { EngPage } from './Pages/Engine/EngPage';
 import { BleedPage } from './Pages/Bleed/BleedPage';
 import { HydPage } from './Pages/Hyd/HydPage';
@@ -29,34 +30,6 @@ import { Mailbox } from './Mailbox';
 
 import '../index.scss';
 import { useArinc429Var, useUpdate } from '@flybywiresim/fbw-sdk';
-
-// Changing the order of the enum will break anything that relies on the numbers being the same
-// This includes:
-// - the external API: e.g. L:A32NX_ECAM_SD_CURRENT_PAGE_INDEX
-// - the flight warning system code here: fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsAbnormalSensed.ts
-// - the PAGES object below
-//
-// this could maybe be moved to a shared file
-
-enum SdPages {
-  None = -1,
-  Eng = 0,
-  Apu = 1,
-  Bleed = 2,
-  Cond = 3,
-  Press = 4,
-  Door = 5,
-  ElecAc = 6,
-  ElecDc = 7,
-  Fuel = 8,
-  Wheel = 9,
-  Hyd = 10,
-  Fctl = 11,
-  Cb = 12,
-  Crz = 13,
-  Status = 14,
-  Video = 15,
-}
 
 const CRZ_CONDITION_TIMER_DURATION = 60;
 const ENG_CONDITION_TIMER_DURATION = 10;
@@ -292,6 +265,7 @@ export const SystemDisplay = () => {
 
   useUpdate(updateCallback);
 
+  // make sure this is in line with the enum in EcamSystemPages.ts
   const PAGES = {
     0: <EngPage />,
     1: <ApuPage />,

--- a/fbw-a380x/src/systems/instruments/src/SD/SystemDisplay.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/SystemDisplay.tsx
@@ -147,19 +147,14 @@ export const SystemDisplay = () => {
     if (ecamAllButtonPushed && !prevEcamAllButtonState) {
       // button press
       setCurrentPage((prev) => {
-        console.log('Initial prev', prev);
         prev = page === SdPages.None ? SdPages.Eng : prev + 1;
-        console.log('After initial prev', prev);
         setEcamButtonLightDelayTimer(ECAM_LIGHT_DELAY_ALL);
         return prev % SdPages.Crz; // CRZ page should not be shown when pressing ALL button - return 0
       });
       setEcamCycleInterval(
         setInterval(() => {
           setCurrentPage((prev) => {
-            console.log('Before prev', prev);
             prev = Math.min(prev + 1, SdPages.Cb); // CRZ page should be last page so index should not exceed SdPages.Cb
-            console.log('After prev', prev);
-            console.log('');
             setEcamButtonLightDelayTimer(ECAM_LIGHT_DELAY_ALL);
             return prev;
           });

--- a/fbw-a380x/src/systems/instruments/src/SD/SystemDisplay.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/SystemDisplay.tsx
@@ -30,6 +30,14 @@ import { Mailbox } from './Mailbox';
 import '../index.scss';
 import { useArinc429Var, useUpdate } from '@flybywiresim/fbw-sdk';
 
+// Changing the order of the enum will break anything that relies on the numbers being the same
+// This includes:
+// - the external API: e.g. L:A32NX_ECAM_SD_CURRENT_PAGE_INDEX
+// - the flight warning system code here: fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsAbnormalSensed.ts
+// - the PAGES object below
+//
+// this could maybe be moved to a shared file
+
 enum SdPages {
   None = -1,
   Eng = 0,

--- a/fbw-a380x/src/systems/instruments/src/SD/SystemDisplay.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/SystemDisplay.tsx
@@ -68,7 +68,7 @@ export const SystemDisplay = () => {
 
   const [pageWhenUnselected, setPageWhenUnselected] = useState(SdPages.Door);
 
-  const [ecamAllButtonPushed] = useSimVar('L:A32NX_ECAM_ALL_Push_IsDown', 'Bool', 100);
+  const [ecamAllButtonPushed] = useSimVar('L:A32NX_BTN_ALL', 'Bool', 100);
   const [fwcFlightPhase] = useSimVar('L:A32NX_FWC_FLIGHT_PHASE', 'Enum', 500);
   const [crzCondTimer, setCrzCondTimer] = useState(CRZ_CONDITION_TIMER_DURATION);
   const [ecamFCTLTimer, setEcamFCTLTimer] = useState(FCTL_CONDITION_TIMER_DURATION);

--- a/fbw-a380x/src/systems/shared/src/EcamSystemPages.ts
+++ b/fbw-a380x/src/systems/shared/src/EcamSystemPages.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2023-2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
+// This file is used to define the enum for the SD pages to be shared between the different systems.
 // Changing the order of the enum will break anything that relies on the numbers being the same
 // This includes:
 // - the external API: e.g. L:A32NX_ECAM_SD_CURRENT_PAGE_INDEX

--- a/fbw-a380x/src/systems/shared/src/EcamSystemPages.ts
+++ b/fbw-a380x/src/systems/shared/src/EcamSystemPages.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2023-2024 FlyByWire Simulations
+// SPDX-License-Identifier: GPL-3.0
+
+// Changing the order of the enum will break anything that relies on the numbers being the same
+// This includes:
+// - the external API: e.g. L:A32NX_ECAM_SD_CURRENT_PAGE_INDEX
+// - the PAGES object at the end of fbw-a380x/src/systems/instruments/src/SD/SystemDisplay.tsx
+
+export enum SdPages {
+  None = -1,
+  Eng = 0,
+  Apu = 1,
+  Bleed = 2,
+  Cond = 3,
+  Press = 4,
+  Door = 5,
+  ElecAc = 6,
+  ElecDc = 7,
+  Fuel = 8,
+  Wheel = 9,
+  Hyd = 10,
+  Fctl = 11,
+  Cb = 12,
+  Crz = 13,
+  Status = 14,
+  Video = 15,
+}

--- a/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsAbnormalSensed.ts
+++ b/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsAbnormalSensed.ts
@@ -14,28 +14,9 @@ import {
   SubscribableMapEventType,
   SubscribableMapFunctions,
 } from '@microsoft/msfs-sdk';
+import { SdPages } from '@shared/EcamSystemPages';
 import { FwsEwdAbnormalSensedEntry, FwsEwdEvents } from 'instruments/src/MsfsAvionicsCommon/providers/FwsEwdPublisher';
 import { FwcAuralWarning, FwsCore } from 'systems-host/systems/FlightWarningSystem/FwsCore';
-
-enum SdPages {
-  None = -1,
-  Eng = 0,
-  Apu = 1,
-  Bleed = 2,
-  Cond = 3,
-  Press = 4,
-  Door = 5,
-  ElecAc = 6,
-  ElecDc = 7,
-  Fuel = 8,
-  Wheel = 9,
-  Hyd = 10,
-  Fctl = 11,
-  Cb = 12,
-  Crz = 13,
-  Status = 14,
-  Video = 15,
-}
 
 export interface EwdAbnormalItem {
   flightPhaseInhib: number[];

--- a/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsAbnormalSensed.ts
+++ b/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsAbnormalSensed.ts
@@ -6,7 +6,6 @@ import {
   AbnormalProcedure,
   EcamAbnormalSensedProcedures,
   isChecklistAction,
-  WD_NUM_LINES,
 } from '../../../instruments/src/MsfsAvionicsCommon/EcamMessages';
 import {
   MappedSubject,
@@ -17,6 +16,26 @@ import {
 } from '@microsoft/msfs-sdk';
 import { FwsEwdAbnormalSensedEntry, FwsEwdEvents } from 'instruments/src/MsfsAvionicsCommon/providers/FwsEwdPublisher';
 import { FwcAuralWarning, FwsCore } from 'systems-host/systems/FlightWarningSystem/FwsCore';
+
+enum SdPages {
+  None = -1,
+  Eng = 0,
+  Apu = 1,
+  Bleed = 2,
+  Cond = 3,
+  Press = 4,
+  Door = 5,
+  ElecAc = 6,
+  ElecDc = 7,
+  Fuel = 8,
+  Wheel = 9,
+  Hyd = 10,
+  Fctl = 11,
+  Cb = 12,
+  Crz = 13,
+  Status = 14,
+  Video = 15,
+}
 
 export interface EwdAbnormalItem {
   flightPhaseInhib: number[];
@@ -35,7 +54,7 @@ export interface EwdAbnormalItem {
   /** 3 = master warning, 2 = master caution */
   failure: number;
   /** Index of ECAM page to be displayed on SD */
-  sysPage: number;
+  sysPage: SdPages;
   /** Cancel flag for level 3 warning audio (only emergency cancel can cancel if false), defaults to true. */
   cancel?: boolean;
   /** Optional for now: Message IDs of INOP SYS to be displayed on STS page for ALL PHASES */
@@ -279,7 +298,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 1,
+      sysPage: SdPages.Bleed,
       redundLoss: () => ['210300001'],
     },
     211800002: {
@@ -290,7 +309,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 1,
+      sysPage: SdPages.Bleed,
       redundLoss: () => ['210300002'],
     },
     211800003: {
@@ -301,7 +320,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 1,
+      sysPage: SdPages.Bleed,
       redundLoss: () => ['210300003'],
     },
     211800004: {
@@ -312,7 +331,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 1,
+      sysPage: SdPages.Bleed,
       redundLoss: () => ['210300004'],
     },
     211800005: {
@@ -323,7 +342,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 1,
+      sysPage: SdPages.Bleed,
       inopSysAllPhases: () => ['210300005'],
     },
     211800006: {
@@ -334,7 +353,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 1,
+      sysPage: SdPages.Bleed,
       inopSysAllPhases: () => ['210300006'],
     },
     211800007: {
@@ -345,7 +364,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 1,
+      sysPage: SdPages.Bleed,
       redundLoss: () => ['210300007'],
     },
     211800008: {
@@ -356,7 +375,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 1,
+      sysPage: SdPages.Bleed,
       redundLoss: () => ['210300008'],
     },
     211800009: {
@@ -371,7 +390,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true, true],
       whichItemsChecked: () => [false, !this.fws.pack1On.get()],
       failure: 2,
-      sysPage: 1,
+      sysPage: SdPages.Bleed,
       inopSysAllPhases: () => ['210300009'],
     },
     211800010: {
@@ -386,7 +405,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true, true],
       whichItemsChecked: () => [false, !this.fws.pack2On.get()],
       failure: 2,
-      sysPage: 1,
+      sysPage: SdPages.Bleed,
       inopSysAllPhases: () => ['210300010'],
     },
     211800011: {
@@ -397,7 +416,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 2,
-      sysPage: 1,
+      sysPage: SdPages.Bleed,
       inopSysAllPhases: () => ['210300009'],
     },
     211800012: {
@@ -408,7 +427,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 2,
-      sysPage: 1,
+      sysPage: SdPages.Bleed,
       inopSysAllPhases: () => ['210300010'],
     },
     211800021: {
@@ -451,7 +470,7 @@ export class FwsAbnormalSensed {
         this.fws.cabinAirExtractOn.get(),
       ],
       failure: 2,
-      sysPage: 1,
+      sysPage: SdPages.Bleed,
       limitationsAllPhases: () => ['2', '210400001'],
       limitationsPfd: () => ['2', '210400001'],
       inopSysAllPhases: () => ['210300011'],
@@ -464,7 +483,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 2,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       info: () => ['210200001'],
       inopSysAllPhases: () => ['210300012'],
     },
@@ -476,7 +495,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       inopSysAllPhases: () => ['210300013'],
     },
     211800026: {
@@ -491,7 +510,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true],
       whichItemsChecked: () => [!this.fws.bulkIsolValvePbOn.get()],
       failure: 2,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       inopSysAllPhases: () => ['210300014'],
     },
     211800027: {
@@ -506,7 +525,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       inopSysAllPhases: () => ['210300013', '210300015'],
     },
     211800029: {
@@ -521,7 +540,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true],
       whichItemsChecked: () => [!this.fws.fwdIsolValvePbOn.get()],
       failure: 2,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       inopSysAllPhases: () => ['210300016'],
     },
     211800031: {
@@ -536,7 +555,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       info: () => ['210200002', '210200003'],
       inopSysAllPhases: () => ['210300017', '210300018'],
     },
@@ -552,7 +571,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       info: () => ['210200001'],
       inopSysAllPhases: () => ['210300019', '210300020'],
     },
@@ -568,7 +587,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       info: () => ['210200001'],
       inopSysAllPhases: () => ['210300019', '210300020'],
     },
@@ -580,7 +599,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 2,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       info: () => ['210200001'],
       inopSysAllPhases: () => ['210300019', '210300020'],
     },
@@ -592,7 +611,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 2,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       info: () => ['210200001'],
       inopSysAllPhases: () => ['210300019', '210300020'],
     },
@@ -608,7 +627,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       inopSysAllPhases: () => [],
     },
     211800049: {
@@ -623,7 +642,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       inopSysAllPhases: () => [],
     },
     211800035: {
@@ -637,7 +656,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       redundLoss: () => ['210300025'],
     },
     211800039: {
@@ -648,7 +667,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       redundLoss: () => ['210300021'],
     },
     211800040: {
@@ -659,7 +678,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       redundLoss: () => ['210300022'],
     },
     211800050: {
@@ -670,7 +689,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       inopSysAllPhases: () => ['210300028'],
     },
     211800041: {
@@ -681,7 +700,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       info: () => ['210200003'],
       inopSysAllPhases: () => ['210300023'],
     },
@@ -707,7 +726,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 2,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       info: () => ['210200001'],
       inopSysAllPhases: () => ['210300027'],
     },
@@ -722,7 +741,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 2,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       info: () => ['210200001'],
       inopSysAllPhases: () => ['210300026'],
     },
@@ -734,7 +753,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       redundLoss: () => ['212300001'],
     },
     212800002: {
@@ -745,7 +764,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       redundLoss: () => ['212300002'],
     },
     212800003: {
@@ -756,7 +775,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       inopSysAllPhases: () => ['212300003'],
     },
     212800004: {
@@ -771,7 +790,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 2,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       info: () => ['210200001'],
       inopSysAllPhases: () => ['212300004', '212300005'],
     },
@@ -794,7 +813,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       redundLoss: () => ['212300007'],
     },
     212800008: {
@@ -805,7 +824,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       redundLoss: () => ['212300008'],
     },
     212800009: {
@@ -816,7 +835,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 1,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       inopSysAllPhases: () => ['212300009'],
     },
     212800010: {
@@ -831,7 +850,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true],
       whichItemsChecked: () => [true], // TODO IFEC overhead PB
       failure: 2,
-      sysPage: 8,
+      sysPage: SdPages.Cond,
       info: () => ['210200001'],
       inopSysAllPhases: () => ['212300010', '212300011', '212300012'],
     },
@@ -1074,7 +1093,7 @@ export class FwsAbnormalSensed {
         this.fws.apuMasterSwitch.get() === 0,
       ],
       failure: 3,
-      sysPage: 7,
+      sysPage: SdPages.Apu,
     },
     260800002: {
       // APU FIRE DET FAULT
@@ -1135,7 +1154,7 @@ export class FwsAbnormalSensed {
         this.fws.eng1Agent2Discharged.get(),
       ],
       failure: 3,
-      sysPage: 0,
+      sysPage: SdPages.Eng,
       inopSysAllPhases: () => ['260300002', '260300006'],
       limitationsAllPhases: () => ['260400001'], // Fixme: should only come on when the ENG 1 fire button is pushed
     },
@@ -1159,7 +1178,7 @@ export class FwsAbnormalSensed {
         this.fws.eng2Agent2Discharged.get(),
       ],
       failure: 3,
-      sysPage: 0,
+      sysPage: SdPages.Eng,
       inopSysAllPhases: () => ['260300003'],
     },
     260800007: {
@@ -1182,7 +1201,7 @@ export class FwsAbnormalSensed {
         this.fws.eng3Agent2Discharged.get(),
       ],
       failure: 3,
-      sysPage: 0,
+      sysPage: SdPages.Eng,
       inopSysAllPhases: () => ['260300004'],
     },
     260800008: {
@@ -1205,7 +1224,7 @@ export class FwsAbnormalSensed {
         this.fws.eng4Agent2Discharged.get(),
       ],
       failure: 3,
-      sysPage: 0,
+      sysPage: SdPages.Eng,
       inopSysAllPhases: () => ['260300005'],
     },
     260800009: {
@@ -1254,7 +1273,7 @@ export class FwsAbnormalSensed {
         false,
       ],
       failure: 3,
-      sysPage: 0,
+      sysPage: SdPages.Eng,
       inopSysAllPhases: () => ['260300002'],
     },
     260800010: {
@@ -1303,7 +1322,7 @@ export class FwsAbnormalSensed {
         false,
       ],
       failure: 3,
-      sysPage: 0,
+      sysPage: SdPages.Eng,
       inopSysAllPhases: () => ['260300003'],
     },
     260800011: {
@@ -1352,7 +1371,7 @@ export class FwsAbnormalSensed {
         false,
       ],
       failure: 3,
-      sysPage: 0,
+      sysPage: SdPages.Eng,
       inopSysAllPhases: () => ['260300004'],
     },
     260800012: {
@@ -1401,7 +1420,7 @@ export class FwsAbnormalSensed {
         false,
       ],
       failure: 3,
-      sysPage: 0,
+      sysPage: SdPages.Eng,
       inopSysAllPhases: () => ['260300005'],
     },
     260800013: {
@@ -1599,7 +1618,7 @@ export class FwsAbnormalSensed {
         false,
       ],
       failure: 3,
-      sysPage: 11, // WHEEL SD PAGE
+      sysPage: SdPages.Wheel, // WHEEL SD PAGE
       limitationsAllPhases: () => ['260400002'],
       limitationsPfd: () => ['260400002'],
     },
@@ -1651,7 +1670,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 3,
-      sysPage: 12,
+      sysPage: SdPages.Fctl,
       inopSysAllPhases: () => [],
     },
     271800032: {
@@ -1674,7 +1693,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 3,
-      sysPage: 12,
+      sysPage: SdPages.Fctl,
       inopSysAllPhases: () => [],
     },
     272800001: {
@@ -1686,7 +1705,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 3,
-      sysPage: 12,
+      sysPage: SdPages.Fctl,
       inopSysAllPhases: () => [],
     },
     272800002: {
@@ -1698,7 +1717,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 3,
-      sysPage: 12,
+      sysPage: SdPages.Fctl,
       inopSysAllPhases: () => [],
     },
     272800028: {
@@ -1709,7 +1728,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [],
       whichItemsChecked: () => [],
       failure: 2,
-      sysPage: 12,
+      sysPage: SdPages.Fctl,
       inopSysAllPhases: () => [],
     },
     271800069: {
@@ -1762,7 +1781,7 @@ export class FwsAbnormalSensed {
         false,
       ],
       failure: 2,
-      sysPage: 4,
+      sysPage: SdPages.Fuel,
       notActiveWhenFaults: [],
       inopSysAllPhases: () => [],
       limitationsAllPhases: () => ['2'],
@@ -1775,7 +1794,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true, true, true, false, false, false, false, false],
       whichItemsChecked: () => [false, false, false, false, false, false, false, false],
       failure: 2,
-      sysPage: 4,
+      sysPage: SdPages.Fuel,
       notActiveWhenFaults: ['281800102', '281800002'],
       inopSysAllPhases: () => [],
     },
@@ -1795,7 +1814,7 @@ export class FwsAbnormalSensed {
         false,
       ],
       failure: 2,
-      sysPage: 4,
+      sysPage: SdPages.Fuel,
       notActiveWhenFaults: ['281800102', '281800002'],
       inopSysAllPhases: () => [],
     },
@@ -1815,7 +1834,7 @@ export class FwsAbnormalSensed {
         false,
       ],
       failure: 2,
-      sysPage: 4,
+      sysPage: SdPages.Fuel,
       notActiveWhenFaults: ['281800103', '281800002'],
       inopSysAllPhases: () => [],
     },
@@ -1835,7 +1854,7 @@ export class FwsAbnormalSensed {
         false,
       ],
       failure: 2,
-      sysPage: 4,
+      sysPage: SdPages.Fuel,
       notActiveWhenFaults: ['281800103', '281800002'],
       inopSysAllPhases: () => [],
     },
@@ -1850,7 +1869,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true, true, false, false, false, false, false],
       whichItemsChecked: () => [false, this.fws.allCrossFeedValvesOpen.get(), false, false, false, false, false],
       failure: 2,
-      sysPage: 4,
+      sysPage: SdPages.Fuel,
       notActiveWhenFaults: ['281800002'],
       inopSysAllPhases: () => [],
     },
@@ -1865,7 +1884,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true, true, false, false, false, false, false],
       whichItemsChecked: () => [false, this.fws.allCrossFeedValvesOpen.get(), false, false, false, false, false],
       failure: 2,
-      sysPage: 4,
+      sysPage: SdPages.Fuel,
       notActiveWhenFaults: ['281800002'],
       inopSysAllPhases: () => [],
     },
@@ -1888,7 +1907,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true],
       whichItemsChecked: () => [!this.fws.greenAPumpAuto.get()],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
       inopSysAllPhases: () => ['290300001'],
     },
@@ -1899,7 +1918,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true],
       whichItemsChecked: () => [!this.fws.greenBPumpAuto.get()],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
       inopSysAllPhases: () => ['290300002'],
     },
@@ -1910,7 +1929,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true],
       whichItemsChecked: () => [!this.fws.yellowAPumpAuto.get()],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
       inopSysAllPhases: () => ['290300003'],
     },
@@ -1921,7 +1940,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true],
       whichItemsChecked: () => [!this.fws.yellowBPumpAuto.get()],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
       inopSysAllPhases: () => ['290300004'],
     },
@@ -1932,7 +1951,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true, this.fws.aircraftOnGround.get() && this.fws.threeYellowPumpsFailed.get()],
       whichItemsChecked: () => [!this.fws.eng1APumpAuto.get(), false],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
     },
     290800006: {
@@ -1942,7 +1961,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true, this.fws.aircraftOnGround.get() && this.fws.threeYellowPumpsFailed.get()],
       whichItemsChecked: () => [!this.fws.eng1BPumpAuto.get(), false],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
     },
     290800007: {
@@ -1952,7 +1971,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true, this.fws.aircraftOnGround.get() && this.fws.threeYellowPumpsFailed.get()],
       whichItemsChecked: () => [!this.fws.eng2APumpAuto.get(), false],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
     },
     290800008: {
@@ -1962,7 +1981,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true, this.fws.aircraftOnGround.get() && this.fws.threeYellowPumpsFailed.get()],
       whichItemsChecked: () => [!this.fws.eng2BPumpAuto.get(), false],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
     },
     290800009: {
@@ -1972,7 +1991,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true, this.fws.aircraftOnGround.get() && this.fws.threeYellowPumpsFailed.get()],
       whichItemsChecked: () => [!this.fws.eng3APumpAuto.get(), false],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
     },
     290800010: {
@@ -1982,7 +2001,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true, this.fws.aircraftOnGround.get() && this.fws.threeYellowPumpsFailed.get()],
       whichItemsChecked: () => [!this.fws.eng3BPumpAuto.get(), false],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
     },
     290800011: {
@@ -1992,7 +2011,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true, this.fws.aircraftOnGround.get() && this.fws.threeYellowPumpsFailed.get()],
       whichItemsChecked: () => [!this.fws.eng4APumpAuto.get(), false],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
     },
     290800012: {
@@ -2002,7 +2021,7 @@ export class FwsAbnormalSensed {
       whichItemsToShow: () => [true, this.fws.aircraftOnGround.get() && this.fws.threeYellowPumpsFailed.get()],
       whichItemsChecked: () => [!this.fws.eng4BPumpAuto.get(), false],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
     },
     290800019: {
@@ -2022,7 +2041,7 @@ export class FwsAbnormalSensed {
         !this.fws.greenAPumpAuto.get() && !this.fws.greenBPumpAuto.get(),
       ],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
     },
     290800020: {
@@ -2042,7 +2061,7 @@ export class FwsAbnormalSensed {
         !this.fws.yellowAPumpAuto.get() && !this.fws.yellowBPumpAuto.get(),
       ],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
     },
     290800021: {
@@ -2064,7 +2083,7 @@ export class FwsAbnormalSensed {
         !this.fws.yellowAPumpAuto.get() && !this.fws.yellowBPumpAuto.get(),
       ],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
     },
     290800022: {
@@ -2086,7 +2105,7 @@ export class FwsAbnormalSensed {
         !this.fws.yellowAPumpAuto.get() && !this.fws.yellowBPumpAuto.get(),
       ],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
     },
     290800031: {
@@ -2108,7 +2127,7 @@ export class FwsAbnormalSensed {
         !this.fws.yellowAPumpAuto.get() && !this.fws.yellowBPumpAuto.get(),
       ],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
     },
     290800032: {
@@ -2130,7 +2149,7 @@ export class FwsAbnormalSensed {
         !this.fws.yellowAPumpAuto.get() && !this.fws.yellowBPumpAuto.get(),
       ],
       failure: 2,
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
       notActiveWhenFaults: [],
     },
     290800035: {
@@ -2154,7 +2173,7 @@ export class FwsAbnormalSensed {
       limitationsApprLdg: () => ['320400001', '290400001', '290400002', '320400002', '320400003', '800400002'],
       info: () => ['800200001', '800200002', '220200005'],
       notActiveWhenFaults: ['290800039'],
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
     },
     290800036: {
       // Y SYS LO PRESS
@@ -2173,7 +2192,7 @@ export class FwsAbnormalSensed {
       limitationsApprLdg: () => ['800400002'],
       info: () => ['800400003', '800200004', '800200004', '220200005'],
       notActiveWhenFaults: ['290800039'],
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
     },
     290800039: {
       // G + Y SYS LO PRESS
@@ -2227,7 +2246,7 @@ export class FwsAbnormalSensed {
       ],
       info: () => ['340200002', '800200001', '320200001', '800200004', '800200005'],
       notActiveWhenFaults: [],
-      sysPage: 5,
+      sysPage: SdPages.Hyd,
     },
     290800040: {
       // Y ELEC PMP A+B OFF
@@ -2248,7 +2267,7 @@ export class FwsAbnormalSensed {
       whichItemsChecked: () => [false, false],
       notActiveWhenFaults: [],
       failure: 2,
-      sysPage: 11,
+      sysPage: SdPages.Wheel,
       limitationsApprLdg: () => ['800400002'],
       inopSysAllPhases: () => ['320300001', '320300002', '220300008'],
       info: () => [
@@ -2275,7 +2294,7 @@ export class FwsAbnormalSensed {
       limitationsAllPhases: () => [this.fws.aircraftOnGround.get() ? '' : '260400002'],
       notActiveWhenFaults: [],
       failure: 2,
-      sysPage: 11,
+      sysPage: SdPages.Wheel,
     },
     320800022: {
       // BRAKES PARK BRK ON
@@ -2305,7 +2324,7 @@ export class FwsAbnormalSensed {
       whichItemsChecked: () => [],
       notActiveWhenFaults: [],
       failure: 3,
-      sysPage: 11,
+      sysPage: SdPages.Wheel,
       cancel: false,
     },
     320800038: {
@@ -2320,7 +2339,7 @@ export class FwsAbnormalSensed {
       whichItemsChecked: () => [],
       notActiveWhenFaults: [],
       failure: 3,
-      sysPage: 11,
+      sysPage: SdPages.Wheel,
       cancel: true,
     },
     // 34 NAVIGATION

--- a/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsMemos.ts
+++ b/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsMemos.ts
@@ -5,6 +5,7 @@
 import { EcamMemos } from '../../../instruments/src/MsfsAvionicsCommon/EcamMessages';
 import { MappedSubject, Subscribable, SubscribableMapFunctions } from '@microsoft/msfs-sdk';
 import { FwsCore } from 'systems-host/systems/FlightWarningSystem/FwsCore';
+import { SdPages } from '@shared/EcamSystemPages';
 
 interface EwdMemoItem {
   flightPhaseInhib: number[];
@@ -14,7 +15,7 @@ interface EwdMemoItem {
   codesToReturn: string[];
   memoInhibit: () => boolean;
   failure: number;
-  sysPage: number;
+  sysPage: SdPages;
   side: string;
 }
 
@@ -34,7 +35,7 @@ export class FwsMemos {
       codesToReturn: ['000005001'],
       memoInhibit: () => this.fws.toMemo.get() === 1 || this.fws.ldgMemo.get() === 1,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     271000001: {
@@ -45,7 +46,7 @@ export class FwsMemos {
       codesToReturn: ['271000001'],
       memoInhibit: () => this.fws.toMemo.get() === 1 || this.fws.ldgMemo.get() === 1,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '0000060': {
@@ -60,7 +61,7 @@ export class FwsMemos {
       codesToReturn: ['000006001', '000006002'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '280000001': {
@@ -71,7 +72,7 @@ export class FwsMemos {
       codesToReturn: ['280000001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '280000013': {
@@ -82,7 +83,7 @@ export class FwsMemos {
       codesToReturn: ['280000013'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '300000001': {
@@ -99,7 +100,7 @@ export class FwsMemos {
       codesToReturn: ['300000001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '300000002': {
@@ -110,7 +111,7 @@ export class FwsMemos {
       codesToReturn: ['300000002'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '300000003': {
@@ -125,7 +126,7 @@ export class FwsMemos {
       codesToReturn: ['300000003'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '0000170': {
@@ -140,7 +141,7 @@ export class FwsMemos {
       codesToReturn: ['000017001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '0000180': {
@@ -155,7 +156,7 @@ export class FwsMemos {
       codesToReturn: ['000018001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '0000290': {
@@ -166,7 +167,7 @@ export class FwsMemos {
       codesToReturn: ['000029001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '0000230': {
@@ -177,7 +178,7 @@ export class FwsMemos {
       codesToReturn: ['000023001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '230000001': {
@@ -193,7 +194,7 @@ export class FwsMemos {
       codesToReturn: ['230000001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     // 22 - Flight guidance
@@ -205,7 +206,7 @@ export class FwsMemos {
       codesToReturn: ['220000001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     220000002: {
@@ -216,7 +217,7 @@ export class FwsMemos {
       codesToReturn: ['220000002'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '230000002': {
@@ -232,7 +233,7 @@ export class FwsMemos {
       codesToReturn: ['230000002'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '230000003': {
@@ -248,7 +249,7 @@ export class FwsMemos {
       codesToReturn: ['230000003'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '230000009': {
@@ -264,7 +265,7 @@ export class FwsMemos {
       codesToReturn: ['230000009'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '230000010': {
@@ -280,7 +281,7 @@ export class FwsMemos {
       codesToReturn: ['230000010'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '230000011': {
@@ -296,7 +297,7 @@ export class FwsMemos {
       codesToReturn: ['230000011'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '230000012': {
@@ -312,7 +313,7 @@ export class FwsMemos {
       codesToReturn: ['230000012'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '230000015': {
@@ -323,7 +324,7 @@ export class FwsMemos {
       codesToReturn: ['230000015'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
 
@@ -345,7 +346,7 @@ export class FwsMemos {
       codesToReturn: ['241000001', '241000002'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '242000001': {
@@ -356,7 +357,7 @@ export class FwsMemos {
       codesToReturn: ['242000001', '242000002'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     // ATA 29
@@ -368,7 +369,7 @@ export class FwsMemos {
       codesToReturn: ['290000001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '290000002': {
@@ -379,7 +380,7 @@ export class FwsMemos {
       codesToReturn: ['290000002'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '290000003': {
@@ -390,7 +391,7 @@ export class FwsMemos {
       codesToReturn: ['290000003'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '290000004': {
@@ -401,7 +402,7 @@ export class FwsMemos {
       codesToReturn: ['290000004'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     // 31 INDICATING RECORDING
@@ -413,7 +414,7 @@ export class FwsMemos {
       codesToReturn: ['314000001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     314000002: {
@@ -424,7 +425,7 @@ export class FwsMemos {
       codesToReturn: ['314000002'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     // 32 LANDING GEAR
@@ -436,7 +437,7 @@ export class FwsMemos {
       codesToReturn: ['320000001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     // ATA 32
@@ -457,7 +458,7 @@ export class FwsMemos {
       codesToReturn: ['322000001', '322000002'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '320000002': {
@@ -468,7 +469,7 @@ export class FwsMemos {
       codesToReturn: ['320000002'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '333000001': {
@@ -483,7 +484,7 @@ export class FwsMemos {
       codesToReturn: ['333000001'],
       memoInhibit: () => this.fws.toMemo.get() === 1 || this.fws.ldgMemo.get() === 1,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '335000001': {
@@ -494,7 +495,7 @@ export class FwsMemos {
       codesToReturn: ['335000001'],
       memoInhibit: () => this.fws.toMemo.get() === 1 || this.fws.ldgMemo.get() === 1,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '335000003': {
@@ -505,7 +506,7 @@ export class FwsMemos {
       codesToReturn: ['335000003'],
       memoInhibit: () => this.fws.toMemo.get() === 1 || this.fws.ldgMemo.get() === 1,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '340000001': {
@@ -516,7 +517,7 @@ export class FwsMemos {
       codesToReturn: ['340000001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '340003001': {
@@ -554,7 +555,7 @@ export class FwsMemos {
       ],
       memoInhibit: () => this.fws.toMemo.get() === 1 || this.fws.ldgMemo.get() === 1,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '340003101': {
@@ -593,7 +594,7 @@ export class FwsMemos {
       ],
       memoInhibit: () => this.fws.toMemo.get() === 1 || this.fws.ldgMemo.get() === 1,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '340068001': {
@@ -608,7 +609,7 @@ export class FwsMemos {
       codesToReturn: ['340068001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
 
@@ -620,7 +621,7 @@ export class FwsMemos {
       codesToReturn: ['341000001'],
       memoInhibit: () => this.fws.toMemo.get() === 1 || this.fws.ldgMemo.get() === 1,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '341000002': {
@@ -631,7 +632,7 @@ export class FwsMemos {
       codesToReturn: ['341000002'],
       memoInhibit: () => this.fws.toMemo.get() === 1 || this.fws.ldgMemo.get() === 1,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '341000003': {
@@ -642,7 +643,7 @@ export class FwsMemos {
       codesToReturn: ['341000003'],
       memoInhibit: () => this.fws.toMemo.get() === 1 || this.fws.ldgMemo.get() === 1,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
 
@@ -654,7 +655,7 @@ export class FwsMemos {
       codesToReturn: ['343000001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '343000002': {
@@ -665,7 +666,7 @@ export class FwsMemos {
       codesToReturn: ['343000002'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '343000003': {
@@ -676,7 +677,7 @@ export class FwsMemos {
       codesToReturn: ['343000003'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '350000001': {
@@ -687,7 +688,7 @@ export class FwsMemos {
       codesToReturn: [!this.fws.aircraftOnGround.get() && this.fws.excessPressure.get() ? '350000001' : '350000002'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '460000001': {
@@ -698,7 +699,7 @@ export class FwsMemos {
       codesToReturn: ['460000001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
     '709000001': {
@@ -709,7 +710,7 @@ export class FwsMemos {
       codesToReturn: ['709000001'],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'RIGHT',
     },
   };
@@ -748,7 +749,7 @@ export class FwsMemos {
       ],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'LEFT',
     },
     '0000020': {
@@ -783,7 +784,7 @@ export class FwsMemos {
       ],
       memoInhibit: () => false,
       failure: 0,
-      sysPage: -1,
+      sysPage: SdPages.None,
       side: 'LEFT',
     },
   };
@@ -1008,7 +1009,7 @@ export class FwsMemos {
       codeToReturn: ['270005201'],
       memoInhibit: () => false,
       failure: 3,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     2700110: {
       // ELAC 1 FAULT
@@ -1179,7 +1180,7 @@ export class FwsMemos {
       codeToReturn: ['270050201'],
       memoInhibit: () => false,
       failure: 2,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     2700555: {
       // FCDC 1 FAULT
@@ -1189,7 +1190,7 @@ export class FwsMemos {
       codeToReturn: ['270055501'],
       memoInhibit: () => false,
       failure: 1,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     2700557: {
       // FCDC 2 FAULT
@@ -1199,7 +1200,7 @@ export class FwsMemos {
       codeToReturn: ['270055701'],
       memoInhibit: () => false,
       failure: 1,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     2700870: {
       // GND SPLR NOT ARMED
@@ -1209,7 +1210,7 @@ export class FwsMemos {
       codeToReturn: ['270087001'],
       memoInhibit: () => false,
       failure: 2,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     2131221: {
       // EXCESS CAB ALT
@@ -1450,7 +1451,7 @@ export class FwsMemos {
       codeToReturn: ['216129101'],
       memoInhibit: () => false,
       failure: 1,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     2161297: {
       // COND CTL 1-B FAULT
@@ -1464,7 +1465,7 @@ export class FwsMemos {
       codeToReturn: ['216129701'],
       memoInhibit: () => false,
       failure: 1,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     2161294: {
       // COND CTL 2-A FAULT
@@ -1478,7 +1479,7 @@ export class FwsMemos {
       codeToReturn: ['216129401'],
       memoInhibit: () => false,
       failure: 1,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     2161298: {
       // COND CTL 2-B FAULT
@@ -1492,7 +1493,7 @@ export class FwsMemos {
       codeToReturn: ['216129801'],
       memoInhibit: () => false,
       failure: 1,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     2163210: {
       // CKPT DUCT OVHT
@@ -1546,7 +1547,7 @@ export class FwsMemos {
       codeToReturn: ['216326001'],
       memoInhibit: () => false,
       failure: 1,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     2163290: {
       // HOT AIR FAULT
@@ -1578,7 +1579,7 @@ export class FwsMemos {
       codeToReturn: ['216330501', '216330502', '216330503', '216330504', '216330505'],
       memoInhibit: () => false,
       failure: 1,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     2600150: {
       // SMOKE FWD CARGO SMOKE
@@ -1608,7 +1609,7 @@ export class FwsMemos {
       ],
       memoInhibit: () => false,
       failure: 3,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     7700647: {
       // THR LEVERS NOT SET  (on ground)
@@ -1628,7 +1629,7 @@ export class FwsMemos {
       codeToReturn: ['770064701', '770064702', '770064703'],
       memoInhibit: () => false,
       failure: 2,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     3200050: {
       // PK BRK ON
@@ -1643,7 +1644,7 @@ export class FwsMemos {
       codeToReturn: ['320005001'],
       memoInhibit: () => false,
       failure: 3,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     3200060: {
       // NW ANTI SKID INACTIVE
@@ -1663,7 +1664,7 @@ export class FwsMemos {
       codeToReturn: ['320015001'],
       memoInhibit: () => false,
       failure: 3,
-      sysPage: -1,
+      sysPage: SdPages.None,
       cancel: false,
     },
     3200155: {
@@ -1678,7 +1679,7 @@ export class FwsMemos {
       codeToReturn: ['320015501'],
       memoInhibit: () => false,
       failure: 3,
-      sysPage: -1,
+      sysPage: SdPages.None,
       cancel: true,
     },
     3200180: {
@@ -1695,7 +1696,7 @@ export class FwsMemos {
       codeToReturn: ['320018001', '320018002'],
       memoInhibit: () => false,
       failure: 1,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     3200190: {
       // LGCIU 2 FAULT
@@ -1710,7 +1711,7 @@ export class FwsMemos {
       codeToReturn: ['320019001'],
       memoInhibit: () => false,
       failure: 1,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     3200195: {
       // LGCIU 1+2 FAULT
@@ -1741,7 +1742,7 @@ export class FwsMemos {
       codeToReturn: ['340014001'],
       memoInhibit: () => false,
       failure: 2,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     3400150: {
       // RA 2 FAULT
@@ -1755,7 +1756,7 @@ export class FwsMemos {
       codeToReturn: ['340015001'],
       memoInhibit: () => false,
       failure: 2,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     3400500: {
       // TCAS FAULT
@@ -1765,7 +1766,7 @@ export class FwsMemos {
       codeToReturn: ['340050001'],
       memoInhibit: () => false,
       failure: 2,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     3400507: {
       // NAV TCAS STBY (in flight)
@@ -1775,7 +1776,7 @@ export class FwsMemos {
       codeToReturn: ['340050701'],
       memoInhibit: () => false,
       failure: 2,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     3200010: {
       // L/G-BRAKES OVHT
@@ -1820,7 +1821,7 @@ export class FwsMemos {
       codeToReturn: ['308128001', '308128002', '308128003'],
       memoInhibit: () => false,
       failure: 2,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     3081280: {
       // ICE DETECTED
@@ -1830,7 +1831,7 @@ export class FwsMemos {
       codeToReturn: ['308128001', '308128002', '308128003'],
       memoInhibit: () => false,
       failure: 2,
-      sysPage: -1,
+      sysPage: SdPages.None,
     },
     2900126: {
       // *HYD  - Blue reservoir overheat


### PR DESCRIPTION
## Summary of Changes
On the A380 the ECP ALL button was not active and the cycling through pages had the wrong order.
It also missed the extra pages the A380 has compared to the A320.

This PR changes the index numbers of the pages for easy cycling using the index. 
This includes the public API which uses the index numbers to allow opening a page by setting a LVAR. 

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): cdr_maverick

## Testing instructions
In the A380 power up the aircraft and:

- test all page buttons and ensure the correct page is shown. 
- use the ALL button to cycle though all pages.
	- Cycling should start with the page after the currently active page and end with page where it started. 
	- It should wrap around and start with the engine page again
	- Release the ALL button and press it again - should start a new cycle starting at the page last visible. 
	- Chose another SD page and test again. 

Please test in any possible combinations.

If available also test with external tools such as SPAD, AaO, Mobiflight, etc.
Use these values for configuring:

- A32NX_BTN_{button_name}
    - Number
    - Button state of the ECAM CP buttons
        - 0: Not pressed, 1: Pressed
    - {button_name}
        - ALL
        - ABNPROC
        - CHECK_LH
        - CHECK_RH
        - CL
        - CLR
        - CLR2
        - DOWN
        - EMERCANC
        - MORE
        - RCL
        - TOCONFIG
        - UP

- 
    - Enum
    
- Currently requested page on the ECAM CP
    - | State | Value |
      |-------|-------|
      | ENG   | 0     |
      | APU   | 1     |
      | BLEED | 2     |
      | COND  | 3     |
      | PRESS | 4     |
      | DOOR  | 5     |
      | EL/AC | 6     |
      | EL/DC | 7     |
      | FUEL  | 8     |
      | WHEEL | 9     |
      | HYD   | 10    |
      | F/CTL | 11    |
      | C/B   | 12    |
      | CRZ   | 13    |    
      | STS   | 14    |
      | VIDEO | 15    |

- Also the FWS (flight warning system) code has been touched as the FWS activates SD pages for certain failures. Checking a few won't hurt but it is impractical to have them all tested.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
