### PR TITLE
feat(fms): implement TOO STEEP PATH

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/components/fms-messages/FmsMessages.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/components/fms-messages/FmsMessages.ts
@@ -24,6 +24,7 @@ import { GpsPrimaryLost } from './GpsPrimaryLost';
 import { MapPartlyDisplayedLeft, MapPartlyDisplayedRight } from './MapPartlyDisplayed';
 import { Navigation } from '@fmgc/navigation/Navigation';
 import { GuidanceController } from '@fmgc/guidance/GuidanceController';
+import { TooSteepPathAhead } from '@fmgc/components/fms-messages/TooSteepPathAhead';
 
 /**
  * This class manages Type II messages sent from the FMGC.
@@ -63,6 +64,7 @@ export class FmsMessages implements FmgcComponent {
     new TdReached(),
     new StepAhead(),
     new StepDeleted(),
+    new TooSteepPathAhead(),
   ];
 
   init(navigation: Navigation, guidanceController: GuidanceController, flightPlanService: FlightPlanService): void {

--- a/fbw-a32nx/src/systems/fmgc/src/components/fms-messages/TooSteepPathAhead.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/components/fms-messages/TooSteepPathAhead.ts
@@ -6,6 +6,8 @@ import { GuidanceController } from '@fmgc/guidance/GuidanceController';
 import { FMMessageTypes } from '@flybywiresim/fbw-sdk';
 
 import { FMMessageSelector, FMMessageUpdate } from './FmsMessages';
+import { FlightPlanService } from '../../flightplanning/FlightPlanService';
+import { Navigation } from '../../navigation/Navigation';
 
 export class TooSteepPathAhead implements FMMessageSelector {
   message = FMMessageTypes.TooSteepPathAhead;
@@ -14,8 +16,8 @@ export class TooSteepPathAhead implements FMMessageSelector {
 
   private lastState = false;
 
-  init(baseInstrument: BaseInstrument): void {
-    this.guidanceController = baseInstrument.guidanceController;
+  init(_navigation: Navigation, guidanceController: GuidanceController, _flightPlanService: FlightPlanService): void {
+    this.guidanceController = guidanceController;
   }
 
   process(_: number): FMMessageUpdate {

--- a/fbw-a32nx/src/systems/fmgc/src/components/fms-messages/TooSteepPathAhead.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/components/fms-messages/TooSteepPathAhead.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2021-2023 FlyByWire Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
+import { GuidanceController } from '@fmgc/guidance/GuidanceController';
+import { FMMessageTypes } from '@flybywiresim/fbw-sdk';
+
+import { FMMessageSelector, FMMessageUpdate } from './FmsMessages';
+
+export class TooSteepPathAhead implements FMMessageSelector {
+  message = FMMessageTypes.TooSteepPathAhead;
+
+  private guidanceController: GuidanceController;
+
+  private lastState = false;
+
+  init(baseInstrument: BaseInstrument): void {
+    this.guidanceController = baseInstrument.guidanceController;
+  }
+
+  process(_: number): FMMessageUpdate {
+    const newState = this.guidanceController.vnavDriver.shouldShowTooSteepPathAhead();
+
+    if (newState !== this.lastState) {
+      this.lastState = newState;
+
+      return newState ? FMMessageUpdate.SEND : FMMessageUpdate.RECALL;
+    }
+
+    return FMMessageUpdate.NO_ACTION;
+  }
+}

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/legs/FlightPlanLeg.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/legs/FlightPlanLeg.ts
@@ -63,6 +63,8 @@ export interface LegCalculations {
   cumulativeDistanceWithTransitions: number;
   /** The cumulative distance in nautical miles from this point to the missed approach point, with leg transition turns taken into account. */
   cumulativeDistanceToEndWithTransitions: number;
+  /** Whether the leg terminates in a vertical discontinuity */
+  endsInTooSteepPath: boolean;
 }
 
 /**

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/plans/FlightPlan.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/plans/FlightPlan.ts
@@ -644,4 +644,23 @@ export class FlightPlan<P extends FlightPlanPerformanceData = FlightPlanPerforma
 
     return false;
   }
+
+  /**
+   * Check if there is a TOO STEEP PATH segment on a leg after the active leg
+   * @returns true if there is a TOO STEEP PATH segment
+   */
+  hasTooSteepPathAhead(): boolean {
+    for (let i = this.activeLegIndex; i < this.firstMissedApproachLegIndex; i++) {
+      const element = this.maybeElementAt(i);
+      if (element?.isDiscontinuity === true) {
+        continue;
+      }
+
+      if (element?.calculated?.endsInTooSteepPath) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 }

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/Geometry.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/Geometry.ts
@@ -557,14 +557,16 @@ export class Geometry {
         cumulativeDistance += distance;
         cumulativeDistanceWithTransitions += distanceWithTransitions;
 
-        flightPlanLeg.calculated = {
-          distance,
-          distanceWithTransitions,
-          cumulativeDistance,
-          cumulativeDistanceWithTransitions,
-          cumulativeDistanceToEnd: undefined,
-          cumulativeDistanceToEndWithTransitions: undefined,
-        };
+        if (!flightPlanLeg.calculated) {
+          this.initializeCalculatedDistances(flightPlanLeg, geometryLeg);
+        }
+
+        flightPlanLeg.calculated.distance = distance;
+        flightPlanLeg.calculated.distanceWithTransitions = distanceWithTransitions;
+        flightPlanLeg.calculated.cumulativeDistance = cumulativeDistance;
+        flightPlanLeg.calculated.cumulativeDistanceWithTransitions = cumulativeDistanceWithTransitions;
+        flightPlanLeg.calculated.cumulativeDistanceToEnd = undefined;
+        flightPlanLeg.calculated.cumulativeDistanceToEndWithTransitions = undefined;
 
         geometryLeg.calculated = flightPlanLeg.calculated;
       }
@@ -586,6 +588,7 @@ export class Geometry {
       cumulativeDistanceWithTransitions: 0,
       cumulativeDistanceToEnd: undefined,
       cumulativeDistanceToEndWithTransitions: undefined,
+      endsInTooSteepPath: false,
     };
 
     if (geometryLeg) {

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/ConstraintReader.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/ConstraintReader.ts
@@ -132,6 +132,7 @@ export class ConstraintReader {
               this.descentAltitudeConstraints.push({
                 distanceFromStart: legDistanceFromStart,
                 constraint: altConstraint,
+                leg,
               });
               break;
             default:

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VerticalProfileManager.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VerticalProfileManager.ts
@@ -747,6 +747,21 @@ export class VerticalProfileManager {
         return managedClimbSpeedMach;
     }
   }
+
+  shouldShowTooSteepPathAhead(): boolean {
+    const isManagedLateralMode = this.fcuModes.isLatAutoControlActive();
+    const flightPhase = this.observer.get().flightPhase;
+    const isDesOrApprPhase = flightPhase === FmgcFlightPhase.Descent || flightPhase === FmgcFlightPhase.Approach;
+    const isCruisePhase = flightPhase === FmgcFlightPhase.Cruise;
+    const isCloseToDestination =
+      ((this.constraintReader.distanceToEnd ?? Infinity) > 150 && isCruisePhase) || isDesOrApprPhase;
+
+    if (!isManagedLateralMode || !isCloseToDestination) {
+      return false;
+    }
+
+    return this.flightPlanService.active?.hasTooSteepPathAhead();
+  }
 }
 
 class FcuModeObserver {
@@ -754,7 +769,9 @@ class FcuModeObserver {
     LateralMode.NAV,
     LateralMode.LOC_CPT,
     LateralMode.LOC_TRACK,
+    LateralMode.LAND,
     LateralMode.RWY,
+    LateralMode.GA_TRACK,
   ];
 
   private VERT_CLIMB_MODES: VerticalMode[] = [

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VnavDriver.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VnavDriver.ts
@@ -32,6 +32,7 @@ import {
 } from './profile/NavGeometryProfile';
 import { VMLeg } from '@fmgc/guidance/lnav/legs/VM';
 import { FMLeg } from '@fmgc/guidance/lnav/legs/FM';
+import { MathUtils } from '@flybywiresim/fbw-sdk';
 
 export class VnavDriver implements GuidanceComponent {
   version: number = 0;
@@ -288,11 +289,10 @@ export class VnavDriver implements GuidanceComponent {
 
       const isPastCstrDeceleration =
         checkpoint.reason === VerticalCheckpointReason.StartDecelerationToConstraint &&
-        currentDistanceFromStart - checkpoint.distanceFromStart > -1e-4;
+        MathUtils.isCloseToGreaterThan(currentDistanceFromStart, checkpoint.distanceFromStart);
       const isPastLimitDeceleration =
         checkpoint.reason === VerticalCheckpointReason.StartDecelerationToLimit &&
-        currentAltitude - checkpoint.altitude < 1e-4;
-
+        MathUtils.isCloseToLessThan(currentAltitude, checkpoint.altitude);
       if (
         isSpeedChangePoint(checkpoint) &&
         checkpoint.targetSpeed >= decelPointSpeed &&

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VnavDriver.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VnavDriver.ts
@@ -630,6 +630,10 @@ export class VnavDriver implements GuidanceComponent {
       ? completeLegAlongTrackPathDtg + referenceLeg.calculated.cumulativeDistanceToEndWithTransitions
       : undefined;
   }
+
+  shouldShowTooSteepPathAhead(): boolean {
+    return this.profileManager.shouldShowTooSteepPathAhead();
+  }
 }
 
 /// To check whether the value changed from old to new, but not if both values are NaN. (NaN !== NaN in JS)

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/climb/ClimbStrategy.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/climb/ClimbStrategy.ts
@@ -338,7 +338,7 @@ export class ClimbThrustClimbStrategy implements ClimbStrategy {
       tropoPause,
       config.speedbrakesExtended,
       config.flapConfig,
-      config.speedbrakesExtended,
+      config.gearExtended,
       perfFactor,
     );
   }

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/climb/ClimbStrategy.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/climb/ClimbStrategy.ts
@@ -3,9 +3,12 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { VerticalProfileComputationParametersObserver } from '@fmgc/guidance/vnav/VerticalProfileComputationParameters';
-import { DEFAULT_AIRCRAFT_CONTROL_SURFACE_CONFIG, DescentStrategy } from '@fmgc/guidance/vnav/descent/DescentStrategy';
+import { DescentStrategy } from '@fmgc/guidance/vnav/descent/DescentStrategy';
 import { WindComponent } from '@fmgc/guidance/vnav/wind';
-import { AircraftConfiguration as AircraftCtlSurfcConfiguration } from '@fmgc/guidance/vnav/descent/ApproachPathBuilder';
+import {
+  AircraftConfiguration as AircraftCtlSurfcConfiguration,
+  DEFAULT_AIRCRAFT_CONTROL_SURFACE_CONFIG,
+} from '@fmgc/guidance/vnav/descent/ApproachPathBuilder';
 import { MathUtils } from '@flybywiresim/fbw-sdk';
 import { UnitType } from '@microsoft/msfs-sdk';
 import { AircraftConfig, EngineModelParameters } from '@fmgc/flightplanning/AircraftConfigTypes';

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/ApproachPathBuilder.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/ApproachPathBuilder.ts
@@ -100,7 +100,7 @@ export interface AircraftConfiguration {
   gearExtended: boolean;
 }
 
-export const DEFAULT_AIRCRAFT_CONTROL_SURFACE_CONFIG: AircraftConfiguration = {
+export const DEFAULT_AIRCRAFT_CONTROL_SURFACE_CONFIG: Readonly<AircraftConfiguration> = {
   flapConfig: FlapConf.CLEAN,
   speedbrakesExtended: false,
   gearExtended: false,
@@ -125,7 +125,7 @@ export const DEFAULT_AIRCRAFT_CONTROL_SURFACE_CONFIG: AircraftConfiguration = {
  * assert(config === config2);
  */
 export class AircraftConfigurationRegister {
-  private readonly config: AircraftConfiguration = DEFAULT_AIRCRAFT_CONTROL_SURFACE_CONFIG;
+  private readonly config: AircraftConfiguration = { ...DEFAULT_AIRCRAFT_CONTROL_SURFACE_CONFIG };
 
   setFromSpeed(speed: Knots, parameters: VerticalProfileComputationParameters, useSpeedbrakes = false) {
     this.config.flapConfig = FlapConfigurationProfile.getBySpeed(speed, parameters);

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/ApproachPathBuilder.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/ApproachPathBuilder.ts
@@ -369,8 +369,6 @@ export class ApproachPathBuilder {
           reason: VerticalCheckpointReason.AltitudeConstraint,
           altitude: minimumAltitude,
         });
-        // Ensure TOO STEEP PATH marker is shown after the waypoint
-        sequence.checkpoints[sequence.length - 2].distanceFromStart += 1e-4;
 
         constraint.leg.calculated.endsInTooSteepPath = true;
 

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/DescentPathBuilder.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/DescentPathBuilder.ts
@@ -2,45 +2,36 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-import {
-  DescentAltitudeConstraint,
-  MaxSpeedConstraint,
-  VerticalCheckpoint,
-  VerticalCheckpointReason,
-} from '@fmgc/guidance/vnav/profile/NavGeometryProfile';
+import { VerticalCheckpoint, VerticalCheckpointReason } from '@fmgc/guidance/vnav/profile/NavGeometryProfile';
 import { BaseGeometryProfile } from '@fmgc/guidance/vnav/profile/BaseGeometryProfile';
-import { ManagedSpeedType, SpeedProfile } from '@fmgc/guidance/vnav/climb/SpeedProfile';
+import { SpeedProfile } from '@fmgc/guidance/vnav/climb/SpeedProfile';
 import { AtmosphericConditions } from '@fmgc/guidance/vnav/AtmosphericConditions';
 import { VerticalProfileComputationParametersObserver } from '@fmgc/guidance/vnav/VerticalProfileComputationParameters';
 import { GeometricPathBuilder } from '@fmgc/guidance/vnav/descent/GeometricPathBuilder';
-import { DescentStrategy, IdleDescentStrategy } from '@fmgc/guidance/vnav/descent/DescentStrategy';
-import { StepResults } from '@fmgc/guidance/vnav/Predictions';
 import { HeadwindProfile } from '@fmgc/guidance/vnav/wind/HeadwindProfile';
 import { TemporaryCheckpointSequence } from '@fmgc/guidance/vnav/profile/TemporaryCheckpointSequence';
 import { AltitudeDescriptor, MathUtils } from '@flybywiresim/fbw-sdk';
-import { SpeedLimit } from '@fmgc/guidance/vnav/SpeedLimit';
 import { ConstraintUtils, AltitudeConstraint } from '@fmgc/flightplanning/data/constraint';
 import { AircraftConfig } from '@fmgc/flightplanning/AircraftConfigTypes';
+import { IdlePathBuilder } from '@fmgc/guidance/vnav/descent/IdlePathBuilder';
+import { GeometricPathPlanner, PlannedGeometricSegment } from '@fmgc/guidance/vnav/descent/GeometricPathPlanner';
 
 export class DescentPathBuilder {
   private geometricPathBuilder: GeometricPathBuilder;
 
-  private idleDescentStrategy: DescentStrategy;
+  private idlePathBuilder: IdlePathBuilder;
 
   constructor(
-    private computationParametersObserver: VerticalProfileComputationParametersObserver,
-    private atmosphericConditions: AtmosphericConditions,
+    computationParametersObserver: VerticalProfileComputationParametersObserver,
+    atmosphericConditions: AtmosphericConditions,
     private readonly acConfig: AircraftConfig,
   ) {
+    this.idlePathBuilder = new IdlePathBuilder(computationParametersObserver, atmosphericConditions, this.acConfig);
+
     this.geometricPathBuilder = new GeometricPathBuilder(
       computationParametersObserver,
       atmosphericConditions,
-      this.acConfig,
-    );
-
-    this.idleDescentStrategy = new IdleDescentStrategy(
-      computationParametersObserver,
-      atmosphericConditions,
+      this,
       this.acConfig,
     );
   }
@@ -51,6 +42,7 @@ export class DescentPathBuilder {
     speedProfile: SpeedProfile,
     windProfile: HeadwindProfile,
     cruiseAltitude: Feet,
+    toDistance: NauticalMiles = -Infinity,
   ) {
     const TOL = 10;
     const decelPoint: VerticalCheckpoint = { ...sequence.lastCheckpoint };
@@ -58,12 +50,22 @@ export class DescentPathBuilder {
     const geometricSequence = new TemporaryCheckpointSequence(decelPoint);
     const idleSequence = new TemporaryCheckpointSequence(decelPoint);
 
-    this.buildIdlePath(idleSequence, profile, speedProfile, windProfile, cruiseAltitude);
+    this.idlePathBuilder.buildIdlePath(
+      idleSequence,
+      profile.descentSpeedConstraints,
+      speedProfile,
+      windProfile,
+      cruiseAltitude,
+      toDistance,
+    );
 
     for (let i = profile.descentAltitudeConstraints.length - 1; i >= 0; i -= 1) {
       const constraintPoint = profile.descentAltitudeConstraints[i];
 
-      if (constraintPoint.distanceFromStart >= decelPoint.distanceFromStart) {
+      if (
+        constraintPoint.distanceFromStart >= decelPoint.distanceFromStart ||
+        constraintPoint.distanceFromStart <= toDistance
+      ) {
         // If we've found a constraint that's beyond the decel point, we can ignore it.
         continue;
       } else if (!this.isConstraintBelowCruisingAltitude(constraintPoint.constraint, cruiseAltitude)) {
@@ -81,6 +83,7 @@ export class DescentPathBuilder {
         const geometricPathPoint = {
           distanceFromStart: constraintPoint.distanceFromStart,
           altitude: altitudeToContinueFrom,
+          leg: constraintPoint.leg,
         };
 
         // Plan geometric path between decel point and geometric path point (point between geometric and idle path)
@@ -98,12 +101,20 @@ export class DescentPathBuilder {
         this.geometricPathBuilder.executeGeometricSegments(
           geometricSequence,
           geometricSegments,
-          profile.descentSpeedConstraints.slice(),
+          profile,
+          speedProfile,
           windProfile,
         );
 
         idleSequence.reset(geometricSequence.lastCheckpoint);
-        this.buildIdlePath(idleSequence, profile, speedProfile, windProfile, cruiseAltitude);
+        this.idlePathBuilder.buildIdlePath(
+          idleSequence,
+          profile.descentSpeedConstraints,
+          speedProfile,
+          windProfile,
+          cruiseAltitude,
+          toDistance,
+        );
       }
     }
 
@@ -117,233 +128,16 @@ export class DescentPathBuilder {
     sequence.push(...idleSequence.get());
   }
 
-  private buildIdlePath(
-    sequence: TemporaryCheckpointSequence,
-    profile: BaseGeometryProfile,
-    speedProfile: SpeedProfile,
-    windProfile: HeadwindProfile,
-    topOfDescentAltitude: Feet,
-  ): void {
-    // Assume the last checkpoint is the start of the geometric path
-    sequence.copyLastCheckpoint({ reason: VerticalCheckpointReason.IdlePathEnd });
-
-    const { managedDescentSpeedMach, descentSpeedLimit } = this.computationParametersObserver.get();
-    const speedConstraintsAhead = this.speedConstraintGenerator(profile.descentSpeedConstraints, sequence);
-
-    // We try to figure out what speed we might be decelerating for
-    let previousCasTarget =
-      this.tryGetAnticipatedTarget(
-        sequence,
-        profile.descentSpeedConstraints,
-        speedProfile.shouldTakeDescentSpeedLimitIntoAccount() ? descentSpeedLimit : null,
-      ) ??
-      speedProfile.getTarget(
-        sequence.lastCheckpoint.distanceFromStart,
-        sequence.lastCheckpoint.altitude,
-        ManagedSpeedType.Descent,
-      );
-    let wasPreviouslyUnderSpeedLimitAltitude =
-      speedProfile.shouldTakeDescentSpeedLimitIntoAccount() &&
-      sequence.lastCheckpoint.altitude < descentSpeedLimit.underAltitude;
-
-    for (let i = 0; i < 100 && topOfDescentAltitude - sequence.lastCheckpoint.altitude > 1; i++) {
-      const { distanceFromStart, altitude, speed, remainingFuelOnBoard } = sequence.lastCheckpoint;
-      const headwind = windProfile.getHeadwindComponent(distanceFromStart, altitude);
-      const isUnderSpeedLimitAltitude =
-        speedProfile.shouldTakeDescentSpeedLimitIntoAccount() && altitude < descentSpeedLimit.underAltitude;
-
-      const casTarget = speedProfile.getTarget(distanceFromStart - 1e-4, altitude + 1e-4, ManagedSpeedType.Descent);
-      const currentSpeedTarget = Math.min(
-        casTarget,
-        this.atmosphericConditions.computeCasFromMach(managedDescentSpeedMach, altitude),
-      );
-      const canAccelerate = currentSpeedTarget > speed;
-
-      if (canAccelerate) {
-        // Build acceleration path
-        const speedStep = this.idleDescentStrategy.predictToSpeed(
-          altitude,
-          casTarget,
-          speed,
-          managedDescentSpeedMach,
-          remainingFuelOnBoard,
-          headwind,
-        );
-        const scaling = Math.min(1, (topOfDescentAltitude - altitude) / (speedStep.finalAltitude - altitude));
-        this.scaleStepBasedOnLastCheckpoint(sequence.lastCheckpoint, speedStep, scaling);
-
-        const didCrossoverSpeedLimitAltitude = wasPreviouslyUnderSpeedLimitAltitude && !isUnderSpeedLimitAltitude;
-        const checkpointReason = didCrossoverSpeedLimitAltitude
-          ? VerticalCheckpointReason.StartDecelerationToLimit
-          : VerticalCheckpointReason.StartDecelerationToConstraint;
-
-        sequence.addDecelerationCheckpointFromStep(speedStep, checkpointReason, previousCasTarget);
-      } else {
-        // Try alt path
-        let finalAltitude = Math.min(altitude + 1500, topOfDescentAltitude);
-        let reason = VerticalCheckpointReason.IdlePathAtmosphericConditions;
-        if (isUnderSpeedLimitAltitude && finalAltitude >= descentSpeedLimit.underAltitude) {
-          finalAltitude = descentSpeedLimit.underAltitude;
-          reason = VerticalCheckpointReason.CrossingDescentSpeedLimit;
-        }
-
-        const altitudeStep = this.idleDescentStrategy.predictToAltitude(
-          altitude,
-          finalAltitude,
-          speed,
-          managedDescentSpeedMach,
-          remainingFuelOnBoard,
-          headwind,
-        );
-        // Check if constraint violated
-        const nextSpeedConstraint = speedConstraintsAhead.next();
-        if (
-          !nextSpeedConstraint.done &&
-          distanceFromStart + altitudeStep.distanceTraveled < nextSpeedConstraint.value.distanceFromStart
-        ) {
-          // Constraint violated
-          const distanceToConstraint = nextSpeedConstraint.value.distanceFromStart - distanceFromStart;
-          const distanceStep = this.idleDescentStrategy.predictToDistance(
-            altitude,
-            distanceToConstraint,
-            speed,
-            managedDescentSpeedMach,
-            remainingFuelOnBoard,
-            headwind,
-          );
-          sequence.addCheckpointFromStep(distanceStep, VerticalCheckpointReason.SpeedConstraint);
-        } else {
-          sequence.addCheckpointFromStep(altitudeStep, reason);
-        }
-      }
-
-      previousCasTarget = casTarget;
-      wasPreviouslyUnderSpeedLimitAltitude = isUnderSpeedLimitAltitude;
-    }
-
-    if (sequence.lastCheckpoint.reason === VerticalCheckpointReason.IdlePathAtmosphericConditions) {
-      sequence.lastCheckpoint.reason = VerticalCheckpointReason.TopOfDescent;
-    } else {
-      sequence.copyLastCheckpoint({ reason: VerticalCheckpointReason.TopOfDescent });
-    }
-  }
-
-  // TODO: I really don't know if this function does what it's supposed to, so I hope I don't have to return to it.
-  // The problem it's trying to solve is this: After having built the geometric path to the first violating altitude constraint, we might not be at econ speed yet.
-  // So then we need to accelerate to it on the idle path. However, we want to figure out what the reason for this acceleration is, i.e whether it is due
-  // to the speed limit or a constraint. We need to know this to place the correct checkpoint reason.
-  // What the function does is to try and figure this out based on different criteria.
-  private tryGetAnticipatedTarget(
-    sequence: TemporaryCheckpointSequence,
-    speedConstraints: MaxSpeedConstraint[],
-    speedLimit?: SpeedLimit,
-  ): Knots | null {
-    const {
-      distanceFromStart: pposDistanceFromStart,
-      speed: currentSpeed,
-      altitude: currentAltitude,
-    } = sequence.lastCheckpoint;
-
-    // Find next constraint
-    const nextSpeedConstraint = speedConstraints.find(
-      (c) => c.distanceFromStart >= pposDistanceFromStart && c.maxSpeed <= currentSpeed,
-    );
-
-    const isSpeedLimitValidCandidate =
-      speedLimit && currentAltitude > speedLimit.underAltitude && currentSpeed > speedLimit.speed;
-
-    if (nextSpeedConstraint) {
-      // Try to figure out which speed is more important
-      if (isSpeedLimitValidCandidate) {
-        const altAtConstraint = sequence.interpolateAltitudeBackwards(nextSpeedConstraint.distanceFromStart);
-
-        if (speedLimit.underAltitude > altAtConstraint) {
-          return speedLimit.speed;
-        }
-      }
-
-      return nextSpeedConstraint.maxSpeed;
-    }
-
-    // If we did not find a valid speed constraint candidate, see if the speed limit might be a candidate. If so, return it.
-    if (isSpeedLimitValidCandidate) {
-      return speedLimit.speed;
-    }
-
-    return null;
-  }
-
-  private scaleStepBasedOnLastCheckpoint(lastCheckpoint: VerticalCheckpoint, step: StepResults, scaling: number) {
-    step.distanceTraveled *= scaling;
-    step.fuelBurned *= scaling;
-    step.timeElapsed *= scaling;
-    step.finalAltitude = (1 - scaling) * lastCheckpoint.altitude + scaling * step.finalAltitude;
-    step.speed = (1 - scaling) * lastCheckpoint.speed + scaling * step.speed;
-  }
-
-  isConstraintBelowCruisingAltitude(constraint: AltitudeConstraint, finalCruiseAltitude: Feet): boolean {
+  private isConstraintBelowCruisingAltitude(constraint: AltitudeConstraint, finalCruiseAltitude: Feet): boolean {
     return ConstraintUtils.minimumAltitude(constraint) <= finalCruiseAltitude;
   }
-
-  private *speedConstraintGenerator(
-    constraints: MaxSpeedConstraint[],
-    sequence: TemporaryCheckpointSequence,
-  ): Generator<MaxSpeedConstraint> {
-    for (let i = constraints.length - 1; i >= 0; ) {
-      // Small tolerance here, so we don't get stuck on a constraint
-      if (constraints[i].distanceFromStart - sequence.lastCheckpoint.distanceFromStart > -1e-4) {
-        i--;
-        continue;
-      }
-
-      yield constraints[i];
-    }
-  }
 }
 
-export class GeometricPathPlanner {
-  static planDescentSegments(
-    constraints: DescentAltitudeConstraint[],
-    start: GeometricPathPoint,
-    end: GeometricPathPoint,
-    segments: PlannedGeometricSegment[] = [],
-    tolerance: number,
-  ): PlannedGeometricSegment[] {
-    // A "gradient" is just a quantity of units Feet / NauticalMiles
-    const gradient = calculateGradient(start, end);
-
-    for (let i = 0; i < constraints.length; i++) {
-      const constraintPoint = constraints[i];
-
-      if (
-        constraintPoint.distanceFromStart >= start.distanceFromStart ||
-        constraintPoint.distanceFromStart <= end.distanceFromStart
-      ) {
-        continue;
-      }
-
-      const altAtConstraint = start.altitude + gradient * (constraintPoint.distanceFromStart - start.distanceFromStart);
-
-      const [isAltitudeConstraintMet, altitudeToContinueFrom] = evaluateAltitudeConstraint(
-        constraintPoint.constraint,
-        altAtConstraint,
-        tolerance,
-      );
-      if (!isAltitudeConstraintMet) {
-        const center = { distanceFromStart: constraintPoint.distanceFromStart, altitude: altitudeToContinueFrom };
-
-        this.planDescentSegments(constraints, start, center, segments, tolerance);
-        this.planDescentSegments(constraints, center, end, segments, tolerance);
-
-        return;
-      }
-    }
-
-    segments.push({ end, gradient });
-  }
-}
-
-function evaluateAltitudeConstraint(constraint: AltitudeConstraint, altitude: Feet, tol: number): [boolean, Feet] {
+export function evaluateAltitudeConstraint(
+  constraint: AltitudeConstraint,
+  altitude: Feet,
+  tol: number,
+): [boolean, Feet] {
   // Even though in the MCDU constraints count as met if within 250 ft, we use 10 ft here for the initial path construction.
   switch (constraint.altitudeDescriptor) {
     case AltitudeDescriptor.AtAlt1:
@@ -393,20 +187,3 @@ export const isAltitudeConstraintMet = (constraint: AltitudeConstraint, altitude
       return true;
   }
 };
-
-export type GeometricPathPoint = {
-  distanceFromStart: NauticalMiles;
-  altitude: Feet;
-};
-
-export type PlannedGeometricSegment = {
-  gradient: number;
-  end: GeometricPathPoint;
-  isTooSteep?: boolean;
-};
-
-export function calculateGradient(start: GeometricPathPoint, end: GeometricPathPoint): number {
-  return Math.abs(start.distanceFromStart - end.distanceFromStart) < 1e-9
-    ? 0
-    : (start.altitude - end.altitude) / (start.distanceFromStart - end.distanceFromStart);
-}

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/DescentStrategy.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/DescentStrategy.ts
@@ -6,18 +6,15 @@ import { AircraftConfig } from '@fmgc/flightplanning/AircraftConfigTypes';
 import { AtmosphericConditions } from '@fmgc/guidance/vnav/AtmosphericConditions';
 import { FlightPathAngleStrategy, VerticalSpeedStrategy } from '@fmgc/guidance/vnav/climb/ClimbStrategy';
 import { FlapConf } from '@fmgc/guidance/vnav/common';
-import { AircraftConfiguration as AircraftCtlSurfcConfiguration } from '@fmgc/guidance/vnav/descent/ApproachPathBuilder';
+import {
+  AircraftConfiguration as AircraftCtlSurfcConfiguration,
+  DEFAULT_AIRCRAFT_CONTROL_SURFACE_CONFIG,
+} from '@fmgc/guidance/vnav/descent/ApproachPathBuilder';
 import { EngineModel } from '@fmgc/guidance/vnav/EngineModel';
 import { Predictions, StepResults } from '@fmgc/guidance/vnav/Predictions';
 import { VerticalProfileComputationParametersObserver } from '@fmgc/guidance/vnav/VerticalProfileComputationParameters';
 import { VnavConfig } from '@fmgc/guidance/vnav/VnavConfig';
 import { WindComponent } from '@fmgc/guidance/vnav/wind';
-
-export const DEFAULT_AIRCRAFT_CONTROL_SURFACE_CONFIG: AircraftCtlSurfcConfiguration = {
-  flapConfig: FlapConf.CLEAN,
-  speedbrakesExtended: false,
-  gearExtended: false,
-};
 
 export interface DescentStrategy {
   /**

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/GeometricPathPlanner.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/GeometricPathPlanner.ts
@@ -1,0 +1,67 @@
+import { FlightPlanLeg } from '@fmgc/flightplanning/legs/FlightPlanLeg';
+import { evaluateAltitudeConstraint } from '@fmgc/guidance/vnav/descent/DescentPathBuilder';
+import { DescentAltitudeConstraint } from '@fmgc/guidance/vnav/profile/NavGeometryProfile';
+
+export class GeometricPathPlanner {
+  static planDescentSegments(
+    constraints: DescentAltitudeConstraint[],
+    start: GeometricPathPoint,
+    end: GeometricPathPoint & { leg: FlightPlanLeg },
+    segments: PlannedGeometricSegment[] = [],
+    tolerance: number,
+  ): PlannedGeometricSegment[] {
+    // A "gradient" is just a quantity of units Feet / NauticalMiles
+    const gradient = calculateGradient(start, end);
+
+    for (let i = 0; i < constraints.length; i++) {
+      const constraintPoint = constraints[i];
+
+      if (
+        constraintPoint.distanceFromStart >= start.distanceFromStart ||
+        constraintPoint.distanceFromStart <= end.distanceFromStart
+      ) {
+        continue;
+      }
+
+      const altAtConstraint = start.altitude + gradient * (constraintPoint.distanceFromStart - start.distanceFromStart);
+
+      const [isAltitudeConstraintMet, altitudeToContinueFrom] = evaluateAltitudeConstraint(
+        constraintPoint.constraint,
+        altAtConstraint,
+        tolerance,
+      );
+
+      if (!isAltitudeConstraintMet) {
+        const center = {
+          distanceFromStart: constraintPoint.distanceFromStart,
+          altitude: altitudeToContinueFrom,
+          leg: constraintPoint.leg,
+        };
+
+        this.planDescentSegments(constraints, start, center, segments, tolerance);
+        this.planDescentSegments(constraints, center, end, segments, tolerance);
+
+        return;
+      }
+    }
+
+    segments.push({ end, gradient });
+  }
+}
+
+type GeometricPathPoint = {
+  distanceFromStart: NauticalMiles;
+  altitude: Feet;
+};
+
+export type PlannedGeometricSegment = {
+  gradient: number;
+  end: GeometricPathPoint & { leg: FlightPlanLeg };
+  isTooSteep?: boolean;
+};
+
+function calculateGradient(start: GeometricPathPoint, end: GeometricPathPoint): number {
+  return Math.abs(start.distanceFromStart - end.distanceFromStart) < 1e-9
+    ? 0
+    : (start.altitude - end.altitude) / (start.distanceFromStart - end.distanceFromStart);
+}

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/IdlePathBuilder.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/IdlePathBuilder.ts
@@ -1,0 +1,248 @@
+import { AircraftConfig } from '@fmgc/flightplanning/AircraftConfigTypes';
+import { AtmosphericConditions } from '@fmgc/guidance/vnav/AtmosphericConditions';
+import { SpeedProfile, ManagedSpeedType } from '@fmgc/guidance/vnav/climb/SpeedProfile';
+import { DescentStrategy, IdleDescentStrategy } from '@fmgc/guidance/vnav/descent/DescentStrategy';
+import { StepResults } from '@fmgc/guidance/vnav/Predictions';
+import {
+  VerticalCheckpointReason,
+  MaxSpeedConstraint,
+  VerticalCheckpoint,
+} from '@fmgc/guidance/vnav/profile/NavGeometryProfile';
+import { TemporaryCheckpointSequence } from '@fmgc/guidance/vnav/profile/TemporaryCheckpointSequence';
+import { SpeedLimit } from '@fmgc/guidance/vnav/SpeedLimit';
+import { VerticalProfileComputationParametersObserver } from '@fmgc/guidance/vnav/VerticalProfileComputationParameters';
+import { HeadwindProfile } from '@fmgc/guidance/vnav/wind/HeadwindProfile';
+
+export class IdlePathBuilder {
+  private readonly idleDescentStrategy: DescentStrategy;
+
+  constructor(
+    private computationParametersObserver: VerticalProfileComputationParametersObserver,
+    private atmosphericConditions: AtmosphericConditions,
+    private readonly acConfig: AircraftConfig,
+  ) {
+    this.idleDescentStrategy = new IdleDescentStrategy(
+      computationParametersObserver,
+      atmosphericConditions,
+      this.acConfig,
+    );
+  }
+
+  buildIdlePath(
+    sequence: TemporaryCheckpointSequence,
+    descentSpeedConstraints: MaxSpeedConstraint[],
+    speedProfile: SpeedProfile,
+    windProfile: HeadwindProfile,
+    topOfDescentAltitude: Feet,
+    toDistance: NauticalMiles = -Infinity,
+  ): void {
+    // Assume the last checkpoint is the start of the geometric path
+    sequence.copyLastCheckpoint({ reason: VerticalCheckpointReason.IdlePathEnd });
+
+    this.buildIdleSequence(
+      sequence,
+      descentSpeedConstraints,
+      speedProfile,
+      windProfile,
+      topOfDescentAltitude,
+      toDistance,
+    );
+
+    if (sequence.lastCheckpoint.reason === VerticalCheckpointReason.IdlePathAtmosphericConditions) {
+      sequence.lastCheckpoint.reason = VerticalCheckpointReason.TopOfDescent;
+    } else {
+      sequence.copyLastCheckpoint({ reason: VerticalCheckpointReason.TopOfDescent });
+    }
+  }
+
+  private buildIdleSequence(
+    sequence: TemporaryCheckpointSequence,
+    descentSpeedConstraints: MaxSpeedConstraint[],
+    speedProfile: SpeedProfile,
+    windProfile: HeadwindProfile,
+    topOfDescentAltitude: Feet,
+    toDistance: NauticalMiles = -Infinity,
+  ) {
+    const { managedDescentSpeedMach, descentSpeedLimit } = this.computationParametersObserver.get();
+    const speedConstraintsAhead = this.speedConstraintGenerator(descentSpeedConstraints, sequence);
+
+    // We try to figure out what speed we might be decelerating for
+    let previousCasTarget =
+      this.tryGetAnticipatedTarget(
+        sequence,
+        descentSpeedConstraints,
+        speedProfile.shouldTakeDescentSpeedLimitIntoAccount() ? descentSpeedLimit : null,
+      ) ??
+      speedProfile.getTarget(
+        sequence.lastCheckpoint.distanceFromStart,
+        sequence.lastCheckpoint.altitude,
+        ManagedSpeedType.Descent,
+      );
+    let wasPreviouslyUnderSpeedLimitAltitude =
+      speedProfile.shouldTakeDescentSpeedLimitIntoAccount() &&
+      sequence.lastCheckpoint.altitude < descentSpeedLimit.underAltitude;
+
+    for (
+      let i = 0;
+      i < 100 &&
+      sequence.lastCheckpoint.distanceFromStart - toDistance > 1e-4 &&
+      topOfDescentAltitude - sequence.lastCheckpoint.altitude > 1;
+      i++
+    ) {
+      const { distanceFromStart, altitude, speed, remainingFuelOnBoard } = sequence.lastCheckpoint;
+      const headwind = windProfile.getHeadwindComponent(distanceFromStart, altitude);
+      const isUnderSpeedLimitAltitude =
+        speedProfile.shouldTakeDescentSpeedLimitIntoAccount() && altitude < descentSpeedLimit.underAltitude;
+
+      const casTarget = speedProfile.getTarget(distanceFromStart - 1e-4, altitude + 1e-4, ManagedSpeedType.Descent);
+      const currentSpeedTarget = Math.min(
+        casTarget,
+        this.atmosphericConditions.computeCasFromMach(managedDescentSpeedMach, altitude),
+      );
+      const canAccelerate = currentSpeedTarget > speed;
+
+      if (canAccelerate) {
+        // Build acceleration path
+        const speedStep = this.idleDescentStrategy.predictToSpeed(
+          altitude,
+          casTarget,
+          speed,
+          managedDescentSpeedMach,
+          remainingFuelOnBoard,
+          headwind,
+        );
+        const scaling = Math.min(
+          1,
+          (topOfDescentAltitude - altitude) / (speedStep.finalAltitude - altitude),
+          (toDistance - sequence.lastCheckpoint.distanceFromStart) / speedStep.distanceTraveled,
+        );
+        this.scaleStepBasedOnLastCheckpoint(sequence.lastCheckpoint, speedStep, scaling);
+
+        const didCrossoverSpeedLimitAltitude = wasPreviouslyUnderSpeedLimitAltitude && !isUnderSpeedLimitAltitude;
+        const checkpointReason = didCrossoverSpeedLimitAltitude
+          ? VerticalCheckpointReason.StartDecelerationToLimit
+          : VerticalCheckpointReason.StartDecelerationToConstraint;
+
+        sequence.addDecelerationCheckpointFromStep(speedStep, checkpointReason, previousCasTarget);
+      } else {
+        // Try alt path
+        let finalAltitude = Math.min(altitude + 1500, topOfDescentAltitude);
+
+        if (isUnderSpeedLimitAltitude) {
+          finalAltitude = Math.min(finalAltitude, descentSpeedLimit.underAltitude);
+        }
+
+        const altitudeStep = this.idleDescentStrategy.predictToAltitude(
+          altitude,
+          finalAltitude,
+          speed,
+          managedDescentSpeedMach,
+          remainingFuelOnBoard,
+          headwind,
+        );
+        const scaling = Math.min(
+          1,
+          (toDistance - sequence.lastCheckpoint.distanceFromStart) / altitudeStep.distanceTraveled,
+        );
+        this.scaleStepBasedOnLastCheckpoint(sequence.lastCheckpoint, altitudeStep, scaling);
+
+        const reason =
+          isUnderSpeedLimitAltitude && altitudeStep.finalAltitude >= descentSpeedLimit.underAltitude
+            ? VerticalCheckpointReason.CrossingDescentSpeedLimit
+            : VerticalCheckpointReason.IdlePathAtmosphericConditions;
+
+        // Check if constraint violated
+        const nextSpeedConstraint = speedConstraintsAhead.next();
+        if (
+          !nextSpeedConstraint.done &&
+          distanceFromStart + altitudeStep.distanceTraveled < nextSpeedConstraint.value.distanceFromStart
+        ) {
+          // Constraint violated
+          const distanceToConstraint = nextSpeedConstraint.value.distanceFromStart - distanceFromStart;
+          const distanceStep = this.idleDescentStrategy.predictToDistance(
+            altitude,
+            distanceToConstraint,
+            speed,
+            managedDescentSpeedMach,
+            remainingFuelOnBoard,
+            headwind,
+          );
+          sequence.addCheckpointFromStep(distanceStep, VerticalCheckpointReason.SpeedConstraint);
+        } else {
+          sequence.addCheckpointFromStep(altitudeStep, reason);
+        }
+      }
+
+      previousCasTarget = casTarget;
+      wasPreviouslyUnderSpeedLimitAltitude = isUnderSpeedLimitAltitude;
+    }
+  }
+
+  // TODO: I really don't know if this function does what it's supposed to, so I hope I don't have to return to it.
+  // The problem it's trying to solve is this: After having built the geometric path to the first violating altitude constraint, we might not be at econ speed yet.
+  // So then we need to accelerate to it on the idle path. However, we want to figure out what the reason for this acceleration is, i.e whether it is due
+  // to the speed limit or a constraint. We need to know this to place the correct checkpoint reason.
+  // What the function does is to try and figure this out based on different criteria.
+  private tryGetAnticipatedTarget(
+    sequence: TemporaryCheckpointSequence,
+    speedConstraints: MaxSpeedConstraint[],
+    speedLimit?: SpeedLimit,
+  ): Knots | null {
+    const {
+      distanceFromStart: pposDistanceFromStart,
+      speed: currentSpeed,
+      altitude: currentAltitude,
+    } = sequence.lastCheckpoint;
+
+    // Find next constraint
+    const nextSpeedConstraint = speedConstraints.find(
+      (c) => c.distanceFromStart >= pposDistanceFromStart && c.maxSpeed <= currentSpeed,
+    );
+
+    const isSpeedLimitValidCandidate =
+      speedLimit && currentAltitude > speedLimit.underAltitude && currentSpeed > speedLimit.speed;
+
+    if (nextSpeedConstraint) {
+      // Try to figure out which speed is more important
+      if (isSpeedLimitValidCandidate) {
+        const altAtConstraint = sequence.interpolateAltitudeBackwards(nextSpeedConstraint.distanceFromStart);
+
+        if (speedLimit.underAltitude > altAtConstraint) {
+          return speedLimit.speed;
+        }
+      }
+
+      return nextSpeedConstraint.maxSpeed;
+    }
+
+    // If we did not find a valid speed constraint candidate, see if the speed limit might be a candidate. If so, return it.
+    if (isSpeedLimitValidCandidate) {
+      return speedLimit.speed;
+    }
+
+    return null;
+  }
+
+  private scaleStepBasedOnLastCheckpoint(lastCheckpoint: VerticalCheckpoint, step: StepResults, scaling: number) {
+    step.distanceTraveled *= scaling;
+    step.fuelBurned *= scaling;
+    step.timeElapsed *= scaling;
+    step.finalAltitude = (1 - scaling) * lastCheckpoint.altitude + scaling * step.finalAltitude;
+    step.speed = (1 - scaling) * lastCheckpoint.speed + scaling * step.speed;
+  }
+
+  private *speedConstraintGenerator(
+    constraints: MaxSpeedConstraint[],
+    sequence: TemporaryCheckpointSequence,
+  ): Generator<MaxSpeedConstraint> {
+    for (let i = constraints.length - 1; i >= 0; ) {
+      // Small tolerance here, so we don't get stuck on a constraint
+      if (constraints[i].distanceFromStart - sequence.lastCheckpoint.distanceFromStart > -1e-4) {
+        i--;
+        continue;
+      }
+
+      yield constraints[i];
+    }
+  }
+}

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/TacticalDescentPathBuilder.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/TacticalDescentPathBuilder.ts
@@ -7,7 +7,7 @@ import { AircraftConfig } from '@fmgc/flightplanning/AircraftConfigTypes';
 import { AtmosphericConditions } from '@fmgc/guidance/vnav/AtmosphericConditions';
 import { VerticalSpeedStrategy } from '@fmgc/guidance/vnav/climb/ClimbStrategy';
 import { SpeedProfile } from '@fmgc/guidance/vnav/climb/SpeedProfile';
-import { AircraftConfiguration, AircraftConfigurationProfile } from '@fmgc/guidance/vnav/descent/ApproachPathBuilder';
+import { AircraftConfiguration, AircraftConfigurationRegister } from '@fmgc/guidance/vnav/descent/ApproachPathBuilder';
 import { DescentStrategy } from '@fmgc/guidance/vnav/descent/DescentStrategy';
 import { StepResults } from '@fmgc/guidance/vnav/Predictions';
 import { BaseGeometryProfile } from '@fmgc/guidance/vnav/profile/BaseGeometryProfile';
@@ -605,6 +605,8 @@ class PhaseTable {
 
   phases: SubPhase[] = [];
 
+  private readonly configuration: AircraftConfigurationRegister = new AircraftConfigurationRegister();
+
   constructor(
     private readonly parameters: VerticalProfileComputationParameters,
     private readonly winds: HeadwindProfile,
@@ -627,12 +629,10 @@ class PhaseTable {
           sequence.lastCheckpoint.distanceFromStart,
           sequence.lastCheckpoint.altitude,
         );
-        const configuration = AircraftConfigurationProfile.getBySpeed(sequence.lastCheckpoint.speed, this.parameters);
-
         const phaseResult = phase.execute(phase.shouldFlyAsLevelSegment ? levelFlightStrategy : descentStrategy)(
           sequence.lastCheckpoint,
           headwind,
-          configuration,
+          this.configuration.setFromSpeed(sequence.lastCheckpoint.speed, this.parameters),
         );
 
         if (phase instanceof DescendingDeceleration) {

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/profile/NavGeometryProfile.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/profile/NavGeometryProfile.ts
@@ -9,6 +9,7 @@ import { isAltitudeConstraintMet } from '@fmgc/guidance/vnav/descent/DescentPath
 import { FlightPlanService } from '@fmgc/flightplanning/FlightPlanService';
 import { AltitudeConstraint, SpeedConstraint } from '@fmgc/flightplanning/data/constraint';
 import { AltitudeDescriptor } from '@flybywiresim/fbw-sdk';
+import { FlightPlanLeg } from '@fmgc/flightplanning/legs/FlightPlanLeg';
 
 // TODO: Merge this with VerticalCheckpoint
 export interface VerticalWaypointPrediction {
@@ -128,6 +129,7 @@ export interface MaxSpeedConstraint {
 export interface DescentAltitudeConstraint {
   distanceFromStart: NauticalMiles;
   constraint: AltitudeConstraint;
+  leg: FlightPlanLeg;
 }
 
 export interface GeographicCruiseStep {

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/profile/TemporaryCheckpointSequence.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/profile/TemporaryCheckpointSequence.ts
@@ -82,7 +82,7 @@ export class TemporaryCheckpointSequence {
       return this.checkpoints[0].altitude;
     }
 
-    for (let i = 1; i < this.checkpoints.length - 1; i++) {
+    for (let i = 1; i < this.checkpoints.length; i++) {
       if (distanceFromStart >= this.checkpoints[i].distanceFromStart) {
         return Common.interpolate(
           distanceFromStart,

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_FlightPlanPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_FlightPlanPage.ts
@@ -119,7 +119,7 @@ export class CDUFlightPlanPage {
 
       const wp = targetPlan.allLegs[i];
 
-      if (wp.isDiscontinuity) {
+      if (wp.isDiscontinuity === true) {
         waypointsAndMarkers.push({
           marker: Markers.FPLN_DISCONTINUITY,
           fpIndex: i,
@@ -170,6 +170,10 @@ export class CDUFlightPlanPage {
         distanceFromLastLine,
         isActive: isActiveLeg && pseudoWaypointsOnLeg.length === 0,
       });
+
+      if (wp.calculated && wp.calculated.endsInTooSteepPath) {
+        waypointsAndMarkers.push({ marker: Markers.TOO_STEEP_PATH, fpIndex: i, inAlternate: false, inMissedApproach });
+      }
 
       if (i === targetPlan.destinationLegIndex) {
         destinationAirportOffset = Math.max(waypointsAndMarkers.length - 4, 0);
@@ -716,7 +720,12 @@ export class CDUFlightPlanPage {
         scrollWindow[rowI] = waypointsAndMarkers[winI];
         addLskAt(rowI, 0, (value, scratchpadCallback) => {
           if (value === Keypad.clrValue) {
-            CDUFlightPlanPage.clearElement(mcdu, fpIndex, offset, forPlan, inAlternate, scratchpadCallback);
+            if (marker.marker === Markers.FPLN_DISCONTINUITY) {
+              CDUFlightPlanPage.clearElement(mcdu, fpIndex, offset, forPlan, inAlternate, scratchpadCallback);
+            } else {
+              mcdu.setScratchpadMessage(NXSystemMessages.notAllowed);
+              scratchpadCallback();
+            }
             return;
           } else if (value === '') {
             return;

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FlightManagementComputer.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FlightManagementComputer.ts
@@ -985,6 +985,7 @@ export class FlightManagementComputer implements FmcInterface {
         this.acInterface.updateWeights();
         this.acInterface.toSpeedsChecks();
         this.acInterface.checkForStepClimb();
+        this.acInterface.checkTooSteepPath();
 
         const toFlaps = this.fmgc.getTakeoffFlapsSetting();
         if (toFlaps) {

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcAircraftInterface.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcAircraftInterface.ts
@@ -1859,6 +1859,24 @@ export class FmcAircraftInterface {
 
     return SimVar.SetSimVarValue('L:A32NX_FM_LS_COURSE', 'number', course);
   }
+
+  private hasTooSteepPathAhead = false;
+
+  checkTooSteepPath() {
+    const hasTooSteepPathAhead = this.fmc.guidanceController?.vnavDriver?.shouldShowTooSteepPathAhead();
+
+    if (hasTooSteepPathAhead !== this.hasTooSteepPathAhead) {
+      this.hasTooSteepPathAhead = hasTooSteepPathAhead;
+
+      if (hasTooSteepPathAhead) {
+        this.fmc.addMessageToQueue(
+          NXSystemMessages.tooSteepPathAhead,
+          () => !this.fmc.guidanceController?.vnavDriver?.shouldShowTooSteepPathAhead(),
+          undefined,
+        );
+      }
+    }
+  }
 }
 
 class FmArinc429OutputWord extends Arinc429Word {

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
@@ -374,6 +374,14 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
           leg?.calculated?.cumulativeDistanceWithTransitions ??
           lastDistanceFromStart + (this.derivedFplnLegData[i].distanceFromLastWpt ?? 0) - reduceDistanceBy;
         this.lineData.push(data);
+
+        if (leg.calculated?.endsInTooSteepPath) {
+          this.lineData.push({
+            type: FplnLineType.Special,
+            originalLegIndex: null,
+            label: 'TOO STEEP PATH',
+          });
+        }
       } else {
         const data: FplnLineSpecialDisplayData = {
           type: FplnLineType.Special,

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnVertRev.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnVertRev.tsx
@@ -225,6 +225,10 @@ export class MfdFmsFplnVertRev extends FmsPage<MfdFmsFplnVertRevProps> {
     }
 
     const leg = this.loadedFlightPlan.legElementAt(this.selectedLegIndex);
+    const previousElement = this.loadedFlightPlan.maybeElementAt(this.selectedLegIndex - 1);
+    const isPartOfTooSteepPathSegment =
+      leg.calculated?.endsInTooSteepPath ||
+      (previousElement?.isDiscontinuity === false && previousElement.calculated?.endsInTooSteepPath);
 
     if (!MfdFmsFplnVertRev.isEligibleForVerticalRevision(this.selectedLegIndex, leg, this.loadedFlightPlan)) {
       this.speedMessageArea.set(`SPD CSTR NOT ALLOWED AT ${leg.ident}`);
@@ -235,7 +239,7 @@ export class MfdFmsFplnVertRev extends FmsPage<MfdFmsFplnVertRevProps> {
     }
     this.speedMessageArea.set('');
     this.spdConstraintDisabled.set(false);
-    this.altitudeMessageArea.set('');
+    this.altitudeMessageArea.set(isPartOfTooSteepPathSegment ? 'TOO STEEP PATH AHEAD' : '');
     this.altConstraintDisabled.set(false);
 
     // Load speed constraints

--- a/fbw-a380x/src/systems/instruments/src/MFD/shared/NXSystemMessages.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/shared/NXSystemMessages.ts
@@ -111,6 +111,7 @@ export const NXSystemMessages = {
   stepAboveMaxFl: new TypeIIMessage('STEP ABOVE MAX FL'),
   stepAhead: new TypeIIMessage('STEP AHEAD'),
   stepDeleted: new TypeIIMessage('STEP DELETED'),
+  tooSteepPathAhead: new TypeIIMessage('TOO STEEP PATH AHEAD'),
 };
 
 export const NXFictionalMessages = {

--- a/fbw-common/src/systems/shared/src/FmMessages.ts
+++ b/fbw-common/src/systems/shared/src/FmMessages.ts
@@ -218,4 +218,10 @@ export const FMMessageTypes: Readonly<Record<string, FMMessage>> = {
     color: 'White',
     clearable: true,
   },
+  TooSteepPathAhead: {
+    id: 20,
+    text: 'TOO STEEP PATH AHEAD',
+    color: 'Amber',
+    clearable: true,
+  },
 };

--- a/fbw-common/src/systems/shared/src/MathUtils.ts
+++ b/fbw-common/src/systems/shared/src/MathUtils.ts
@@ -597,4 +597,57 @@ export class MathUtils {
 
     return MathUtils.interpolate(j, table[0][c1], table[0][c2], interpolatedRowAtC1, interpolatedRowAtC2);
   }
+
+  /**
+   * Checks whether two numbers are within a certain epsilon of each other.
+   * @param a
+   * @param b
+   * @param epsilon the absolute tolerance
+   * @returns true if the numbers are within epsilon of each other
+   */
+  public static isAboutEqual(a: number, b: number, epsilon = 1e-4): boolean {
+    return Math.abs(a - b) < epsilon;
+  }
+
+  /**
+   * Checks whether a number is positive and within a certain epsilon of zero.
+   * @param num
+   * @param epsilon the absolute tolerance
+   * @returns true if the number is positive and within epsilon of zero
+   */
+  public static isCloseToPositive(num: number, epsilon = 1e-4): boolean {
+    return num > -Math.abs(epsilon);
+  }
+
+  /**
+   * Checks whether a number is negative and within a certain epsilon of zero.
+   * @param num
+   * @param epsilon the absolute tolerance
+   * @returns true if the number is negative and within epsilon of zero
+   */
+  public static isCloseToNegative(num: number, epsilon = 1e-4): boolean {
+    return this.isCloseToPositive(-num, epsilon);
+  }
+
+  /**
+   * Checks whether a > b or a is within a certain epsilon of b.
+   * @param a
+   * @param b
+   * @param epsilon the absolute tolerance
+   * @returns true if the number is greater than or within epsilon of the other
+   */
+  public static isCloseToGreaterThan(a: number, b: number, epsilon = 1e-4): boolean {
+    return this.isCloseToPositive(a - b, epsilon);
+  }
+
+  /**
+   * Checks whether a < b or a is within a certain epsilon of b.
+   * @param a
+   * @param b
+   * @param epsilon the absolute tolerance
+   * @returns true if the number is less than or within epsilon of the other
+   */
+  public static isCloseToLessThan(a: number, b: number, epsilon = 1e-4): boolean {
+    return this.isCloseToNegative(a - b, epsilon);
+  }
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
When the FMS predicts that a segment between two altitude constraints cannot be met, it shows a TOO STEEP PATH marker.
When the aircraft sequences the first of those constraints, the linear deviation (yoyo) will jump, putting the aircraft high on profile. When a vertical profile is predicted to have a TOO STEEP PATH segment, the "TOO STEEP PATH AHEAD" scratchpad message is shown. On the vertical revision page of the legs before and after the marker, the TOO STEEP PATH BEYOND indication is shown.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://github.com/user-attachments/assets/38bc2741-ef88-4592-b29f-8a84c03dcc60)
![image](https://github.com/user-attachments/assets/0f85778c-4474-4d98-824c-c4648e193d50)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
This affects both the A32NX and the A380X.

- Spawn, enter a flight plan, ZFW, and cruise altitude to ensure you get vertical predictions in the flight plan.
- Enter an arrival/approach segment with a steep descent imposed by the constraints, check if the TOO STEEP PATH marker is shown. If you cannot find such a procedure, enter a really high constraint manually.
- Check the TOO STEEP PATH BEYOND message appears on the VERT REV page of the leg before and after the marker.
- Check the TOO STEEP PATH AHEAD scratchpad message appears in cruise when within 150 NM of the TOO STEEP PATH segment, or in the descent.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
