### PR TITLE
fix(a380x/mfd): Fixed DIRECT TO selection of active waypoint does nothing

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -26,6 +26,7 @@
 1. [A380/MFD] Limit keyboard inputs to keys present in the KCCU and remap comma to decimal dot - @beheh (Benedict Etzel)
 1. [A380X/AP] Improved support of simulation rate 4x - @aguther (Andreas Guther)
 1. [A32NX/FANS] Restore Portuguese station codes - @tracernz (Mike)
+1. [A380X/MFD] Fixed DIRECT TO selection of active waypoint does nothing - @sognodelx (Sven Gross)
 
 ## 0.12.0
 

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnDirectTo.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnDirectTo.tsx
@@ -164,7 +164,7 @@ export class MfdFmsFplnDirectTo extends FmsPage<MfdFmsFplnDirectToProps> {
                     containerStyle="width: 175px;"
                     alignLabels="flex-start"
                     onModified={(i, text) => {
-                      if (i) {
+                      if (i != null) {
                         this.onDropdownModified(i, text);
                       }
                     }}

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnDirectTo.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnDirectTo.tsx
@@ -164,7 +164,7 @@ export class MfdFmsFplnDirectTo extends FmsPage<MfdFmsFplnDirectToProps> {
                     containerStyle="width: 175px;"
                     alignLabels="flex-start"
                     onModified={(i, text) => {
-                      if (i != null) {
+                      if (i !== null) {
                         this.onDropdownModified(i, text);
                       }
                     }}


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
DIRECT TO selection of active waypoint results in index 0 and thus onModified leads to no action. Changed the condition to check for null in the onModified action to allow selection of active waypoint.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
<img width="956" alt="image" src="https://github.com/user-attachments/assets/892163c2-b68f-4937-b3e9-f917f8a5510b">

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

<img width="884" alt="image" src="https://github.com/user-attachments/assets/4fd08d33-6af5-4be4-b127-3db4e584643d">

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
In flight with an active flight plan select the active waypoint as DIRECT TO.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
