### PR TITLE
fix: A380X temporarily deactivate the MSFS-PLN sync in the A380X

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/EFB/index.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/index.tsx
@@ -53,6 +53,7 @@ render(
         },
         sim: {
           cones: true,
+          msfsFplnSync: true,
           pilotSeat: false,
           registrationDecal: true,
           wheelChocks: true,

--- a/fbw-a380x/src/systems/instruments/src/EFB/index.tsx
+++ b/fbw-a380x/src/systems/instruments/src/EFB/index.tsx
@@ -50,6 +50,7 @@ render(
         },
         sim: {
           cones: false,
+          msfsFplnSync: false, // FIXME: Enable when MSFS FPLN sync is available
           pilotSeat: true,
           registrationDecal: false, // TODO FIXME: Enable when dynamic registration decal is completed
           wheelChocks: false,

--- a/fbw-common/src/systems/instruments/src/EFB/AircraftContext.ts
+++ b/fbw-common/src/systems/instruments/src/EFB/AircraftContext.ts
@@ -46,9 +46,10 @@ interface RealismOptions {
 
 interface SimOptions {
   cones: boolean;
+  msfsFplnSync: boolean;
+  pilotSeat: boolean;
   registrationDecal: boolean;
   wheelChocks: boolean;
-  pilotSeat: boolean;
 }
 
 interface ThrottleOptions {
@@ -93,6 +94,7 @@ export const AircraftContext = createContext<AircraftEfbContext>({
     },
     sim: {
       cones: false,
+      msfsFplnSync: false,
       pilotSeat: false,
       registrationDecal: false,
       wheelChocks: false,

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
@@ -2,13 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0
 
 /* eslint-disable max-len */
+/* eslint-disable max-len */
 import React, { useContext, useState } from 'react';
-
-import { toast } from 'react-toastify';
-import { AircraftContext, SelectGroup, SelectItem, SimpleInput, t, Toggle, useAppSelector } from '@flybywiresim/flypad';
-import { ButtonType, SettingItem, SettingsPage } from '../Settings';
-
-import { ThrottleConfig } from '../ThrottleConfig/ThrottleConfig';
 import {
   AirframeType,
   DefaultPilotSeatConfig,
@@ -17,6 +12,17 @@ import {
   usePersistentProperty,
   useSimVar,
 } from '@flybywiresim/fbw-sdk';
+
+import { toast } from 'react-toastify';
+import { t } from '../../Localization/translation';
+import { Toggle } from '../../UtilComponents/Form/Toggle';
+import { ButtonType, SettingItem, SettingsPage } from '../Settings';
+
+import { SelectGroup, SelectItem } from '../../UtilComponents/Form/Select';
+import { SimpleInput } from '../../UtilComponents/Form/SimpleInput/SimpleInput';
+
+import { ThrottleConfig } from '../ThrottleConfig/ThrottleConfig';
+import { AircraftContext } from '@flybywiresim/flypad';
 
 export const SimOptionsPage = () => {
   const aircraftContext = useContext(AircraftContext);

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
@@ -5,7 +5,6 @@
 /* eslint-disable max-len */
 import React, { useContext, useState } from 'react';
 import {
-  AirframeType,
   DefaultPilotSeatConfig,
   PilotSeatConfig,
   usePersistentNumberProperty,
@@ -27,7 +26,6 @@ import { AircraftContext } from '@flybywiresim/flypad';
 export const SimOptionsPage = () => {
   const aircraftContext = useContext(AircraftContext);
   const [showThrottleSettings, setShowThrottleSettings] = useState(false);
-  const airframeInfo = useAppSelector((state) => state.config.airframeInfo);
 
   const [defaultBaro, setDefaultBaro] = usePersistentProperty('CONFIG_INIT_BARO_UNIT', 'AUTO');
   const [dynamicRegistration, setDynamicRegistration] = usePersistentProperty('DYNAMIC_REGISTRATION_DECAL', '0');
@@ -60,8 +58,6 @@ export const SimOptionsPage = () => {
     { name: t('Settings.SimOptions.Right'), setting: PilotSeatConfig.Right },
   ];
 
-  const isA380X = airframeInfo.variant === AirframeType.A380_842;
-
   return (
     <>
       {!showThrottleSettings && (
@@ -80,8 +76,7 @@ export const SimOptionsPage = () => {
             </SelectGroup>
           </SettingItem>
 
-          {/* TODO: reactivate this when feature is available - deactivated in the A380X until feature is available */}
-          {!isA380X && (
+          {aircraftContext.settingsPages.sim.msfsFplnSync && (
             <SettingItem name={t('Settings.SimOptions.SyncMsfsFlightPlan')}>
               <SelectGroup>
                 {fpSyncButtons.map((button) => (

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
@@ -3,7 +3,14 @@
 
 /* eslint-disable max-len */
 import React, { useContext, useState } from 'react';
+
+import { toast } from 'react-toastify';
+import { AircraftContext, SelectGroup, SelectItem, SimpleInput, t, Toggle, useAppSelector } from '@flybywiresim/flypad';
+import { ButtonType, SettingItem, SettingsPage } from '../Settings';
+
+import { ThrottleConfig } from '../ThrottleConfig/ThrottleConfig';
 import {
+  AirframeType,
   DefaultPilotSeatConfig,
   PilotSeatConfig,
   usePersistentNumberProperty,
@@ -11,20 +18,10 @@ import {
   useSimVar,
 } from '@flybywiresim/fbw-sdk';
 
-import { toast } from 'react-toastify';
-import { t } from '../../Localization/translation';
-import { Toggle } from '../../UtilComponents/Form/Toggle';
-import { ButtonType, SettingItem, SettingsPage } from '../Settings';
-
-import { SelectGroup, SelectItem } from '../../UtilComponents/Form/Select';
-import { SimpleInput } from '../../UtilComponents/Form/SimpleInput/SimpleInput';
-
-import { ThrottleConfig } from '../ThrottleConfig/ThrottleConfig';
-import { AircraftContext } from '@flybywiresim/flypad';
-
 export const SimOptionsPage = () => {
   const aircraftContext = useContext(AircraftContext);
   const [showThrottleSettings, setShowThrottleSettings] = useState(false);
+  const airframeInfo = useAppSelector((state) => state.config.airframeInfo);
 
   const [defaultBaro, setDefaultBaro] = usePersistentProperty('CONFIG_INIT_BARO_UNIT', 'AUTO');
   const [dynamicRegistration, setDynamicRegistration] = usePersistentProperty('DYNAMIC_REGISTRATION_DECAL', '0');
@@ -57,6 +54,8 @@ export const SimOptionsPage = () => {
     { name: t('Settings.SimOptions.Right'), setting: PilotSeatConfig.Right },
   ];
 
+  const isA380X = airframeInfo.variant === AirframeType.A380_842;
+
   return (
     <>
       {!showThrottleSettings && (
@@ -75,19 +74,22 @@ export const SimOptionsPage = () => {
             </SelectGroup>
           </SettingItem>
 
-          <SettingItem name={t('Settings.SimOptions.SyncMsfsFlightPlan')}>
-            <SelectGroup>
-              {fpSyncButtons.map((button) => (
-                <SelectItem
-                  key={button.setting}
-                  onSelect={() => setFpSync(button.setting)}
-                  selected={fpSync === button.setting}
-                >
-                  {button.name}
-                </SelectItem>
-              ))}
-            </SelectGroup>
-          </SettingItem>
+          {/* TODO: reactivate this when feature is available - deactivated in the A380X until feature is available */}
+          {!isA380X && (
+            <SettingItem name={t('Settings.SimOptions.SyncMsfsFlightPlan')}>
+              <SelectGroup>
+                {fpSyncButtons.map((button) => (
+                  <SelectItem
+                    key={button.setting}
+                    onSelect={() => setFpSync(button.setting)}
+                    selected={fpSync === button.setting}
+                  >
+                    {button.name}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SettingItem>
+          )}
 
           <SettingItem name={t('Settings.SimOptions.EnableSimBridge')}>
             <SelectGroup>


### PR DESCRIPTION
## Summary of Changes
Hides the EFB Setting for loading and synching from and to the MSFS Flight Plan (World Map, etc.) in the A380X until the feature is migrated to the A380X. 

Discord username (if different from GitHub): cdr_maverick

## Testing instructions
Check regression in the A32NX - should not have any impact and still showing the setting.
In the A380X the setting should be hidden. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
