### PR TITLE
fix(nd): reuse the terrain NanoVG texture and fix memory leak

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,7 +15,8 @@
 1. [A32NX/CAMERA] Improved default camera position for Virtual Reality (VR) - @aguther (Andreas Guther)
 1. [A380X/EFB] Fixed doors automatically opening in flight - @saschl (saschl)
 1. [A380X/FMS] Fixed layouting issue on FMS/ACTIVE/PERF/T.O page for some users - @flogross89 (floridude)
-1. [A380X/TELEX] Added popup for telex consent @saschl (saschl) @Maximilian-Reuter (\_chaoz)
+1. [A380X/TELEX] Added popup for telex consent - @saschl (saschl) @Maximilian-Reuter (\_chaoz)
+1. [ND] Fix memory leak when using TERR ON ND - @Nufflee (nufflee)
 
 ## 0.12.0
 

--- a/fbw-common/src/wasm/terronnd/build.sh
+++ b/fbw-common/src/wasm/terronnd/build.sh
@@ -62,6 +62,7 @@ clang++ \
   -O2 \
   -I "${MSFS_SDK}/WASM/include" \
   -I "${MSFS_SDK}/SimConnect SDK/include" \
+  -I "${DIR}/../cpp-msfs-framework/lib/" \
   "${DIR}/src/main.cpp" \
   "${DIR}/src/nanovg/nanovg.cpp" \
   "${DIR}/src/navigationdisplay/collection.cpp" \

--- a/fbw-common/src/wasm/terronnd/src/navigationdisplay/display.h
+++ b/fbw-common/src/wasm/terronnd/src/navigationdisplay/display.h
@@ -139,6 +139,7 @@ class Display : public DisplayBase {
         if (decodedWidth != width || decodedHeight != height) {
           // This should never happen, but bail just in case
           fprintf(stderr, "TERR ON ND: The image size does not match the expected size. Expected: %dx%d, actual: %dx%d\n", width, height, decodedWidth, decodedHeight);
+          stbi_image_free(decodedImage);
           return;
         }
 

--- a/fbw-common/src/wasm/terronnd/src/navigationdisplay/display.h
+++ b/fbw-common/src/wasm/terronnd/src/navigationdisplay/display.h
@@ -11,8 +11,10 @@
 #include <cstdint>
 #include <string_view>
 #include <vector>
-
 #include <iostream>
+
+#define FMT_HEADER_ONLY
+#include <fmt/format.h>
 
 #include "../simconnect/clientdataarea.hpp"
 #include "../simconnect/connection.hpp"
@@ -119,7 +121,7 @@ class Display : public DisplayBase {
           // If we don't have an image yet, create one
           this->_nanovgImage = nvgCreateImageMem(this->_context, 0, this->_frameData->data().data(), static_cast<int>(this->_frameBufferSize));
           if (this->_nanovgImage == 0) {
-            fprintf(stderr, "TERR ON ND: Unable to decode the image from the stream. Reason: %s\n", stbi_failure_reason());
+            std::cerr << fmt::format("TERR ON ND: Unable to create the image from the stream. Reason: {}", stbi_failure_reason());
           }
 
           return;
@@ -129,7 +131,7 @@ class Display : public DisplayBase {
         int decodedWidth, decodedHeight;
         uint8_t* decodedImage = stbi_load_from_memory(this->_frameData->data().data(), static_cast<int>(this->_frameBufferSize), &decodedWidth, &decodedHeight, nullptr, 4);
         if (decodedImage == nullptr) {
-          fprintf(stderr, "TERR ON ND: Unable to decode the image from the stream. Reason: %s\n", stbi_failure_reason());
+          std::cerr << fmt::format("TERR ON ND: Unable to create the image from the stream. Reason: {}", stbi_failure_reason());
           return;
         }
 
@@ -138,7 +140,7 @@ class Display : public DisplayBase {
 
         if (decodedWidth != width || decodedHeight != height) {
           // This should never happen, but bail just in case
-          fprintf(stderr, "TERR ON ND: The image size does not match the expected size. Expected: %dx%d, actual: %dx%d\n", width, height, decodedWidth, decodedHeight);
+          std::cerr << fmt::format("TERR ON ND: The image size does not match the expected size. Expected: {}x{}, actual: {}x{}", width, height, decodedWidth, decodedHeight);
           stbi_image_free(decodedImage);
           return;
         }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Previously, the terrain NanoVG texture was recreated on every terrain update (several times per second) but this is not necessary and we can instead reuse the same texture all the time as the size of the terrain image never changes (there is a failsafe in place in case this assumption is broken). In order to do this, I had to use the `stbi` library to manually parse the PNG data and then upload it to the existing texture.

This also seems to fix the reported memory leak within MSFS (not within SimBridge) when using TERR display, but to confirm this further, long haul testing would be needed. It appears that creating and then deleting a texture causes a memory leak within the MSFS NanoVG backend.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Start a several hour long flight in the A380X (the longer the better)
2. Note the `CPU Mem` value in the FPS display (`DevMode -> Debug -> Display FPS`)
3. Turn the TERR display on and keep it on for the rest of the flight, ideally on both NDs
4. Observe the `CPU Mem` usage throughout the flight, it should not rise rapidly or increase significantly compared to the value noted at the start (during the cruise at least)
5. Ensure that the TERR display looks the same as before, without any visual glitches or similar

![image](https://github.com/user-attachments/assets/99eb6f88-0e6f-4167-b7c3-d9fd19fa485d)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
