### PR TITLE
fix(a380x/fms): Fix VLS computation for CONF 1

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -86,6 +86,7 @@
 1. [A380X/FWS] Fix "NO ZFW OR ZFWCG DATA" ECAM alert after landing - @flogross89 (floridude)
 1. [A380X/SD] Add brake temperature color change to amber when brakes are hot - @heclak (Heclak)
 1. [A380X/FCU] Fix display of values on FCU during light test - @heclak (Heclak)
+1. [A380X/FMS] Fix VLS computation error for CONF 1, might have lead to FMS crashes during climb out - @flogross89 (floridude)
 
 ## 0.12.0
 

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcAircraftInterface.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcAircraftInterface.ts
@@ -1178,14 +1178,10 @@ export class FmcAircraftInterface {
       // Only update speeds if ADR data valid
 
       const flapLever = SimVar.GetSimVarValue('L:A32NX_FLAPS_HANDLE_INDEX', 'Enum');
-      let flaps = flapLever;
-      if (flapLever === 1 && SimVar.GetSimVarValue('L:A32NX_FLAPS_CONF_INDEX', 'Enum') === 1) {
-        flaps = 5; // CONF 1
-      }
       const speeds = new A380OperatingSpeeds(
         grossWeight,
         cas,
-        flaps,
+        flapLever,
         this.flightPhase.get(),
         this.fmgc.getV2Speed(),
         alt,
@@ -1199,10 +1195,10 @@ export class FmcAircraftInterface {
         const f = Math.max(speeds.f2, Vmcl + 5);
         this.fmgc.data.flapRetractionSpeed.set(Math.ceil(f));
       } else {
-        if (flaps === 2) {
+        if (flapLever === 2) {
           const f = Math.max(speeds.f2, Vmcl + 15);
           this.fmgc.data.flapRetractionSpeed.set(Math.ceil(f));
-        } else if (flaps === 3) {
+        } else if (flapLever === 3) {
           const f = Math.max(speeds.f3, Vmcl + 10);
           this.fmgc.data.flapRetractionSpeed.set(Math.ceil(f));
         }

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcAircraftInterface.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcAircraftInterface.ts
@@ -1116,7 +1116,7 @@ export class FmcAircraftInterface {
     const altActive = false;
     const landingWeight =
       this.fmgc.data.zeroFuelWeight.get() ??
-      NaN + (altActive ? this.fmgc.getAltEFOB(true) : this.fmgc.getDestEFOB(true));
+      NaN + (altActive ? this.fmgc.getAltEFOB(true) : this.fmgc.getDestEFOB(true)) * 1_000;
 
     return Number.isFinite(landingWeight) ? landingWeight : NaN;
   }
@@ -1128,7 +1128,7 @@ export class FmcAircraftInterface {
     /** in kg */
     const estLdgWeight = this.tryEstimateLandingWeight();
     let ldgWeight = estLdgWeight;
-    const grossWeight = this.fmc.fmgc.getGrossWeightKg() ?? maxZfw + this.fmc.fmgc.getFOB();
+    const grossWeight = this.fmc.fmgc.getGrossWeightKg() ?? maxZfw + this.fmc.fmgc.getFOB() * 1_000;
     const vnavPrediction = this.fmc.guidanceController?.vnavDriver?.getDestinationPrediction();
     // Actual weight is used during approach phase (FCOM bulletin 46/2), and we also assume during go-around
     if (this.flightPhase.get() >= FmgcFlightPhase.Approach || !Number.isFinite(estLdgWeight)) {

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/fmgc.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/fmgc.ts
@@ -564,7 +564,7 @@ export class FmgcDataService implements Fmgc {
     return this.data.approachTemperature.get() ?? 0;
   }
 
-  /** in kilograms */
+  /** in tons */
   getDestEFOB(useFob: boolean): number {
     // Metric tons
     const efob = this.guidanceController?.vnavDriver?.getDestinationPrediction()?.estimatedFuelOnBoard; // in Pounds
@@ -574,7 +574,7 @@ export class FmgcDataService implements Fmgc {
     return 0;
   }
 
-  /** in kilograms */
+  /** in tons */
   getAltEFOB(useFOB = false): number {
     // TODO estimate alternate fuel
     if (this.getDestEFOB(useFOB) === 0) {

--- a/fbw-a380x/src/systems/shared/src/OperatingSpeeds.tsx
+++ b/fbw-a380x/src/systems/shared/src/OperatingSpeeds.tsx
@@ -515,13 +515,12 @@ export class A380OperatingSpeeds {
     this.f2 =
       fmgcFlightPhase <= FmgcFlightPhase.Takeoff
         ? Math.max(1.18 * vs1gConf1F, Vmcl + 5)
-        : SpeedsLookupTables.F2_SPEED.get(altitude, m);
+        : SpeedsLookupTables.F2_SPEED.get(cg, m);
     this.f3 =
       fmgcFlightPhase <= FmgcFlightPhase.Takeoff
         ? Math.max(1.18 * vs1gConf1F, Vmcl + 5)
-        : SpeedsLookupTables.F3_SPEED.get(altitude, m);
-    this.s =
-      fmgcFlightPhase <= FmgcFlightPhase.Takeoff ? 1.21 * vs1gConf0 : SpeedsLookupTables.S_SPEED.get(altitude, m);
+        : SpeedsLookupTables.F3_SPEED.get(cg, m);
+    this.s = fmgcFlightPhase <= FmgcFlightPhase.Takeoff ? 1.21 * vs1gConf0 : SpeedsLookupTables.S_SPEED.get(m);
   }
 }
 

--- a/fbw-a380x/src/systems/shared/src/OperatingSpeeds.tsx
+++ b/fbw-a380x/src/systems/shared/src/OperatingSpeeds.tsx
@@ -119,6 +119,9 @@ export class SpeedsLookupTables {
     if (conf === 0) {
       return SpeedsLookupTables.VLS_CONF_0.get(0, weight);
     } else {
+      if (conf > 5) {
+        throw new Error('Invalid flap config for approach VLS computation');
+      }
       return SpeedsLookupTables.VLS_APPR_CONF[conf].get(cg, weight);
     }
   }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9609 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes MFD/FMS error when selecting CONF 1, might crash the FMS on climb

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
