### PR TITLE
fix(cdu): correct tmply fpln activation logic in airways page

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -65,7 +65,7 @@
 1. [FMS] Fix T/D not showing in selected speed - @BlueberryKing (BlueberryKing)
 1. [FMS] Fix Pause at T/D not working in selected speed - @BlueberryKing (BlueberryKing)
 1. [MISC] Replaced brake temperature simulation with physics based model of brakes - @Gurgel100 (Pascal)
-1. [A32NX/MCDU] Suppress TMPY FPLN when no modifications made in airways page - @robertxing2004 (robeet)
+1. [A32NX/MCDU] Correct TMPY FPLN activation logic in airways page - @robertxing2004 (robeet)
 
 ## 0.12.0
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
@@ -98,11 +98,17 @@ class A320_Neo_CDU_AirwaysFromWaypointPage {
                     rows[i] = [`${pendingAirway.ident}[color]cyan`, "[\xa0\xa0\xa0][color]cyan"];
 
                     mcdu.onRightInput[i] = (value, scratchpadCallback) => {
-                        const targetPlan = mcdu.flightPlan(forPlan, inAlternate);
+                        const currentPlan = mcdu.flightPlan(forPlan, inAlternate);
 
                         if (value.length > 0) {
                             Fmgc.WaypointEntryUtils.getOrCreateWaypoint(mcdu, value, false).then(/** @param wp {import('msfs-navdata').Fix | undefined} */ (wp) => {
                                 if (wp) {
+                                    if (!currentPlan.pendingAirways) {
+                                        mcdu.flightPlanService.startAirwayEntry(prevFpIndex, forPlan, inAlternate);
+                                    }
+
+                                    const targetPlan = mcdu.flightPlan(forPlan, inAlternate);
+                                    targetPlan.pendingAirways.thenAirway(pendingAirway);
                                     const result = targetPlan.pendingAirways.thenTo(wp);
 
                                     A320_Neo_CDU_AirwaysFromWaypointPage.ShowPage(mcdu, reviseIndex, undefined, result ? 1 : -1, forPlan, inAlternate);

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
@@ -164,20 +164,6 @@ class A320_Neo_CDU_AirwaysFromWaypointPage {
      * @param plan {FlightPlan}
      */
     static _GetAllRows(plan) {
-
-        //  const allRows = [];
-        //  const elements = plan.pendingAirways.elements;
-
-        //  for (let i = 0; i < elements.length; i++) {
-        //      const element = elements[i];
-
-        //      if (element.to) {
-        //          allRows.push([`{cyan}${element.airway.ident}{end}`, `{cyan}${element.isAutoConnected ? '{small}' : '{big}'}${element.to.ident}{end}{end}`, element.to.databaseId, i]);
-        //      }
-        //  }
-
-        //  return allRows;
-
         const allRows = [];
 
         if (plan.pendingAirways) {

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
@@ -124,11 +124,17 @@ class A320_Neo_CDU_AirwaysFromWaypointPage {
                         subRows[i + 1] = ["\xa0VIA", ""];
 
                         mcdu.onLeftInput[i + 1] = async (value, scratchpadCallback) => {
-                            const targetPlan = mcdu.flightPlan(forPlan, inAlternate);
+                            const currentPlan = mcdu.flightPlan(forPlan, inAlternate);
 
                             if (value.length > 0) {
                                 const airway = await this._getFirstIntersection(mcdu, pendingAirway, prevIcao, value).catch(console.error);
                                 if (airway) {
+                                    if (!currentPlan.pendingAirways) {
+                                        mcdu.flightPlanService.startAirwayEntry(prevFpIndex, forPlan, inAlternate);
+                                    }
+
+                                    const targetPlan = mcdu.flightPlan(forPlan, inAlternate);
+                                    targetPlan.pendingAirways.thenAirway(pendingAirway);
                                     const result = targetPlan.pendingAirways.thenAirway(airway);
 
                                     A320_Neo_CDU_AirwaysFromWaypointPage.ShowPage(mcdu, reviseIndex, airway, result ? 1 : -1, forPlan, inAlternate);

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
@@ -76,15 +76,15 @@ class A320_Neo_CDU_AirwaysFromWaypointPage {
                         const targetPlan = mcdu.flightPlan(forPlan, inAlternate);
 
                         if (value.length > 0) {
-                            const elements = targetPlan.pendingAirways.elements;
-                            const tailElement = elements[elements.length - 1];
+                            const elements = (targetPlan.pendingAirways && targetPlan.pendingAirways.elements) || undefined;
+                            const tailElement = elements ? elements[elements.length - 1] : undefined;
 
                             const lastFix = tailElement ? tailElement.to : targetPlan.legElementAt(prevFpIndex).terminationWaypoint();
 
                             const airway = await this._getAirway(mcdu, prevFpIndex, tailElement ? tailElement.airway : undefined, lastFix, value).catch(console.error);
 
                             if (airway) {
-                                const result = targetPlan.pendingAirways.thenAirway(airway);
+                                const result = elements ? targetPlan.pendingAirways.thenAirway(airway) : 1;
 
                                 A320_Neo_CDU_AirwaysFromWaypointPage.ShowPage(mcdu, reviseIndex, airway, result ? 1 : -1, forPlan, inAlternate);
                             } else {
@@ -158,14 +158,31 @@ class A320_Neo_CDU_AirwaysFromWaypointPage {
      * @param plan {FlightPlan}
      */
     static _GetAllRows(plan) {
+
+        //  const allRows = [];
+        //  const elements = plan.pendingAirways.elements;
+
+        //  for (let i = 0; i < elements.length; i++) {
+        //      const element = elements[i];
+
+        //      if (element.to) {
+        //          allRows.push([`{cyan}${element.airway.ident}{end}`, `{cyan}${element.isAutoConnected ? '{small}' : '{big}'}${element.to.ident}{end}{end}`, element.to.databaseId, i]);
+        //      }
+        //  }
+
+        //  return allRows;
+
         const allRows = [];
-        const elements = plan.pendingAirways.elements;
 
-        for (let i = 0; i < elements.length; i++) {
-            const element = elements[i];
+        if (plan.pendingAirways) {
+            const elements = plan.pendingAirways.elements;
 
-            if (element.to) {
-                allRows.push([`{cyan}${element.airway.ident}{end}`, `{cyan}${element.isAutoConnected ? '{small}' : '{big}'}${element.to.ident}{end}{end}`, element.to.databaseId, i]);
+            for (let i = 0; i < elements.length; i++) {
+                const element = elements[i];
+
+                if (element.to) {
+                    allRows.push([`{cyan}${element.airway.ident}{end}`, `{cyan}${element.isAutoConnected ? '{small}' : '{big}'}${element.to.ident}{end}{end}`, element.to.databaseId, i]);
+                }
             }
         }
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
@@ -17,10 +17,6 @@ class A320_Neo_CDU_AirwaysFromWaypointPage {
         let prevIcao = waypoint.definition.waypoint.databaseId;
         let prevFpIndex = reviseIndex;
 
-        if (!targetPlan.pendingAirways) {
-            mcdu.flightPlanService.startAirwayEntry(reviseIndex, forPlan, inAlternate);
-        }
-
         const rows = [["----"], [""], [""], [""], [""]];
         const subRows = [["VIA", ""], [""], [""], [""], [""]];
         const allRows = lastIndex ? A320_Neo_CDU_AirwaysFromWaypointPage._GetAllRows(targetPlan) : [];


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Extension of #9148

The airways page now only creates a tmpy fpln after a valid segment is entered; either an airway and a terminating waypoint, or an airway followed by an intersecting airway. Prior to either of these two conditions being met, there is no pending flight plan, and pressing return will not result in a false tmpy state on the fpln page.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
While troubleshooting this issue, I discovered bugs #9560 and #9561, but as it stands this PR only fixes the tmpy fpln activation logic. Those bugs can be addressed in a separate PR.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
robeet

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Spawn anywhere and start a fpln from the mcdu
2. After entering a STAR and transition, enter the airways page and make modifications
3. Verify that there is no option to erase or insert until a terminating waypoint or intersecting airway has been entered
4. Returning any time before the above two conditions should not create a tmpy fpln

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
