### PR TITLE
fix(a32nx/lights): Strobe lights flashing when switched from off to auto on ground

### DIFF
--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -1689,7 +1689,7 @@
                 <!-- EXT LT STROBE -->
                 <UseTemplate Name="FBW_Anim_Interactions">
                     <ANIM_TYPE>SWITCH</ANIM_TYPE>
-                    <ANIM_TEMPLATE>ASOBO_LIGHTING_Switch_Light_Strobe_Template</ANIM_TEMPLATE>
+                    <ANIM_TEMPLATE>FBW_Switch_Light_Strobe</ANIM_TEMPLATE>
                     <NODE_ID>SWITCH_OVHD_EXTLT_STROBE</NODE_ID>
                     <PART_ID>EXTLT_STROBE</PART_ID>
                     <ANIM_NAME>SWITCH_OVHD_EXTLT_STROBE</ANIM_NAME>

--- a/fbw-a32nx/src/behavior/src/A32NX_Interior_Generics.xml
+++ b/fbw-a32nx/src/behavior/src/A32NX_Interior_Generics.xml
@@ -806,4 +806,32 @@
         <UseTemplate Name="#ANIM_TEMPLATE#"></UseTemplate>
     </Template>
 
+    <Template Name="FBW_Switch_Light_Strobe">
+        <Parameters Type="Default">
+            <INTERACTION_TYPE>SWITCH</INTERACTION_TYPE>
+            <LIGHT_TYPE>STROBE</LIGHT_TYPE>
+        </Parameters>
+        <Parameters Type="Override">
+            <STATE_ON_ID>0</STATE_ON_ID>
+            <STATE_X_ID>1</STATE_X_ID>
+            <STATE_X_VAR>L:#LIGHT_TYPE#_#SIMVAR_INDEX#_Auto</STATE_X_VAR>
+            <STATE_X_TT>@TT_Auto</STATE_X_TT>
+            <STATE_X_VALUE>1</STATE_X_VALUE>
+            <STATE_OFF_ID>2</STATE_OFF_ID>
+            <TYPE>OnOffX</TYPE>
+            <LIGHT_UPDATE_CODE>
+                (A:LIGHT STROBE:0, Bool) if{
+                    (L:STROBE_0_Auto) if{
+                        (A:SIM ON GROUND, Bool) ! 100 * (&gt;K:LIGHT_POTENTIOMETER_24_SET)
+                    } els{
+                        100 (&gt;K:LIGHT_POTENTIOMETER_24_SET)
+                    }
+                } els{
+                    0 (&gt;K:LIGHT_POTENTIOMETER_24_SET)
+                }
+            </LIGHT_UPDATE_CODE>
+        </Parameters>
+        <UseTemplate Name="ASOBO_LIGHTING_Light_Template" />
+    </Template>
+
 </ModelBehaviors>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8647

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes an issue where the strobe lights flash once if the aircraft is on the ground (main gear compressed) and the strobe lights are switched from off to auto
In the auto position the Potentiometer 24 is set to 0 if the main gear is compressed or to 100 if it is not compressed. Update rate: 1/s

To fix this the Potentiometer should now also be set to 0 if the strobe light switch is in the off position.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Load in the aircraft on the ground (a32nx)
2. Power up the aircraft
3. Check that the strobe lights do not flash (in the off position)
4. Switch the strobe light switch from off to auto and monitor the strobe lights (lights should not flash)
5. Switch the strobe light switch to on (Lights should flash now in the expected interval)
6. Switch the strobe light back to auto and takeoff
7. Check that the strobe lights flash as soon as airborne (in the expected interval)
8. Switch the strobe light switch to on and check that the strobe lights are still flashing
9. Switch the strobe light switch to off (strobe lights should not flash anymore)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
