### PR TITLE
fix(a32nx/fcu): baro unit auto init

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## 0.13.0
 
+1. [FCU] Fixed auto-initialisation of baro unit - @tracernz (Mike)
+
 ## 0.12.0
 
 1. [EFB/ATSU] Added NOAA (aviationweather.gov) as a METAR source - @tracernz (Mike)

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_BaroSelector.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_BaroSelector.js
@@ -1,65 +1,44 @@
+const IN_HG_REGIONS = ["K", "C", "M", "P", "RJ", "RO", "TI", "TJ"];
+
 class A32NX_BaroSelector {
     init() {
-        this.totalDeltaTime = 0;
-        this.callbackDispatchedAt = null;
-        this.baroSelectionCompleted = false;
-
-        this.nearestAirportSamples = 0;
-        this.nearestAirportChanges = 0;
-        this.cachedNearestAirportIcao = "";
-
         const configInitBaroUnit = NXDataStore.get("CONFIG_INIT_BARO_UNIT", "IN HG");
         if (configInitBaroUnit != "AUTO") {
             this.setBaroSelector(configInitBaroUnit == "HPA");
+        } else {
+            const interval = setInterval(() => {
+                const inGame = window.parent && window.parent.document.body.getAttribute("gamestate") === "ingame";
+                if (inGame) {
+                    clearInterval(interval);
+                    this.autoSetBaroUnit();
+                }
+            }, 100);
         }
     }
     update(_deltaTime, _core) {
-        if (this.baroSelectionCompleted) {
-            return;
-        }
-        this.totalDeltaTime += _deltaTime;
-
-        // Check if we are waiting for a dispatched callback. If we've waited for more then 100ms, then try again.
-        if (this.callbackDispatchedAt != null && (this.totalDeltaTime - this.callbackDispatchedAt) < 100) {
-            return;
-        }
-
-        const lat = SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude");
-        const lon = SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude");
-        SimVar.SetSimVarValue("C:fs9gps:NearestAirportMaximumItems", "number", 1);
-        SimVar.SetSimVarValue("C:fs9gps:NearestAirportMaximumDistance", "nautical miles", 10000);
-        SimVar.SetSimVarValue("C:fs9gps:NearestAirportCurrentLatitude", "degree latitude", lat);
-        SimVar.SetSimVarValue("C:fs9gps:NearestAirportCurrentLongitude", "degree longitude", lon);
-        const batch = new SimVar.SimVarBatch("C:fs9gps:NearestAirportItemsNumber", "C:fs9gps:NearestAirportCurrentLine");
-        batch.add("C:fs9gps:NearestAirportCurrentICAO", "string", "string");
-
-        this.callbackDispatchedAt = this.totalDeltaTime;
-        SimVar.GetSimVarArrayValues(batch, (values) => {
-            if (!values || !values[0] || !values[0][0]) { // make sure next lines does not throw exception
-                return;
-            }
-            const icao = values[0][0].substr(2).trim();
-
-            if (this.nearestAirportIcao !== icao) {
-                this.nearestAirportChanges++;
-            }
-            this.nearestAirportIcao = icao;
-            this.nearestAirportSamples++;
-            this.callbackDispatchedAt = null;
-
-            // If nearestAirportChanges is more than 1, then the nearest airport has updated successfuly.
-            // If nearestAirportSamples is more than 2 (experimentally found) then the airport we initially found was correct.
-            if (this.nearestAirportChanges > 1 || this.nearestAirportSamples > 2) {
-                this.setBaroSelectorForAirport(icao);
-            }
-        });
+        // noop
     }
     setBaroSelector(value) {
         SimVar.SetSimVarValue("L:XMLVAR_Baro_Selector_HPA_1", "bool", value);
         this.baroSelectionCompleted = true;
     }
-    setBaroSelectorForAirport(icao) {
-        const inchOfMercuryRegions = ["K", "C", "M", "P", "RJ", "RO", "TI", "TJ"];
-        this.setBaroSelector(!inchOfMercuryRegions.some(r => icao.startsWith(r)));
+    /** @private */
+    async autoSetBaroUnit() {
+        const sessionId = await Coherent.call("START_NEAREST_SEARCH_SESSION", 1 /* AIRPORT */);
+        const handler = Coherent.on("NearestSearchCompleted", (result) => {
+            if (result.sessionId === sessionId) {
+                handler.clear();
+                const useInHg = result.added.length > 0 && (
+                    IN_HG_REGIONS.findIndex(result.added[0].charAt(7)) >= 0
+                    || IN_HG_REGIONS.findIndex(result.added[0].substring(7, 9)) >= 0
+                );
+                this.setBaroSelector(!useInHg);
+            }
+        });
+
+        const lat = SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude");
+        const lon = SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude");
+
+        Coherent.call("SEARCH_NEAREST", sessionId, lat, lon, 50000, 1);
     }
 }

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_BaroSelector.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_BaroSelector.js
@@ -29,8 +29,8 @@ class A32NX_BaroSelector {
             if (result.sessionId === sessionId) {
                 handler.clear();
                 const useInHg = result.added.length > 0 && (
-                    IN_HG_REGIONS.findIndex(result.added[0].charAt(7)) >= 0
-                    || IN_HG_REGIONS.findIndex(result.added[0].substring(7, 9)) >= 0
+                    IN_HG_REGIONS.includes(result.added[0].charAt(7))
+                    || IN_HG_REGIONS.includes(result.added[0].substring(7, 9))
                 );
                 this.setBaroSelector(!useInHg);
             }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Remove fs9gps from the FCU baro unit auto init, and fix it so it works (hopefully).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Set the baro unit to auto in the flypad.
- Spawn at an airport in the USA and ensure the unit auto-inits to in.Hg.
- Spawn in most of the rest of the world and ensure the unit auto-inits to hPa.
- Set the baro unit to hPa in the flypad, spawn in the USA, and ensure the unit auto-inits to hPa.
- Set the baro unit to in.Hg in the flypad, spawn somewhere living in the future, and ensure the unit auto-inits to in.Hg.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
