### PR TITLE
feat: Option to disable pushback conflict warning

### DIFF
--- a/fbw-common/src/systems/instruments/src/EFB/Ground/Pages/Pushback/PushbackPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Ground/Pages/Pushback/PushbackPage.tsx
@@ -47,6 +47,7 @@ export const PushbackPage = () => {
   const [pushbackAngle] = useSimVar('PUSHBACK ANGLE', 'Degrees', 100);
 
   const [useControllerInput, setUseControllerInput] = usePersistentNumberProperty('PUSHBACK_USE_CONTROLLER_INPUT', 1);
+  const [pushbackNoConflictWarning] = usePersistentNumberProperty('PUSHBACK_CONFLICTWARN_DISABLED', 0);
   const [rudderPosition] = useSimVar('L:A32NX_RUDDER_PEDAL_POSITION', 'number', 50);
   const [elevatorPosition] = useSimVar('L:A32NX_SIDESTICK_POSITION_Y', 'number', 50);
 
@@ -101,15 +102,19 @@ export const PushbackPage = () => {
       }
       return;
     }
-    showModal(
-      <PromptModal
-        title={t('Pushback.EnableSystemMessageTitle')}
-        bodyText={`${t('Pushback.EnableSystemMessageBody')}`}
-        onConfirm={() => {
-          setPushbackSystemEnabled(1);
-        }}
-      />,
-    );
+    if (pushbackNoConflictWarning) {
+      setPushbackSystemEnabled(1);
+    } else {
+      showModal(
+        <PromptModal
+          title={t('Pushback.EnableSystemMessageTitle')}
+          bodyText={`${t('Pushback.EnableSystemMessageBody')}`}
+          onConfirm={() => {
+            setPushbackSystemEnabled(1);
+          }}
+        />,
+      );
+    }
   };
 
   const handleCallTug = () => {

--- a/fbw-common/src/systems/instruments/src/EFB/Localization/data/en.json
+++ b/fbw-common/src/systems/instruments/src/EFB/Localization/data/en.json
@@ -750,7 +750,7 @@
       "TwentyFourHours": "24h",
       "Utc": "UTC",
       "UtcAndLocal": "UTC and Local",
-      "DisablePushbackConflictWarning": "Disable pushpack system conflict warning"
+      "DisablePushbackConflictWarning": "Disable pushback system conflict warning"
     }
   },
   "StatusBar": {

--- a/fbw-common/src/systems/instruments/src/EFB/Localization/data/en.json
+++ b/fbw-common/src/systems/instruments/src/EFB/Localization/data/en.json
@@ -749,7 +749,8 @@
       "TwelveHours": "12h",
       "TwentyFourHours": "24h",
       "Utc": "UTC",
-      "UtcAndLocal": "UTC and Local"
+      "UtcAndLocal": "UTC and Local",
+      "DisablePushbackConflictWarning": "Disable pushpack system conflict warning"
     }
   },
   "StatusBar": {

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/FlyPadPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/FlyPadPage.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 // Copyright (c) 2023-2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
@@ -30,6 +31,7 @@ export const FlyPadPage = () => {
   const [language, setLanguage] = usePersistentProperty('EFB_LANGUAGE', 'en');
   const [keyboardLayout, setKeyboardLayout] = usePersistentProperty('EFB_KEYBOARD_LAYOUT_IDENT', 'english');
   const [batteryLifeEnabled, setBatteryLifeEnabled] = usePersistentNumberProperty('EFB_BATTERY_LIFE_ENABLED', 1);
+  const [pushbackNoConflictWarning, setPushbackNoConflictWarning] = usePersistentNumberProperty('PUSHBACK_CONFLICTWARN_DISABLED', 0);
 
   // the tt() is a special case to update the page with the correct language after user
   // changes the language. the change to simvar hooks changed timing/order of updates.
@@ -136,6 +138,10 @@ export const FlyPadPage = () => {
 
       <SettingItem name={tt('Settings.flyPad.BatteryLifeEnabled', language)}>
         <Toggle value={!!batteryLifeEnabled} onToggle={(value) => setBatteryLifeEnabled(value ? 1 : 0)} />
+      </SettingItem>
+
+      <SettingItem name={tt('Settings.flyPad.DisablePushbackConflictWarning', language)}>
+        <Toggle value={!!pushbackNoConflictWarning} onToggle={(value) => setPushbackNoConflictWarning(value ? 1 : 0)} />
       </SettingItem>
 
       <SettingItem name={tt('Settings.flyPad.ShowStatusBarFlightProgressIndicator', language)}>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Adds the option to disable the conflict warning when enabling the pushback system

-> new flyPadOS string `Settings.flyPad.DisablePushbackConflictWarning`

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![ezgif-2-4d0933304f](https://github.com/user-attachments/assets/8694ccb7-58d3-4a41-bdd9-080753e09675)
![image](https://github.com/user-attachments/assets/23b82632-57fb-4f75-b53b-c8067cdfe740)



<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
