### PR TITLE
chore: added fbw files to CMakeLists.txt

### DIFF
--- a/fbw-a32nx/src/wasm/fbw_a320/CMakeLists.txt
+++ b/fbw-a32nx/src/wasm/fbw_a320/CMakeLists.txt
@@ -35,16 +35,17 @@ add_executable(flybywire-a32nx-fbw
     ${FBW_ROOT}/fbw-common/src/wasm/fbw_common/src/LocalVariable.cpp
     ${FBW_ROOT}/fbw-common/src/wasm/fbw_common/src/ThrottleAxisMapping.cpp
     ${FBW_ROOT}/fbw-common/src/wasm/fbw_common/src/InterpolatingLookupTable.cpp
-    src/interface/SimConnectInterface.cpp
+    src/Arinc429.cpp
+    src/Arinc429Utils.cpp
+    src/CalculatedRadioReceiver.cpp
+    src/FlyByWireInterface.cpp
+    src/main.cpp
+    src/SpoilersHandler.cpp
     src/elac/Elac.cpp
-    src/sec/Sec.cpp
-    src/fcdc/Fcdc.cpp
     src/fac/Fac.cpp
     src/failures/FailuresConsumer.cpp
-    src/utils/ConfirmNode.cpp
-    src/utils/SRFlipFLop.cpp
-    src/utils/PulseNode.cpp
-    src/utils/HysteresisNode.cpp
+    src/fcdc/Fcdc.cpp
+    src/interface/SimConnectInterface.cpp
     src/model/AutopilotLaws_data.cpp
     src/model/AutopilotLaws.cpp
     src/model/AutopilotStateMachine_data.cpp
@@ -54,28 +55,30 @@ add_executable(flybywire-a32nx-fbw
     src/model/Double2MultiWord.cpp
     src/model/ElacComputer_data.cpp
     src/model/ElacComputer.cpp
-    src/model/SecComputer_data.cpp
-    src/model/SecComputer.cpp
-    src/model/PitchNormalLaw.cpp
-    src/model/PitchAlternateLaw.cpp
-    src/model/PitchDirectLaw.cpp
-    src/model/LateralNormalLaw.cpp
-    src/model/LateralDirectLaw.cpp
     src/model/FacComputer_data.cpp
     src/model/FacComputer.cpp
+    src/model/LateralDirectLaw.cpp
+    src/model/LateralNormalLaw.cpp
     src/model/look1_binlxpw.cpp
     src/model/look2_binlcpw.cpp
     src/model/look2_binlxpw.cpp
+    src/model/look2_pbinlxpw.cpp
     src/model/mod_2RcCQkwc.cpp
+    src/model/mod_obTiuOCQ.cpp
     src/model/MultiWordIor.cpp
+    src/model/PitchAlternateLaw.cpp
+    src/model/PitchDirectLaw.cpp
+    src/model/PitchNormalLaw.cpp
     src/model/rt_modd.cpp
     src/model/rt_remd.cpp
+    src/model/SecComputer_data.cpp
+    src/model/SecComputer.cpp
     src/model/uMultiWord2Double.cpp
-    src/FlyByWireInterface.cpp
-    src/FlightDataRecorder.cpp
-    src/Arinc429.cpp
-    src/Arinc429Utils.cpp
-    src/SpoilersHandler.cpp
-    src/CalculatedRadioReceiver.cpp
-    src/main.cpp
+    src/recording/FlightDataRecorder.cpp
+    src/sec/Sec.cpp
+    src/utils/ConfirmNode.cpp
+    src/utils/HysteresisNode.cpp
+    src/utils/PulseNode.cpp
+    src/utils/SRFlipFLop.cpp
+
 )

--- a/fbw-a380x/src/wasm/fbw_a380/CMakeLists.txt
+++ b/fbw-a380x/src/wasm/fbw_a380/CMakeLists.txt
@@ -35,24 +35,34 @@ add_executable(flybywire-a380x-fbw
     ${FBW_ROOT}/fbw-common/src/wasm/fbw_common/src/LocalVariable.cpp
     ${FBW_ROOT}/fbw-common/src/wasm/fbw_common/src/ThrottleAxisMapping.cpp
     ${FBW_ROOT}/fbw-common/src/wasm/fbw_common/src/InterpolatingLookupTable.cpp
-    src/interface/SimConnectInterface.cpp
-    src/sec/Sec.cpp
+    src/Arinc429.cpp
+    src/Arinc429Utils.cpp
+    src/CalculatedRadioReceiver.cpp
+    src/FlyByWireInterface.cpp
+    src/main.cpp
+    src/SpoilersHandler.cpp
     src/fac/Fac.cpp
     src/failures/FailuresConsumer.cpp
-    src/utils/ConfirmNode.cpp
-    src/utils/SRFlipFLop.cpp
-    src/utils/PulseNode.cpp
-    src/utils/HysteresisNode.cpp
+    src/interface/SimConnectInterface.cpp
+    src/model/A380LateralDirectLaw.cpp
+    src/model/A380LateralNormalLaw.cpp
+    src/model/A380PitchAlternateLaw.cpp
+    src/model/A380PitchDirectLaw.cpp
+    src/model/A380PitchNormalLaw.cpp
+    src/model/A380PrimComputer_data.cpp
+    src/model/A380PrimComputer.cpp
+    src/model/A380SecComputer_data.cpp
+    src/model/A380SecComputer.cpp
     src/model/AutopilotLaws_data.cpp
     src/model/AutopilotLaws.cpp
     src/model/AutopilotStateMachine_data.cpp
     src/model/AutopilotStateMachine.cpp
     src/model/Autothrust_data.cpp
     src/model/Autothrust.cpp
+    src/model/binsearch_u32d.cpp
     src/model/Double2MultiWord.cpp
     src/model/FacComputer_data.cpp
     src/model/FacComputer.cpp
-    src/model/binsearch_u32d.cpp
     src/model/intrp3d_l_pw.cpp
     src/model/look1_binlxpw.cpp
     src/model/look2_binlxpw.cpp
@@ -63,10 +73,12 @@ add_executable(flybywire-a380x-fbw
     src/model/rt_modd.cpp
     src/model/rt_remd.cpp
     src/model/uMultiWord2Double.cpp
-    src/FlyByWireInterface.cpp
-    src/FlightDataRecorder.cpp
-    src/Arinc429Utils.cpp
-    src/SpoilersHandler.cpp
-    src/CalculatedRadioReceiver.cpp
-    src/main.cpp
+    src/prim/Prim.cpp
+    src/recording/FlightDataRecorder.cpp
+    src/sec/Sec.cpp
+    src/utils/ConfirmNode.cpp
+    src/utils/HysteresisNode.cpp
+    src/utils/PulseNode.cpp
+    src/utils/SRFlipFLop.cpp
+
 )


### PR DESCRIPTION
## Summary of Changes
Last update to fbw code did not update the CmakeLists.txt files which are used by some IDEs to understand the code for highlighting and navigation.

Discord username (if different from GitHub): cdr_maverick

## Testing instructions
n/a

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
