### PR TITLE
feat(efb/efis): minimum runway length option to filter airports on the EFIS/ND.

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/efis/EfisSymbols.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/efis/EfisSymbols.ts
@@ -18,6 +18,7 @@ import {
   EfisSide,
   Arinc429SignStatusMatrix,
   Arinc429OutputWord,
+  NXDataStore,
 } from '@flybywiresim/fbw-sdk';
 
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
@@ -187,8 +188,13 @@ export class EfisSymbols<T extends number> {
     const vnavPredictionsChanged = this.lastVnavDriverVersion !== this.guidanceController.vnavDriver.version;
     this.lastVnavDriverVersion = this.guidanceController.vnavDriver.version;
 
-    const hasSuitableRunway = (airport: Airport): boolean =>
-      airport.longestRunwayLength >= 1500 && airport.longestRunwaySurfaceType === RunwaySurfaceType.Hard;
+    const hasSuitableRunway = (airport: Airport): boolean => {
+      const minRwyLengthDisplay = parseInt(NXDataStore.get('CONFIG_MIN_RWY_LENGTH', '1500'));
+      return (
+        airport.longestRunwayLength >= minRwyLengthDisplay &&
+        airport.longestRunwaySurfaceType === RunwaySurfaceType.Hard
+      );
+    };
 
     for (const side of EfisSymbols.sides) {
       const range = this.rangeValues[SimVar.GetSimVarValue(`L:A32NX_EFIS_${side}_ND_RANGE`, 'number')];

--- a/fbw-common/src/systems/instruments/src/EFB/Localization/data/en.json
+++ b/fbw-common/src/systems/instruments/src/EFB/Localization/data/en.json
@@ -573,6 +573,7 @@
     "AircraftOptionsPinPrograms": {
       "AccelerationHeight": "Acceleration Height (ft)",
       "EngineOutAccelerationHeight": "Engine-Out Acceleration Height (ft)",
+      "MinimumRunwayLength": "ND Display Airport Minimum Runway Length (meters)",
       "IsisBaroUnit": "ISIS Baro Unit",
       "IsisMetricAltitude": "ISIS Metric Altitude",
       "LatLonExtendedFormat": "FMGC Lat/Lon Waypoint Format",

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/AircraftOptionsPinProgramsPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/AircraftOptionsPinProgramsPage.tsx
@@ -28,6 +28,8 @@ export const AircraftOptionsPinProgramsPage = () => {
   const [accelerationHeightSetting, setAccelerationHeightSetting] = useState(accelerationHeight);
   const [accelerationOutHeight, setAccelerationOutHeight] = usePersistentProperty('CONFIG_ENG_OUT_ACCEL_ALT', '1500');
   const [accelerationOutHeightSetting, setAccelerationOutHeightSetting] = useState(accelerationOutHeight);
+  const [minRwyLength, setMinRwyLength] = usePersistentProperty('CONFIG_MIN_RWY_LENGTH', '3000');
+  const [minRwyLengthSetting, setMinRwyLengthSetting] = useState(minRwyLength);
 
   const [usingMetric, setUsingMetric] = usePersistentProperty('CONFIG_USING_METRIC_UNIT', '1');
   const [paxSigns, setPaxSigns] = usePersistentProperty('CONFIG_USING_PORTABLE_DEVICES', '0');
@@ -64,6 +66,16 @@ export const AircraftOptionsPinProgramsPage = () => {
 
     if (parsedValue >= 400 && parsedValue <= 10000) {
       setAccelerationOutHeight(value.trim());
+    }
+  };
+
+  const handleSetMinRwyLength = (value: string) => {
+    setMinRwyLengthSetting(value);
+
+    const parsedValue = parseInt(value);
+
+    if (parsedValue >= 1500 && parsedValue <= 4000) {
+      setMinRwyLength(value.trim());
     }
   };
 
@@ -124,6 +136,16 @@ export const AircraftOptionsPinProgramsPage = () => {
               min={400}
               max={10000}
               onChange={(event) => handleSetAccelerationOutAlt(event)}
+            />
+          </SettingItem>
+          <SettingItem name={`${t('Settings.AircraftOptionsPinPrograms.MinimumRunwayLength')}`}>
+            <SimpleInput
+              className="w-30 text-center"
+              placeholder={minRwyLength}
+              value={minRwyLengthSetting}
+              min={1500}
+              max={4000}
+              onChange={(event) => handleSetMinRwyLength(event)}
             />
           </SettingItem>
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes [#9436](https://github.com/flybywiresim/aircraft/issues/9436)

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Added an Minimum Runway Length option in the EFB (Aircraft PIN Programs). Then take that value to filter on airport displayed on the ND when selection ARPT on the EFIS.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
#### EFB Setting
![6E7A257C90FA5E5DFD80E3816FB11D72](https://github.com/user-attachments/assets/788cf72b-267d-4e3a-9fc6-bbfe0ae11368)

#### Minimum Runway Length = 1500
![7E6C7289A9CE65D479E0C9326491D7A6](https://github.com/user-attachments/assets/e14dd271-f716-43d2-ad54-b8a6f5e720a7)

#### Minimum Runway Length = 1500
![ADF8ED89184ABE6D2379DC592B16B828](https://github.com/user-attachments/assets/6086654f-cebf-4559-8c06-d4a237d5b466)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
I will try to work on the default values for this setting to be separate for A32NX/A380X. It's my first PR on the opensource community, feel free to comment on the coding styles, implementations or anything :)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): pzb-85

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
