### PR TITLE
fix(a380x/pfd): Inverted meter altitude indicator color

### DIFF
--- a/fbw-a380x/src/systems/instruments/src/PFD/AltitudeIndicator.tsx
+++ b/fbw-a380x/src/systems/instruments/src/PFD/AltitudeIndicator.tsx
@@ -933,7 +933,7 @@ class MetricAltIndicator extends DisplayComponent<{ bus: EventBus }> {
           this.metricAltTargetText.instance.classList.replace('Magenta', 'Cyan');
         }
 
-        if (this.state.altitude.value > this.state.MDA) {
+        if (this.state.altitude.value < this.state.MDA) {
           this.metricAltText.instance.classList.replace('Green', 'Amber');
         } else {
           this.metricAltText.instance.classList.replace('Amber', 'Green');


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9712

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Updated the comparison logic to ensure AMBER color is shown when the altitude is below MDA, and green when above it.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Push 'meter' button in the AFS Panel.
2.  Check the PFD, the meter altitude indicator should be in GREEN color above the MDA and AMBER below.
- Note: It will show the altitude in BLUE above the MDA, but, i tested it with the changes by #9707 and its working as expected.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
