### PR TITLE
fix(A380X/PFD): Fix CPT VV button turning on VV on both PFDs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -50,6 +50,7 @@
 1. [A380X/PFD] Add T/D Reached PFD message - @BravoMike99 (bruno_pt99)
 1. [A380X/CAMERA] Showcase & pilot view camera fixes @LunakisDev (LunakisLeaks)
 1. [A380X/LIGHTS] Added cockpit ambient bounce lights - @ImenesFBW (Imenes)
+1. [A380X/PFD] Fix CP VV button turning on VV on both PFDs - @heclak (Heclak)
 
 ## 0.12.0
 

--- a/fbw-a380x/src/systems/instruments/src/PFD/FlightPathVector.tsx
+++ b/fbw-a380x/src/systems/instruments/src/PFD/FlightPathVector.tsx
@@ -34,7 +34,7 @@ export class FlightPathVector extends DisplayComponent<{ bus: EventBus }> {
   private readonly isBirdBlack = this.isTrkFpaActive.map(SubscribableMapFunctions.not());
 
   private readonly isVelocityVectorActive = ConsumerSubject.create(
-    this.sub.on(getDisplayIndex() === 2 ? 'fcuRightVelocityVectorOn' : 'fcuLeftVelocityVectorOn'),
+    this.sub.on(getDisplayIndex() === 3 ? 'fcuRightVelocityVectorOn' : 'fcuLeftVelocityVectorOn'),
     false,
   );
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9237

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

* fix VV display logic caused by incorrect duID checks. CPT VV button was turning on the VV on both PFDs. Both CPT and FO VV buttons will now turn on their respective PFDs only.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![image](https://github.com/user-attachments/assets/2d151609-5052-488f-8568-2aa8e876ad86)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

![image](https://github.com/user-attachments/assets/9c00f597-2b48-4cec-b85c-bd5683571557)

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

During the debugging process, I found the same function getDisplayIndex declared 4 times in different files with 3 different variants. One of them in PFD.tsx returns a different value from the other declarations, this might be due for the refactor to standardise/collect the declaration into a common function instead to avoid more issues in the future.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Heclak

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Press the CPT VV pb on the CPT EFIS CP, only the CPT PFD VV should be toggled on/off
2. Press the FO VV pb on the FO EFIS CP, only the FO PFD VV should be toggled on/off

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
