### PR TITLE
revert: try to improve deconflicting with CHANGELOG

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,3 @@
 # line endings.
 /fbw-a32nx/src/localization/flypad/*.json text eol=lf
 /fbw-a32nx/src/localization/msfs/*.locPak text eol=lf
-
-# try to deconflict changelog
-.github/CHANGELOG.md merge=union


### PR DESCRIPTION
Reverts flybywiresim/aircraft#9402

This unfortunately did not work out as well as hoped. It causes duplicated changelogs under some circumstances, and almost always changelogs in the wrong place, especially for long-running PRs.