### PR TITLE
fix(a380x/fcu): altitude and baro instruments should show values during light test

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,9 +8,9 @@
 ## 0.13.0
 
 1. [GENERAL] Fixed issue in C++ WASM Framework that caused performance degradation in some WASM modules - @frankkopp (Frank Kopp)
-1. [FCU] QNH and altitude displays now correctly show "8" values during light test - @mattgogerly (Matt
 1. [A380X/FCU] Fixed auto-initialisation of baro unit - @tracernz (Mike)
 1. [A380X/FCU] Fix baro-preselect not recognising baro unit changes - @tracernz (Mike)
+1. [FCU] QNH and altitude displays now correctly show "8" values during light test - @mattgogerly (Matt)
 
 ## 0.12.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,7 +9,6 @@
 
 1. [GENERAL] Fixed issue in C++ WASM Framework that caused performance degradation in some WASM modules - @frankkopp (Frank Kopp)
 1. [FCU] QNH and altitude displays now correctly show "8" values during light test - @mattgogerly (Matt
-1. [FCU] Fixed auto-initialisation of baro unit - @tracernz (Mike)
 1. [A380X/FCU] Fixed auto-initialisation of baro unit - @tracernz (Mike)
 1. [A380X/FCU] Fix baro-preselect not recognising baro unit changes - @tracernz (Mike)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,7 +10,7 @@
 1. [GENERAL] Fixed issue in C++ WASM Framework that caused performance degradation in some WASM modules - @frankkopp (Frank Kopp)
 1. [A380X/FCU] Fixed auto-initialisation of baro unit - @tracernz (Mike)
 1. [A380X/FCU] Fix baro-preselect not recognising baro unit changes - @tracernz (Mike)
-1. [FCU] QNH and altitude displays now correctly show "8" values during light test - @mattgogerly (Matt)
+1. [A380X/FCU] QNH and altitude displays now correctly show "8" values during light test - @mattgogerly (Matt)
 
 ## 0.12.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## 0.13.0
 
+1. [FCU] QNH and altitude displays now correctly show "8" values during light test - @mattgogerly (Matt)
+
 ## 0.12.0
 
 1. [EFB/ATSU] Added NOAA (aviationweather.gov) as a METAR source - @tracernz (Mike)

--- a/fbw-a380x/src/systems/instruments/src/FCU/FcuFsInstrument.tsx
+++ b/fbw-a380x/src/systems/instruments/src/FCU/FcuFsInstrument.tsx
@@ -23,6 +23,7 @@ import { SpeedManager } from './Managers/SpeedManager';
 import { VerticalSpeedManager } from './Managers/VerticalSpeedManager';
 import { FcuPublisher } from './Publishers/FcuPublisher';
 import { FGDataPublisher } from '../MsfsAvionicsCommon/providers/FGDataPublisher';
+import { OverheadPublisher } from '../MsfsAvionicsCommon/providers/OverheadPublisher';
 
 import './style.scss';
 
@@ -68,6 +69,7 @@ export class FcuFsInstrument implements FsInstrument {
 
     this.backplane.addPublisher('FcuPublisher', new FcuPublisher(this.bus));
     this.backplane.addPublisher('FgBusPublisher', new FGDataPublisher(this.bus));
+    this.backplane.addPublisher('OverheadPublisher', new OverheadPublisher(this.bus));
     this.backplane.addPublisher('MsfsAutopilotAssistancePublisher', new MsfsAutopilotAssitancePublisher(this.bus));
     this.backplane.addPublisher('MsfsRadioNavigationPublisher', new MsfsRadioNavigationPublisher(this.bus));
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes https://github.com/flybywiresim/aircraft/issues/9092

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The OverheadPublisher was not being instantiated anywhere, so the subscription in the Baro/Altitude components was never receiving any events. Now they should show the test values as expected.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Pending model release...

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
See issue for pictures

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): nothematic

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Load into the sim & power on
2. Press light test switch
3. Altitude should show "88888" and baro should show "8.8.8.8"

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
