### PR TITLE
Fix git build info for checklist Workflow

### DIFF
--- a/scripts/git_build_info.js
+++ b/scripts/git_build_info.js
@@ -33,6 +33,13 @@ const getReleaseName = (commitHash, branch, tag) => {
 exports.getGitBuildInfo = () => {
   // all git commands are wrapped in a try block so the build can still succeed outside of a git repo.
   try {
+    try {
+      // set safe.directory to avoid errors
+      evaluate('git config --global --add safe.directory /external');
+    } catch (e) {
+      console.log('Failed to set safe.directory', e);
+    }
+
     const commitHash = process.env.GITHUB_SHA ? process.env.GITHUB_SHA : evaluate('git show-ref -s HEAD');
     let tag = '';
     try {


### PR DESCRIPTION
Fixes #9592 

## Summary of Changes
This pull request introduces a change to the `scripts/git_build_info.js` file to enhance the build process by configuring the Git safe directory.

Build process improvement:

* [`scripts/git_build_info.js`](diffhunk://#diff-aa0fca80bc1d8b22518942d65dcdffe89aba6875c6322c6a345921cb0c384bb5R36-R42): Added a try block to set the Git safe directory to `/external` to avoid errors when running git commands outside of a git repository. This ensures the build process can proceed smoothly even in different environments.

## Screenshots (if necessary)


## References


## Additional context
Execution of the Workflow "Build InGamePanels Chechlist Fix" is failing:
https://github.com/flybywiresim/aircraft/actions/runs/11999917978/job/33448395480#step:6:34

The issue is: "`Git failed Error: Command failed: git rev-parse --abbrev-ref HEAD`"

Executing the command manually in the container reveals the issue:
```
michelz@BEASTLI:/mnt/g/MIZE/dev/GitHub/flybywiresim-aircraft$ ./scripts/dev-env/run.sh git show-ref -s HEAD
fatal: detected dubious ownership in repository at '/external'
To add an exception for this directory, call:

        git config --global --add safe.directory /external
```

which is then fixed when using the mentioned command:
```
michelz@BEASTLI:/mnt/g/MIZE/dev/GitHub/flybywiresim-aircraft$ ./scripts/dev-env/run.sh git config --global --add safe.directory /external && git show-ref -s HEAD
33c4a62f9e8074ad140848c399072f46dd880c69
```

## Testing instructions
- Execute the commands in the Workflow template, e.g.:
```
./scripts/dev-env/run.sh ./scripts/setup.sh --clean
./scripts/dev-env/run.sh ./scripts/build_ingamepanels_checklist_fix.sh --no-tty -j 4
./scripts/dev-env/run.sh node ./scripts/fragment-ingamepanels-checklist-fix.js
```
This will fail in master and will succeed in this PR branch

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
