### PR TITLE
fix(fms): more robust navdata error handling and sorting

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -125,7 +125,7 @@
 1. [A380X/MFD] Add airport data page into the MFD (DATA > AIRPORT) - @bulenteroglu (senolitam)
 1. [A380X/EFB] Adds PRIM/SEC/FCDC failures to EFB - @flogross89 (floridude)
 1. [A380X/PFD] Fix precision of pitch trim indicator - @flogross89 (floridude)
-
+1. [FMS] Improved nav database error handling, preserving as much valid data as possible - @tracernz (Mike)
 
 ## 0.12.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -126,6 +126,7 @@
 1. [A380X/EFB] Adds PRIM/SEC/FCDC failures to EFB - @flogross89 (floridude)
 1. [A380X/PFD] Fix precision of pitch trim indicator - @flogross89 (floridude)
 1. [FMS] Improved nav database error handling, preserving as much valid data as possible - @tracernz (Mike)
+1. [A32NX/FMS] Sort instrument procedures for display on the MCDU - @tracernz (Mike)
 
 ## 0.12.0
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
@@ -143,8 +143,8 @@ class CDUAvailableArrivalsPage {
             // Filter out approaches with no matching runway
             // Approaches not going to a specific runway (i.e circling approaches are filtered out at DB level)
             .filter((a) => !!runways.find((rw) => rw.ident === a.runwayIdent))
-            // Sort the approaches in Honeywell's documented order
-            .sort((a, b) => ApproachTypeOrder[a.type] - ApproachTypeOrder[b.type])
+            // Sort the approaches in Honeywell's documented order, and alphabetical in between
+            .sort((a, b) => a.type != b.type ? ApproachTypeOrder[a.type] - ApproachTypeOrder[b.type] : a.ident.localeCompare(b.ident))
             .map((approach) => ({ approach }))
             .concat(
                 // Runway-by-itself approaches
@@ -252,7 +252,7 @@ class CDUAvailableArrivalsPage {
             const destinationRunway = targetPlan.destinationRunway;
 
             if (destinationRunway) {
-                const arrivals = targetPlan.availableArrivals;
+                const arrivals = [...targetPlan.availableArrivals].sort((a, b) => a.ident.localeCompare(b.ident));
 
                 for (let i = 0; i < arrivals.length; i++) {
                     const arrival = arrivals[i];

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableDeparturesPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableDeparturesPage.js
@@ -47,7 +47,7 @@ class CDUAvailableDeparturesPage {
 
         /** @type {import('msfs-navdata').Runway[]} */
         const availableRunways = [...targetPlan.availableOriginRunways];
-        let availableSids = [...targetPlan.availableDepartures];
+        let availableSids = [...targetPlan.availableDepartures].sort((a, b) => a.ident.localeCompare(b.ident));
         let availableTransitions = [];
 
         if (selectedRunway) {

--- a/fbw-common/src/systems/navdata/client/backends/Msfs/Mapping.ts
+++ b/fbw-common/src/systems/navdata/client/backends/Msfs/Mapping.ts
@@ -671,46 +671,54 @@ export class MsfsMapping {
         // Filter out circling approaches
         .filter((approach) => approach.runwayNumber !== 0)
         .map((approach) => {
-          const approachName = this.mapApproachName(approach);
-          const suffix = approach.approachSuffix.length > 0 ? approach.approachSuffix : undefined;
+          try {
+            const approachName = this.mapApproachName(approach);
+            const suffix = approach.approachSuffix.length > 0 ? approach.approachSuffix : undefined;
 
-          // The AR flag is only available from MSFS2024, so fall back to a heuristic based on analysing the MSFS2020 data if not available.
-          const authorisationRequired =
-            approach.rnpAr !== undefined
-              ? approach.rnpAr
-              : approach.approachType === MSApproachType.Rnav && approach.rnavTypeFlags === 0;
-          const rnp = authorisationRequired ? 0.3 : undefined;
-          const missedApproachAuthorisationRequired =
-            approach.rnpArMissed !== undefined ? approach.rnpArMissed : authorisationRequired;
+            // The AR flag is only available from MSFS2024, so fall back to a heuristic based on analysing the MSFS2020 data if not available.
+            const authorisationRequired =
+              approach.rnpAr !== undefined
+                ? approach.rnpAr
+                : approach.approachType === MSApproachType.Rnav && approach.rnavTypeFlags === 0;
+            const rnp = authorisationRequired ? 0.3 : undefined;
+            const missedApproachAuthorisationRequired =
+              approach.rnpArMissed !== undefined ? approach.rnpArMissed : authorisationRequired;
 
-          const runwayIdent = `${airportIdent}${approach.runwayNumber.toString().padStart(2, '0')}${this.mapRunwayDesignator(approach.runwayDesignator)}`;
+            const runwayIdent = `${airportIdent}${approach.runwayNumber.toString().padStart(2, '0')}${this.mapRunwayDesignator(approach.runwayDesignator)}`;
 
-          const levelOfService = this.mapRnavTypeFlags(approach.rnavTypeFlags);
+            const levelOfService = this.mapRnavTypeFlags(approach.rnavTypeFlags);
 
-          const transitions = this.mapApproachTransitions(approach, facilities, msAirport, approachName);
+            const transitions = this.mapApproachTransitions(approach, facilities, msAirport, approachName);
 
-          return {
-            sectionCode: SectionCode.Airport,
-            subSectionCode: AirportSubsectionCode.ApproachProcedures,
-            databaseId: `P${icaoCode}${airportIdent}${approach.name}`,
-            icaoCode,
-            ident: approachName,
-            suffix,
-            runwayIdent,
-            multipleIndicator: approach.approachSuffix,
-            type: this.mapApproachType(approach.approachType),
-            authorisationRequired,
-            missedApproachAuthorisationRequired,
-            levelOfService,
-            transitions,
-            legs: approach.finalLegs.map((leg, legIndex) =>
-              this.mapLeg(leg, legIndex, facilities, msAirport, approachName, approach.approachType, rnp),
-            ),
-            missedLegs: approach.missedLegs.map((leg, legIndex) =>
-              this.mapLeg(leg, legIndex, facilities, msAirport, approachName),
-            ),
-          };
+            const ret: Approach = {
+              sectionCode: SectionCode.Airport,
+              subSectionCode: AirportSubsectionCode.ApproachProcedures,
+              databaseId: `P${icaoCode}${airportIdent}${approach.name}`,
+              icaoCode,
+              ident: approachName,
+              suffix,
+              runwayIdent,
+              multipleIndicator: approach.approachSuffix,
+              type: this.mapApproachType(approach.approachType),
+              authorisationRequired,
+              missedApproachAuthorisationRequired,
+              levelOfService,
+              transitions,
+              legs: approach.finalLegs.map((leg, legIndex) =>
+                this.mapLeg(leg, legIndex, facilities, msAirport, approachName, approach.approachType, rnp),
+              ),
+              missedLegs: approach.missedLegs.map((leg, legIndex) =>
+                this.mapLeg(leg, legIndex, facilities, msAirport, approachName),
+              ),
+            };
+
+            return ret;
+          } catch (e) {
+            console.error(`Error mapping approach ${msAirport.icao} ${approach.name}`, e);
+          }
+          return null;
         })
+        .filter((v) => v !== null)
     );
   }
 
@@ -720,23 +728,33 @@ export class MsfsMapping {
 
     const facilities = await this.loadFacilitiesFromProcedures(msAirport.arrivals);
 
-    return msAirport.arrivals.map((arrival) => ({
-      sectionCode: SectionCode.Airport,
-      subSectionCode: AirportSubsectionCode.STARs,
-      databaseId: `P${icaoCode}${airportIdent}${arrival.name}`,
-      icaoCode,
-      ident: arrival.name,
-      authorisationRequired: arrival.rnpAr ?? false,
-      commonLegs: arrival.commonLegs.map((leg, legIndex) =>
-        this.mapLeg(leg, legIndex, facilities, msAirport, arrival.name),
-      ),
-      enrouteTransitions: arrival.enRouteTransitions.map((trans, idx) =>
-        this.mapEnrouteTransition(trans, facilities, msAirport, arrival.name, arrival.name + idx),
-      ),
-      runwayTransitions: arrival.runwayTransitions.map((trans, idx) =>
-        this.mapRunwayTransition(trans, facilities, msAirport, arrival.name, arrival.name + idx),
-      ),
-    }));
+    return msAirport.arrivals
+      .map((arrival) => {
+        try {
+          const ret: Arrival = {
+            sectionCode: SectionCode.Airport,
+            subSectionCode: AirportSubsectionCode.STARs,
+            databaseId: `P${icaoCode}${airportIdent}${arrival.name}`,
+            icaoCode,
+            ident: arrival.name,
+            authorisationRequired: arrival.rnpAr ?? false,
+            commonLegs: arrival.commonLegs.map((leg, legIndex) =>
+              this.mapLeg(leg, legIndex, facilities, msAirport, arrival.name),
+            ),
+            enrouteTransitions: arrival.enRouteTransitions.map((trans, idx) =>
+              this.mapEnrouteTransition(trans, facilities, msAirport, arrival.name, arrival.name + idx),
+            ),
+            runwayTransitions: arrival.runwayTransitions.map((trans, idx) =>
+              this.mapRunwayTransition(trans, facilities, msAirport, arrival.name, arrival.name + idx),
+            ),
+          };
+          return ret;
+        } catch (e) {
+          console.error(`Error mapping arrival ${msAirport.icao} ${arrival.name}`, e);
+        }
+        return null;
+      })
+      .filter((v) => v !== null);
   }
 
   public async mapDepartures(msAirport: JS_FacilityAirport): Promise<Departure[]> {
@@ -745,37 +763,45 @@ export class MsfsMapping {
 
     const facilities = await this.loadFacilitiesFromProcedures(msAirport.departures);
 
-    return msAirport.departures.map((departure) => {
-      let authorisationRequired = departure.rnpAr;
-      if (authorisationRequired === undefined) {
-        // fallback heuristic for MSFS2020
-        authorisationRequired =
-          this.isAnyRfLegPresent(departure.commonLegs) ||
-          this.isAnyRfLegPresent(departure.runwayTransitions) ||
-          this.isAnyRfLegPresent(departure.enRouteTransitions);
-      }
+    return msAirport.departures
+      .map((departure) => {
+        try {
+          let authorisationRequired = departure.rnpAr;
+          if (authorisationRequired === undefined) {
+            // fallback heuristic for MSFS2020
+            authorisationRequired =
+              this.isAnyRfLegPresent(departure.commonLegs) ||
+              this.isAnyRfLegPresent(departure.runwayTransitions) ||
+              this.isAnyRfLegPresent(departure.enRouteTransitions);
+          }
 
-      const commonLegsRnp = authorisationRequired ? 0.3 : undefined;
+          const commonLegsRnp = authorisationRequired ? 0.3 : undefined;
 
-      return {
-        sectionCode: SectionCode.Airport,
-        subSectionCode: AirportSubsectionCode.SIDs,
-        databaseId: `P${icaoCode}${airportIdent}${departure.name}`,
-        icaoCode,
-        ident: departure.name,
-        authorisationRequired,
-        commonLegs: departure.commonLegs.map((leg, legIndex) =>
-          this.mapLeg(leg, legIndex, facilities, msAirport, departure.name, undefined, commonLegsRnp),
-        ),
-        engineOutLegs: [],
-        enrouteTransitions: departure.enRouteTransitions.map((trans, idx) =>
-          this.mapEnrouteTransition(trans, facilities, msAirport, departure.name, departure.name + idx),
-        ),
-        runwayTransitions: departure.runwayTransitions.map((trans, idx) =>
-          this.mapRunwayTransition(trans, facilities, msAirport, departure.name, departure.name + idx),
-        ),
-      };
-    });
+          const ret: Departure = {
+            sectionCode: SectionCode.Airport,
+            subSectionCode: AirportSubsectionCode.SIDs,
+            databaseId: `P${icaoCode}${airportIdent}${departure.name}`,
+            icaoCode,
+            ident: departure.name,
+            authorisationRequired,
+            commonLegs: departure.commonLegs.map((leg, legIndex) =>
+              this.mapLeg(leg, legIndex, facilities, msAirport, departure.name, undefined, commonLegsRnp),
+            ),
+            engineOutLegs: [],
+            enrouteTransitions: departure.enRouteTransitions.map((trans, idx) =>
+              this.mapEnrouteTransition(trans, facilities, msAirport, departure.name, departure.name + idx),
+            ),
+            runwayTransitions: departure.runwayTransitions.map((trans, idx) =>
+              this.mapRunwayTransition(trans, facilities, msAirport, departure.name, departure.name + idx),
+            ),
+          };
+          return ret;
+        } catch (e) {
+          console.error(`Error mapping departure ${msAirport.icao} ${departure.name}`, e);
+        }
+        return null;
+      })
+      .filter((v) => v !== null);
   }
 
   public async mapGates(msAirport: JS_FacilityAirport): Promise<Gate[]> {
@@ -1037,6 +1063,31 @@ export class MsfsMapping {
     };
   }
 
+  private tryGetWaypointFromIcao(
+    airport: JS_FacilityAirport,
+    facilities: Map<string, JS_Facility>,
+    icao: string,
+  ): ReturnType<MsfsMapping['mapFacilityToWaypoint']> | undefined {
+    const isRunway = icao.charAt(0) === 'R';
+    if (!FacilityCache.validFacilityIcao(icao) && !isRunway) {
+      return undefined;
+    }
+
+    let ret: ReturnType<MsfsMapping['mapFacilityToWaypoint']> | undefined;
+
+    if (isRunway) {
+      ret = this.mapRunwayWaypoint(airport, icao);
+    } else {
+      const facility = facilities.get(icao);
+      ret = facility ? this.mapFacilityToWaypoint(facility) : undefined;
+    }
+
+    if (!ret) {
+      throw new Error(`Missing fix ${icao} for procedure leg!`);
+    }
+    return ret;
+  }
+
   private mapLeg(
     leg: JS_Leg,
     legIndex: number,
@@ -1046,28 +1097,17 @@ export class MsfsMapping {
     approachType?: MSApproachType,
     fallbackRnp?: number,
   ): ProcedureLeg {
-    const arcCentreFixFacility = FacilityCache.validFacilityIcao(leg.arcCenterFixIcao)
-      ? facilities.get(leg.arcCenterFixIcao)
-      : undefined;
-    const arcCentreFix = arcCentreFixFacility ? this.mapFacilityToWaypoint(arcCentreFixFacility) : undefined;
-    let waypoint;
-    if (leg.fixIcao.charAt(0) === 'R') {
-      waypoint = this.mapRunwayWaypoint(airport, leg.fixIcao);
-    } else {
-      const waypointFacility = FacilityCache.validFacilityIcao(leg.fixIcao) ? facilities.get(leg.fixIcao) : undefined;
-      waypoint = waypointFacility ? this.mapFacilityToWaypoint(waypointFacility) : undefined;
-    }
-    const recommendedNavaidFacility = FacilityCache.validFacilityIcao(leg.originIcao)
-      ? facilities.get(leg.originIcao)
-      : undefined;
-    const recommendedNavaid = recommendedNavaidFacility
-      ? this.mapFacilityToWaypoint(recommendedNavaidFacility)
-      : undefined;
+    const arcCentreFix = this.tryGetWaypointFromIcao(airport, facilities, leg.arcCenterFixIcao);
+    const waypoint = this.tryGetWaypointFromIcao(airport, facilities, leg.fixIcao);
+    const recommendedNavaid = this.tryGetWaypointFromIcao(airport, facilities, leg.originIcao);
 
     let arcRadius: number | undefined;
     if (leg.type === MsLegType.RF) {
-      if (!arcCentreFix || !waypoint) {
-        throw new Error('Missing data for RF leg!');
+      if (!arcCentreFix) {
+        throw new Error(`No arc centre fix for RF leg!`);
+      }
+      if (!waypoint) {
+        throw new Error(`No waypoint fix for RF leg!`);
       }
       arcRadius = distanceTo(arcCentreFix.location, waypoint.location);
     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Improve robustness of procedure loading, discard procedures that are missing data rather than discarding entire airports.
Sort the procedures in the A32NX FMS (this is necessary when navdata is coming from multiple sources).

This potentially helps with INTERNAL ERROR, and certainly helps with some navdata issues I've seen.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Loading some airports in the A32NX, and ensure the procedures work okay (step through in PLAN mode), and that procedures are sorted in order on the arrival and departure pages.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
