### PR TITLE
feat(a380x/ap): improved support of 4x simulation rate

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -24,7 +24,6 @@
 1. [A380X/LIGHTS] Implemented LOGO LT switch funcionality - @ImenesFBW (Imenes)
 1. [A380X/SD] Added correct ECP ALL button SD page cycling to the A380X - @frankkopp (Frank Kopp)
 1. [A380/MFD] Limit keyboard inputs to keys present in the KCCU and remap comma to decimal dot - @beheh (Benedict Etzel)
-
 1. [A380X/AP] Improved support of simulation rate 4x - @aguther (Andreas Guther)
 
 ## 0.12.0

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,13 +19,13 @@
 1. [A380X/TELEX] Added popup for telex consent - @saschl (saschl) @Maximilian-Reuter (\_chaoz)
 1. [ND] Fix memory leak when using TERR ON ND - @Nufflee (nufflee)
 1. [A380X/OVHD] Fix RCDR GND CTL button/logic - @flogross89 (floridude)
-1. [A380X] Various fixes in FMS and ECL @flogross89 (floridude)
 1. [A380X] Various fixes in FMS and ECL - @flogross89 (floridude)
 1. [A380X/EWD] QoL: Add soft keys to EWD checklists, can be enabled via EFB - @flogross89 (floridude)
 1. [A380X/LIGHTS] Implemented LOGO LT switch funcionality - @ImenesFBW (Imenes)
 1. [A380X/SD] Added correct ECP ALL button SD page cycling to the A380X - @frankkopp (Frank Kopp)
 1. [A380/MFD] Limit keyboard inputs to keys present in the KCCU and remap comma to decimal dot - @beheh (Benedict Etzel)
 
+1. [A380X/AP] Improved support of simulation rate 4x - @aguther (Andreas Guther)
 
 ## 0.12.0
 

--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.h
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.h
@@ -35,8 +35,8 @@ class FlyByWireInterface {
  private:
   const std::string CONFIGURATION_FILEPATH = "\\work\\ModelConfiguration.ini";
 
-  static constexpr double MAX_ACCEPTABLE_SAMPLE_TIME = 0.11;
-  static constexpr uint32_t LOW_PERFORMANCE_TIMER_THRESHOLD = 10;
+  static constexpr double MAX_ACCEPTABLE_SAMPLE_TIME = 0.16;
+  static constexpr uint32_t LOW_PERFORMANCE_TIMER_THRESHOLD = 15;
   uint32_t lowPerformanceTimer = 0;
 
   double previousSimulationTime = 0;

--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.h
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.h
@@ -35,8 +35,8 @@ class FlyByWireInterface {
  private:
   const std::string CONFIGURATION_FILEPATH = "\\work\\ModelConfiguration.ini";
 
-  static constexpr double MAX_ACCEPTABLE_SAMPLE_TIME = 0.16;
-  static constexpr uint32_t LOW_PERFORMANCE_TIMER_THRESHOLD = 15;
+  static constexpr double MAX_ACCEPTABLE_SAMPLE_TIME = (1.0 / 6.0);
+  static constexpr uint32_t LOW_PERFORMANCE_TIMER_THRESHOLD = (3 * 6);
   uint32_t lowPerformanceTimer = 0;
 
   double previousSimulationTime = 0;

--- a/fbw-a380x/src/wasm/fbw_a380/src/interface/SimConnectInterface.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/interface/SimConnectInterface.cpp
@@ -3330,7 +3330,7 @@ void SimConnectInterface::processEventWithOneParam(const DWORD eventId, const DW
       // calculate frame rate that will be seen by FBW / AP
       double theoreticalFrameRate = (1 / sampleTime) / (simData.simulation_rate * 2);
       // determine if an increase of simulation rate can be allowed
-      if ((simData.simulation_rate < maxSimulationRate && theoreticalFrameRate >= 8) || simData.simulation_rate < 1 ||
+      if ((simData.simulation_rate < maxSimulationRate && theoreticalFrameRate >= 6) || simData.simulation_rate < 1 ||
           !limitSimulationRateByPerformance) {
         sendEvent(Events::SIM_RATE_INCR, 0, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
         std::cout << "WASM: Simulation rate " << simData.simulation_rate;

--- a/fbw-a380x/src/wasm/fbw_a380/src/model/A380PitchNormalLaw.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/model/A380PitchNormalLaw.cpp
@@ -63,7 +63,7 @@ A380PitchNormalLaw::Parameters_A380PitchNormalLaw_T A380PitchNormalLaw::A380Pitc
   { 0.0, 163.0, 243.0, 344.0, 400.0 },
 
 
-  { 0.0, 0.06, 0.1, 0.2, 1.0 },
+  { 0.0, 0.06, 0.1, 0.13, 0.26, 1.0 },
 
 
   { 0.0, 163.0, 243.0, 344.0, 400.0 },
@@ -246,7 +246,7 @@ A380PitchNormalLaw::Parameters_A380PitchNormalLaw_T A380PitchNormalLaw::A380Pitc
   { 1.0, 1.0, 0.5, 0.3, 0.3 },
 
 
-  { 1.0, 1.0, 0.5, 0.3, 0.3 },
+  { 1.0, 1.0, 1.0, 1.0, 1.0, 0.25 },
 
 
   { 1.0, 1.0, 0.5, 0.3, 0.3 },
@@ -1866,7 +1866,7 @@ void A380PitchNormalLaw::step(const real_T *rtu_In_time_dt, const real_T *rtu_In
     A380PitchNormalLaw_rtP.ScheduledGain1_Table, 4U);
   rtb_Y_a = rtb_Saturation_ix * rtb_Sum_ma;
   rtb_Sum_ma = look1_binlxpw(*rtu_In_time_dt, A380PitchNormalLaw_rtP.ScheduledGain_BreakpointsForDimension1_d,
-    A380PitchNormalLaw_rtP.ScheduledGain_Table_hh, 4U);
+    A380PitchNormalLaw_rtP.ScheduledGain_Table_hh, 5U);
   rtb_Sum_ma = rtb_Y_a * rtb_Sum_ma * A380PitchNormalLaw_rtP.DiscreteTimeIntegratorVariableTs_Gain * *rtu_In_time_dt;
   rtb_Y_a = *rtu_In_eta_deg - rtb_Sum_ma;
   rtb_AND = ((rtb_Y_pa == 0.0) || (rtb_ManualSwitch == A380PitchNormalLaw_rtP.CompareToConstant_const) ||

--- a/fbw-a380x/src/wasm/fbw_a380/src/model/A380PitchNormalLaw.h
+++ b/fbw-a380x/src/wasm/fbw_a380/src/model/A380PitchNormalLaw.h
@@ -131,7 +131,7 @@ class A380PitchNormalLaw final
     real_T ScheduledGain_BreakpointsForDimension1_f[4];
     real_T ScheduledGain_BreakpointsForDimension1_b[4];
     real_T ScheduledGain1_BreakpointsForDimension1[5];
-    real_T ScheduledGain_BreakpointsForDimension1_d[5];
+    real_T ScheduledGain_BreakpointsForDimension1_d[6];
     real_T ScheduledGain1_BreakpointsForDimension1_h[5];
     real_T LagFilter_C1;
     real_T WashoutFilter_C1;
@@ -218,7 +218,7 @@ class A380PitchNormalLaw final
     real_T ScheduledGain_Table_h[4];
     real_T ScheduledGain_Table_e[4];
     real_T ScheduledGain1_Table[5];
-    real_T ScheduledGain_Table_hh[5];
+    real_T ScheduledGain_Table_hh[6];
     real_T ScheduledGain1_Table_c[5];
     real_T DiscreteTimeIntegratorVariableTs_UpperLimit;
     real_T DiscreteTimeIntegratorVariableTs_UpperLimit_p;


### PR DESCRIPTION
## Summary of Changes
This PR improves the performance of AP guidance in cruise and other situations with a simulation rate of 4x with 30 fps. Higher FPS should work even better.

## Testing instructions
Perform a flight and try 4x simulation rate especially in cruise.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
