### PR TITLE
fix(fcu-api): fix KOHLSMANN_SET and custom baro set events

### DIFF
--- a/fbw-a32nx/docs/a320-events.md
+++ b/fbw-a32nx/docs/a320-events.md
@@ -152,7 +152,7 @@
 
 - A32NX.FCU_EFIS_{side}_BARO_SET
     - Triggered to set the baro value on FCU
-    - Value is expected as the first parameter, in hPa.
+    - Value is expected as the first parameter, in hPa * 16 (i.e. with a factor 16 applied, same as KOHLSMANN_SET).
     - side = L, R
 
 - A32NX.FCU_EFIS_{side}_BARO_PUSH

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
@@ -2114,8 +2114,8 @@ void SimConnectInterface::processEvent(const DWORD eventId, const DWORD data0, c
     }
 
     case Events::A32NX_FCU_EFIS_L_BARO_SET: {
-      simInputAutopilot.baro_left_set = static_cast<long>(data0);
-      simInputAutopilot.baro_right_set = static_cast<long>(data0);
+      simInputAutopilot.baro_left_set = static_cast<long>(data0) / 16.;
+      simInputAutopilot.baro_right_set = static_cast<long>(data0) / 16.;
       std::cout << "WASM: event triggered: A32NX_FCU_EFIS_L_BARO_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }
@@ -2210,8 +2210,8 @@ void SimConnectInterface::processEvent(const DWORD eventId, const DWORD data0, c
     }
 
     case Events::A32NX_FCU_EFIS_R_BARO_SET: {
-      simInputAutopilot.baro_left_set = static_cast<long>(data0);
-      simInputAutopilot.baro_right_set = static_cast<long>(data0);
+      simInputAutopilot.baro_left_set = static_cast<long>(data0) / 16.;
+      simInputAutopilot.baro_right_set = static_cast<long>(data0) / 16.;
       std::cout << "WASM: event triggered: A32NX_FCU_EFIS_R_BARO_SET: " << static_cast<long>(data0) << std::endl;
       break;
     }

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
@@ -2103,8 +2103,8 @@ void SimConnectInterface::processEvent(const DWORD eventId, const DWORD data0, c
 
     case Events::KOHLSMANN_SET: {
       if (data1 == 0 || data1 == 1) {
-        simInputAutopilot.baro_left_set = data0;
-        simInputAutopilot.baro_right_set = data0;
+        simInputAutopilot.baro_left_set = data0 / 16.;
+        simInputAutopilot.baro_right_set = data0 / 16.;
       }
       if (data1 != 1) {
         sendEventEx1(KOHLSMANN_SET, SIMCONNECT_GROUP_PRIORITY_STANDARD, data0, data1);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Adds missing /16 factor for KOHLSMANN_SET, and also add the same factor to the custom event, to facilitate setting inHg with four significant digits.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
