### PR TITLE
fix(a380x/nd): Remove leading 0s from terrain elevation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -115,6 +115,7 @@
 1. [A32NX/AMU] Enable VHF3 audio, and allow switching off VHF1 - @tracernz (Mike)
 1. [A380X/PFD] Fix font colours on metric altitude display - @MrJigs7 (MrJigs.)
 1. [A380X/MFD] Fixed the altitude prediction not rounding to the nearest 10 on the FPLN page - @bulenteroglu (senolitam)
+1. [A380X/ND] Remove leading zeros from terrain elevation display - @BravoMike99 (bruno_pt99) 
 
 ## 0.12.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -36,8 +36,6 @@
 1. [A380X/MFD] MFD/SURV: Fixed TCAS not switching status when using DEFAULT SETTINGS button - @flogross89 (floridude)
 1. [A380X/FUEL] Recalibrated inital fuel settings - @sschiphorst (Yahtzee94)
 1. [A380X/ENG] Another adjustment to taxi thrust - @donstim (donbikes)
-1. [A380X/ANIM] Animation of flaps now from FPPU position. Interim fix for spoiler low end animation - @Crocket63 (crocket)
-1. [A380X/ENGINES] Another adjustment to taxi thrust - @donstim (donbikes)
 1. [A380/ANIM] Animation of flaps now from FPPU position. Interim fix for spoiler low end animation - @Crocket63 (crocket)
 1. [A380X/ENG] Improve oil pressure lookup table - @tracernz (Mike)
 1. [A380X/FADEC] Add N1 fan protection measures (METOTS, KOZ) - @flogross89 (floridude)
@@ -104,8 +102,6 @@
 1. [A380X/EFIS] Illuminate ND range and mode selectors during light test - @BravoMike99 (bruno_pt99)
 1. [A380/PFD] Add DISCONNECT AP FOR LDG FMA message - @BravoMike99 (bruno_pt99)
 1. [A380X/ENG] Adjust climb thrust to be more accurate - @BlueberryKing (BlueberryKing)
-1. [A380X/ANIM] Animation of flaps now from FPPU position. Interim fix for spoiler low end animation - @Crocket63 (crocket)
-1. [A380X/ENGINES] Adjust climb thrust to be more accurate - @BlueberryKing (BlueberryKing)
 1. [A380X/EWD] Show THR limit in EWD instead of N1 - @flogross89 (floridude)
 1. [A380X/FLIGHT MODEL] Fix pitchup and unrecoverable stall - - @donstim (donbikes#4084)
 1. [ATC/TCAS] Fixed TCAS failure on baro corrected altitude going invalid - @tracernz (Mike)
@@ -115,7 +111,7 @@
 1. [A32NX/AMU] Enable VHF3 audio, and allow switching off VHF1 - @tracernz (Mike)
 1. [A380X/PFD] Fix font colours on metric altitude display - @MrJigs7 (MrJigs.)
 1. [A380X/MFD] Fixed the altitude prediction not rounding to the nearest 10 on the FPLN page - @bulenteroglu (senolitam)
-1. [A380X/ND] Remove leading zeros from terrain elevation display - @BravoMike99 (bruno_pt99) 
+1. [A380X/ND] Remove leading zeros from terrain elevation display - @BravoMike99 (bruno_pt99)
 
 ## 0.12.0
 

--- a/fbw-a32nx/src/systems/instruments/src/ND/instrument.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/ND/instrument.tsx
@@ -11,7 +11,7 @@ import {
   InstrumentBackplane,
   Subject,
 } from '@microsoft/msfs-sdk';
-import { a320EfisRangeSettings, ArincEventBus, EfisSide } from '@flybywiresim/fbw-sdk';
+import { a320EfisRangeSettings, a320TerrainThresholdPadValue, ArincEventBus, EfisSide } from '@flybywiresim/fbw-sdk';
 import { NDComponent } from '@flybywiresim/navigation-display';
 
 import { NDSimvarPublisher, NDSimvars } from './NDSimvarPublisher';
@@ -141,7 +141,12 @@ class NDInstrument implements FsInstrument {
         failed={this.displayFailed}
         normDmc={getDisplayIndex()}
       >
-        <NDComponent bus={this.bus} side={this.efisSide} rangeValues={a320EfisRangeSettings} />
+        <NDComponent
+          bus={this.bus}
+          side={this.efisSide}
+          rangeValues={a320EfisRangeSettings}
+          terrainThresholdPaddingText={a320TerrainThresholdPadValue}
+        />
       </DisplayUnit>,
       document.getElementById('ND_CONTENT'),
     );

--- a/fbw-a380x/src/systems/instruments/src/ND/instrument.tsx
+++ b/fbw-a380x/src/systems/instruments/src/ND/instrument.tsx
@@ -17,6 +17,7 @@ import {
 import {
   A380EfisNdRangeValue,
   a380EfisRangeSettings,
+  a380TerrainThresholdPadValue,
   ArincEventBus,
   BtvSimvarPublisher,
   EfisNdMode,
@@ -280,7 +281,12 @@ class NDInstrument implements FsInstrument {
               />
             </div>
           </div>
-          <NDComponent bus={this.bus} side={this.efisSide} rangeValues={a380EfisRangeSettings} />
+          <NDComponent
+            bus={this.bus}
+            side={this.efisSide}
+            rangeValues={a380EfisRangeSettings}
+            terrainThresholdPaddingText={a380TerrainThresholdPadValue}
+          />
           <ContextMenu
             ref={this.contextMenuRef}
             opened={this.contextMenuOpened}

--- a/fbw-common/src/systems/instruments/src/ND/ND.tsx
+++ b/fbw-common/src/systems/instruments/src/ND/ND.tsx
@@ -70,6 +70,8 @@ export interface NDProps<T extends number> {
   side: EfisSide;
 
   rangeValues: T[];
+
+  terrainThresholdPaddingText: string;
 }
 
 export class NDComponent<T extends number> extends DisplayComponent<NDProps<T>> {
@@ -463,7 +465,7 @@ export class NDComponent<T extends number> extends DisplayComponent<NDProps<T>> 
               MODE CHANGE
             </Flag>
 
-            <TerrainMapThresholds bus={this.props.bus} />
+            <TerrainMapThresholds bus={this.props.bus} paddingText={this.props.terrainThresholdPaddingText} />
 
             <RadioNavInfo bus={this.props.bus} index={1} mode={this.currentPageMode} />
             <RadioNavInfo bus={this.props.bus} index={2} mode={this.currentPageMode} />

--- a/fbw-common/src/systems/instruments/src/ND/TerrainMapThresholds.tsx
+++ b/fbw-common/src/systems/instruments/src/ND/TerrainMapThresholds.tsx
@@ -47,7 +47,7 @@ export class TerrainMapThresholds extends DisplayComponent<TerrainMapThresholdsP
   });
 
   private readonly lowerBorder = this.minElevationSub.map((elevation) => {
-    if (elevation >= 0) {
+    if (elevation > 0) {
       return Math.floor(elevation / 100)
         .toString()
         .padStart(3, this.props.paddingText);

--- a/fbw-common/src/systems/instruments/src/ND/TerrainMapThresholds.tsx
+++ b/fbw-common/src/systems/instruments/src/ND/TerrainMapThresholds.tsx
@@ -4,6 +4,7 @@ import { GenericTawsEvents, TerrainLevelMode } from './types/GenericTawsEvents';
 
 export interface TerrainMapThresholdsProps {
   bus: EventBus;
+  paddingText: string;
 }
 
 export class TerrainMapThresholds extends DisplayComponent<TerrainMapThresholdsProps> {
@@ -24,13 +25,14 @@ export class TerrainMapThresholds extends DisplayComponent<TerrainMapThresholdsP
   );
 
   private readonly upperBorder = this.maxElevationSub.map((elevation) => {
+    let roundedElevation: string;
     if (elevation !== 0) {
-      return Math.round(elevation / 100 + 0.5)
-        .toString()
-        .padStart(3, '0');
+      roundedElevation = Math.round(elevation / 100 + 0.5).toString();
+    } else {
+      roundedElevation = '0';
     }
 
-    return '000';
+    return roundedElevation.padStart(3, this.props.paddingText);
   });
 
   private readonly upperBorderColor = this.maxElevationModeSub.map((mode) => {
@@ -48,7 +50,7 @@ export class TerrainMapThresholds extends DisplayComponent<TerrainMapThresholdsP
     if (elevation >= 0) {
       return Math.floor(elevation / 100)
         .toString()
-        .padStart(3, '0');
+        .padStart(3, this.props.paddingText);
     }
 
     return '';

--- a/fbw-common/src/systems/instruments/src/NavigationDisplay.ts
+++ b/fbw-common/src/systems/instruments/src/NavigationDisplay.ts
@@ -17,6 +17,10 @@ export const a320EfisOansRangeSettings: A320EfisOansNdRangeValue[] = [-1, 10, 20
 
 export const a380EfisRangeSettings: A380EfisNdRangeValue[] = [-1, 10, 20, 40, 80, 160, 320, 640];
 
+export const a320TerrainThresholdPadValue = '0';
+
+export const a380TerrainThresholdPadValue = '\\xa0';
+
 export enum EfisNdMode {
   ROSE_ILS,
   ROSE_VOR,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Removes leading 0s on the terrain display for A380X.
Blanks lower elevation if value is 0 on both planes.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![Terrain](https://github.com/user-attachments/assets/223033b6-e108-4196-89d1-6d0d0ec7b845)
![TERR2](https://github.com/user-attachments/assets/c3338490-d225-44d4-9a7c-f67ca43f131c)
![TERR3](https://github.com/user-attachments/assets/27d62332-2bc2-4d1b-82ca-6aee1070e3da)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![image](https://github.com/user-attachments/assets/824881bb-ab79-49b9-9b91-1823ca800978)
![image](https://github.com/user-attachments/assets/d1096451-906c-4d1f-b701-2b41f37edb24)
![image](https://github.com/user-attachments/assets/125c0d88-658b-4a2e-934e-bc8368c6288e)

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
bruno_pt99
## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
A380X:
1) Turn on the terrain on ND somewhere and verify the values appear as the screenshots above without leading 0s.
2) Fly over the ocean, ensure lower elevation blanks once it is the lowest elevation displayed, such as the third screenshot.

A32NX:
1) Turn on terrain on ND and verify the values appear with leading 0s.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
