### PR TITLE
fix(a32nx/fans): restore portuguese station codes

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -24,7 +24,7 @@
 1. [A380X/EWD] QoL: Add soft keys to EWD checklists, can be enabled via EFB - @flogross89 (floridude)
 1. [A380X/LIGHTS] Implemented LOGO LT switch funcionality - @ImenesFBW (Imenes)
 1. [A380X/SD] Added correct ECP ALL button SD page cycling to the A380X - @frankkopp (Frank Kopp)
-
+1. [A32NX/FANS] Restore Portuguese station codes - @tracernz (Mike)
 
 ## 0.12.0
 

--- a/fbw-common/src/systems/datalink/common/src/com/FutureAirNavigationSystem.ts
+++ b/fbw-common/src/systems/datalink/common/src/com/FutureAirNavigationSystem.ts
@@ -59,6 +59,8 @@ export class FutureAirNavigationSystem {
     // Spain
     'CBRA', 'CBRN', 'CBRS', 'CBRW', 'CBRC', 'CBRE', 'CBRD', 'CMRA', 'CMRM', 'CMRN', 'CMRC', 'CMRW', 'CMRE', 'CSRA', 'CSRW',
     'CCRA', 'CCRI', 'CCRL', 'CCRW', 'CCRE', 'CCRO',
+    // Portugal
+    'LPPC', 'LPZC', 'LPZD', 'LPZE', 'LPZI', 'LPZN', 'LPZS', 'LPZW', 'LPWU', 'LPNU', 'LPCU', 'LPYP', 'LPYL', 'LPYT', 'LPYF', 'LPYM',
     // Poland
     'EPWW', 'EPWU', 'EPWB', 'EPWC', 'EPWD', 'EPWE', 'EPWF', 'EPWG', 'EPWJ', 'EPWK', 'EPWN', 'EPWR', 'EPWZ',
     // Czech


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
These stations were lost in #8466 .

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
