### PR TITLE
fix: Use SERVER Callsign for the Hoppie is Station Available Check

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,7 +7,6 @@
 
 ## 0.13.0
 
-1. [ATSU] Fixed issues with the ALL-CALLSIGNS recipient on Hoppie - @CronixZero (CronixZero)
 1. [GENERAL] Fixed issue in C++ WASM Framework that caused performance degradation in some WASM modules - @frankkopp (cdr_maverick)
 1. [A32NX/FCU] Fixed auto-initialisation of baro unit - @tracernz (Mike)
 1. [A380X/FCU] Fix baro-preselect not recognising baro unit changes - @tracernz (Mike)
@@ -117,6 +116,7 @@
 1. [A380X/ND] Remove leading zeros from terrain elevation display - @BravoMike99 (bruno_pt99)
 1. [A32NX/FWS] Fix autopilot instinctive disconnect button logic for 3D model - @flogross89 (floridude)
 1. [A380X/EFIS] Fix VV pb indicator not turning on when TRK-FPA mode is selected - @heclak (Heclak)
+1. [ATSU] Fixed issues with the ALL-CALLSIGNS recipient on Hoppie - @CronixZero (CronixZero)
 
 ## 0.12.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## 0.13.0
 
+1. [ATSU] Fixed issues with the ALL-CALLSIGNS recipient on Hoppie - @CronixZero (CronixZero)
 1. [GENERAL] Fixed issue in C++ WASM Framework that caused performance degradation in some WASM modules - @frankkopp (cdr_maverick)
 1. [A32NX/FCU] Fixed auto-initialisation of baro unit - @tracernz (Mike)
 1. [A380X/FCU] Fix baro-preselect not recognising baro unit changes - @tracernz (Mike)

--- a/fbw-common/src/systems/datalink/router/src/webinterfaces/HoppieConnector.ts
+++ b/fbw-common/src/systems/datalink/router/src/webinterfaces/HoppieConnector.ts
@@ -96,7 +96,7 @@ export class HoppieConnector {
     };
     const text = await Hoppie.sendRequest(body).then((resp) => resp.response);
 
-    if (text === 'error {callsign already in use}' || text === `ok {${station}}`) {
+    if (text === 'error {callsign already in use}' || text.includes(station)) {
       return AtsuStatusCodes.CallsignInUse;
     }
     if (text.includes('error')) {

--- a/fbw-common/src/systems/datalink/router/src/webinterfaces/HoppieConnector.ts
+++ b/fbw-common/src/systems/datalink/router/src/webinterfaces/HoppieConnector.ts
@@ -49,7 +49,7 @@ export class HoppieConnector {
     };
 
     Hoppie.sendRequest(body).then((resp) => {
-      if (resp.response !== 'error {illegal logon code}') {
+      if (resp.response !== 'error {invalid logon code}') {
         SimVar.SetSimVarValue('L:A32NX_HOPPIE_ACTIVE', 'number', 1);
         console.log('Activated Hoppie ID');
       } else {
@@ -96,7 +96,7 @@ export class HoppieConnector {
     };
     const text = await Hoppie.sendRequest(body).then((resp) => resp.response);
 
-    if (text === 'error {callsign already in use}' || text === `ok {${station}`) {
+    if (text === 'error {callsign already in use}' || text === `ok {${station}}`) {
       return AtsuStatusCodes.CallsignInUse;
     }
     if (text.includes('error')) {

--- a/fbw-common/src/systems/datalink/router/src/webinterfaces/HoppieConnector.ts
+++ b/fbw-common/src/systems/datalink/router/src/webinterfaces/HoppieConnector.ts
@@ -121,7 +121,7 @@ export class HoppieConnector {
     const body = {
       logon: NXDataStore.get('CONFIG_HOPPIE_USERID', ''),
       from: HoppieConnector.flightNumber,
-      to: 'ALL-CALLSIGNS',
+      to: 'SERVER', // Not needed as Hoppie ignores this field usually
       type: 'ping',
       packet: station,
     };

--- a/fbw-common/src/systems/datalink/router/src/webinterfaces/HoppieConnector.ts
+++ b/fbw-common/src/systems/datalink/router/src/webinterfaces/HoppieConnector.ts
@@ -43,7 +43,7 @@ export class HoppieConnector {
     const body = {
       logon: NXDataStore.get('CONFIG_HOPPIE_USERID', ''),
       from: 'FBWA32NX',
-      to: 'ALL-CALLSIGNS',
+      to: 'SERVER',
       type: 'ping',
       packet: '',
     };
@@ -90,13 +90,14 @@ export class HoppieConnector {
     const body = {
       logon: NXDataStore.get('CONFIG_HOPPIE_USERID', ''),
       from: station,
-      to: 'ALL-CALLSIGNS',
+      to: 'SERVER',
       type: 'ping',
       packet: station,
     };
     const text = await Hoppie.sendRequest(body).then((resp) => resp.response);
 
-    if (text === 'error {callsign already in use}') {
+    if (text === 'error {callsign already in use}'
+        || text === `ok {${station}`) {
       return AtsuStatusCodes.CallsignInUse;
     }
     if (text.includes('error')) {

--- a/fbw-common/src/systems/datalink/router/src/webinterfaces/HoppieConnector.ts
+++ b/fbw-common/src/systems/datalink/router/src/webinterfaces/HoppieConnector.ts
@@ -96,8 +96,7 @@ export class HoppieConnector {
     };
     const text = await Hoppie.sendRequest(body).then((resp) => resp.response);
 
-    if (text === 'error {callsign already in use}'
-        || text === `ok {${station}`) {
+    if (text === 'error {callsign already in use}' || text === `ok {${station}`) {
       return AtsuStatusCodes.CallsignInUse;
     }
     if (text.includes('error')) {

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/AtsuAocPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/AtsuAocPage.tsx
@@ -41,7 +41,7 @@ export const AtsuAocPage = () => {
         packet: '',
       };
       return Hoppie.sendRequest(body).then((resp) => {
-        if (resp.response === 'error {illegal logon code}') {
+        if (resp.response === 'error {invalid logon code}') {
           reject(new Error(`Error: Unknown user ID: ${resp.response}`));
         } else {
           resolve(value);

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/AtsuAocPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/AtsuAocPage.tsx
@@ -36,7 +36,7 @@ export const AtsuAocPage = () => {
       const body = {
         logon: value,
         from: 'FBWA32NX',
-        to: 'ALL-CALLSIGNS',
+        to: 'SERVER',
         type: 'ping',
         packet: '',
       };


### PR DESCRIPTION
fix: Use SERVER Callsign as to in the isStationAvailable Method for the HoppieConnector

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9704 
Fixes #9722 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Changed the `to` Callsign when checking whether a station is available on Hoppie to `SERVER` as that field gets ignored and `ALL-CALLSIGNS` is the only special fake callsign

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://github.com/user-attachments/assets/3f31d5d4-c196-4339-aa51-fc0360232e4c)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
https://www.hoppie.nl/acars/system/tech.html
https://github.com/flybywiresim/aircraft/issues/9704

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Power up Aircraft as normal
2. Enter INIT Page
3. Open ATC Communications page -> Ground Requests -> Departure
4. Enter online Station Code
5. Should work instead of displaying "NO ACTIVE ATC"

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
