### PR TITLE
fix(a32nx/pfd): Fix baro radio text rendering overlapped

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -87,6 +87,7 @@
 1. [A380X/SD] Add brake temperature color change to amber when brakes are hot - @heclak (Heclak)
 1. [A380X/FCU] Fix display of values on FCU during light test - @heclak (Heclak)
 1. [A380X/FMS] Fix VLS computation error for CONF 1, might have lead to FMS crashes during climb out - @flogross89 (floridude)
+1. [A32NX/PFD] Fix Radio DH not displaying correctly when Baro DA is already entered - @MrJigs7 (MrJigs)
 
 ## 0.12.0
 

--- a/fbw-a32nx/src/systems/instruments/src/PFD/FMA.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/FMA.tsx
@@ -1737,6 +1737,10 @@ class D3Cell extends DisplayComponent<{ bus: ArincEventBus }> {
     this.dh,
     this.mda,
   );
+  private readonly DhModexPos = MappedSubject.create(
+    ([noDhSelected]) => (noDhSelected ? 118.38384 : 104.75),
+    this.noDhSelected,
+  );
 
   onAfterRender(node: VNode): void {
     super.onAfterRender(node);
@@ -1754,17 +1758,19 @@ class D3Cell extends DisplayComponent<{ bus: ArincEventBus }> {
         ref={this.textRef}
         class={{
           FontSmallest: this.noDhSelected.map(SubscribableMapFunctions.not()),
+          StartAlign: this.noDhSelected.map(SubscribableMapFunctions.not()),
           FontMedium: this.noDhSelected,
-          MiddleAlign: true,
+          MiddleAlign: this.noDhSelected,
           White: true,
         }}
-        x="118.38384"
+        x={this.DhModexPos}
         y="21.104172"
       >
         <tspan>{this.mdaDhMode}</tspan>
         <tspan
-          class={{ Cyan: true, HiddenElement: this.mdaDhValueText.map((v) => v.length <= 0) }}
-          style="white-space: pre"
+          class={{ EndAlign: true, Cyan: true, HiddenElement: this.mdaDhValueText.map((v) => v.length <= 0) }}
+          x="132.25"
+          y="21.104172"
         >
           {this.mdaDhValueText}
         </tspan>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9546 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Added MappedSubject to handle rendering X position correctly depending on if noDhSelected true\false
Added alignment classes depending on if noDhSelected true\false
Added alignment to MdaDhValue
Updated X pos of mdaDhMode
Updated X pos of MdaDhValue

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![Baro DA](https://github.com/user-attachments/assets/d1f3c0c3-f6a9-4c21-95de-d00a121c039a)
![Radio DA](https://github.com/user-attachments/assets/750067aa-16f9-4586-b1c1-8648735b8ff6)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![Reference image](https://github.com/user-attachments/assets/12b564b9-d84d-4819-97a5-2a85a8c5637d)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): MrJigs

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Load aircraft, flightplan, weights etc
2. Depart and activate APPR phase
3. Enter baro decision altitude on APPR page, check display
4. Enter radio decision height on APPR page, check display
5. Fly approach with neither baro or radio minimums set to check no dh

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
