### PR TITLE
feat(efb): Set default efb auto brightness on

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -85,6 +85,7 @@
 1. [A380X/LIGHTS] Fix function of FCU brightness knobs - @heclak (Heclak)
 1. [A380X/FWS] Fix "NO ZFW OR ZFWCG DATA" ECAM alert after landing - @flogross89 (floridude)
 1. [A380X/SD] Add brake temperature color change to amber when brakes are hot - @heclak (Heclak)
+1. [EFB] Set EFB Auto Brightness to default to On - @MrJigs7 (MrJigs)
 
 
 ## 0.12.0

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/FlyPadPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/FlyPadPage.tsx
@@ -17,7 +17,7 @@ import { languageOptions, tt } from '../../Localization/translation';
 export const FlyPadPage = () => {
   const [brightnessSetting, setBrightnessSetting] = usePersistentNumberProperty('EFB_BRIGHTNESS', 0);
   const [brightness] = useSimVar('L:A32NX_EFB_BRIGHTNESS', 'number', 500);
-  const [usingAutobrightness, setUsingAutobrightness] = usePersistentNumberProperty('EFB_USING_AUTOBRIGHTNESS', 0);
+  const [usingAutobrightness, setUsingAutobrightness] = usePersistentNumberProperty('EFB_USING_AUTOBRIGHTNESS', 1);
   const [theme, setTheme] = usePersistentProperty('EFB_UI_THEME', 'blue');
   const [autoOSK, setAutoOSK] = usePersistentNumberProperty('EFB_AUTO_OSK', 0);
   const [timeDisplayed, setTimeDisplayed] = usePersistentProperty('EFB_TIME_DISPLAYED', 'utc');

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/sync.ts
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/sync.ts
@@ -37,7 +37,7 @@ export const globalSyncedSettings: SyncedSettingDefinition[] = [
     configKey: 'EFB_USING_AUTOBRIGHTNESS',
     localVarName: 'L:A32NX_EFB_USING_AUTOBRIGHTNESS',
     localVarUnit: 'bool',
-    defaultValue: '0',
+    defaultValue: '1',
   },
   { configKey: 'CABIN_MANUAL_BRIGHTNESS', localVarName: 'L:A32NX_CABIN_MANUAL_BRIGHTNESS', defaultValue: '0' },
   {

--- a/fbw-common/src/systems/instruments/src/EFB/StatusBar/QuickControls.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/StatusBar/QuickControls.tsx
@@ -176,7 +176,7 @@ export const QuickControlsPane = ({
 
   const [brightnessSetting, setBrightnessSetting] = usePersistentNumberProperty('EFB_BRIGHTNESS', 0);
   const [brightness] = useSimVar('L:A32NX_EFB_BRIGHTNESS', 'number', 500);
-  const [usingAutobrightness, setUsingAutobrightness] = usePersistentNumberProperty('EFB_USING_AUTOBRIGHTNESS', 0);
+  const [usingAutobrightness, setUsingAutobrightness] = usePersistentNumberProperty('EFB_USING_AUTOBRIGHTNESS', 1);
   const [cabinAutoBrightness] = useSimVar('L:A32NX_CABIN_AUTOBRIGHTNESS', 'number', 500);
   const [cabinManualBrightness, setCabinManualBrightness] = usePersistentNumberProperty('CABIN_MANUAL_BRIGHTNESS', 0);
   const [usingCabinAutobrightness, setUsingCabinAutobrightness] = usePersistentNumberProperty(


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9630 

## Summary of Changes
Updated EFB so auto brightness defaults to on

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
MrJigs

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Load aircraft
2. Power on EFB if necessary, check auto brightness is set to on in Flypad settings and quick settings

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
