### PR TITLE
feat(a32nx): hook up engine oil sim

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -133,6 +133,7 @@
 1. [A380X/FMS] Use cruise mach above crossover altitude - @flogross89 (floridude)
 1. [A380X/SD] Display oil quantity on ENG page - @flogross89 (floridude)
 1. [A380X/FMS] Accept KCCU plus/minus key as first entry into field - @flogross89 (floridude)
+1. [A32NX/SD] Use oil quantity and pressure simulation on ENG page - @tracernz (Mike)
 
 ## 0.12.0
 

--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -2380,13 +2380,23 @@ In the variables below, {number} should be replaced with one item in the set: { 
     - Number (lbs)
     - Previous deltaTime fuel for the center tank
 
-- A32NX_ENGINE_OIL_TOTAL:{index}
+- `A32NX_ENGINE_OIL_PRESS:{index}`
+    - Number (psi)
+    - Total engine {index} oil quantity in the oil tank
+
+- `A32NX_ENGINE_OIL_QTY:{index}`
+    - Number (quarts)
+    - Total engine {index} oil quantity in the oil tank
+
+- `A32NX_ENGINE_OIL_TEMP:{index}`
+    - Number (celsius)
+    - Total engine {index} oil quantity in the oil system (tank + circuit)
+
+- `A32NX_ENGINE_OIL_TOTAL:{index}`
     - Number (quarts)
     - Total engine {index} oil quantity in the oil system (tank + circuit)
 
-- A32NX_ENGINE_OIL_QTY:{index}
-    - Number (quarts)
-    - Total engine {index} oil quantity in the oil tank
+
 
 ## Air Conditioning / Pressurisation / Ventilation
 

--- a/fbw-a32nx/src/systems/instruments/src/SD/Pages/Eng/Eng.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Pages/Eng/Eng.tsx
@@ -4,7 +4,7 @@
 
 import React, { FC, useState, useEffect } from 'react';
 import { Arc, Needle } from '@instruments/common/gauges';
-import { usePersistentProperty, useSimVar } from '@flybywiresim/fbw-sdk';
+import { MathUtils, usePersistentProperty, useSimVar } from '@flybywiresim/fbw-sdk';
 import { PageTitle } from '../../Common/PageTitle';
 import { EcamPage } from '../../Common/EcamPage';
 import { SvgGroup } from '../../Common/SvgGroup';
@@ -87,13 +87,14 @@ function getNeedleValue(value: any, max: number): number {
 interface ComponentPositionProps {
   x: number;
   y: number;
+  /** 1-based index of the engine.*/
   engineNumber: number;
   fadecOn: boolean;
 }
 
 const PressureGauge = ({ x, y, engineNumber, fadecOn }: ComponentPositionProps) => {
-  const [engineOilPressure] = useSimVar(`ENG OIL PRESSURE:${engineNumber}`, 'psi', 100);
-  const displayedEngineOilPressure = Math.round(engineOilPressure / 2) * 2; // Engine oil pressure has a step of 2
+  const [engineOilPressure] = useSimVar(`L:A32NX_ENGINE_OIL_PRESS:${engineNumber}`, 'number', 100);
+  const displayedEngineOilPressure = MathUtils.round(engineOilPressure, 2); // Engine oil pressure has a step of 2
   const OIL_PSI_MAX = 130;
   const OIL_PSI_HIGH_LIMIT = 130;
   const OIL_PSI_LOW_LIMIT = 14; // TODO FIXME: standin value
@@ -190,11 +191,10 @@ const PressureGauge = ({ x, y, engineNumber, fadecOn }: ComponentPositionProps) 
 };
 
 const QuantityGauge = ({ x, y, engineNumber, fadecOn }: ComponentPositionProps) => {
-  const [engineOilQuantity] = useSimVar(`ENG OIL QUANTITY:${engineNumber}`, 'percent', 100);
+  const [engineOilQuantity] = useSimVar(`L:A32NX_ENGINE_OIL_QTY:${engineNumber}`, 'number', 100);
   const OIL_QTY_MAX = 24.25;
   const OIL_QTY_LOW_ADVISORY = 1.35;
-  const displayedEngineOilQuantity =
-    engineOilQuantity === 100 ? OIL_QTY_MAX : Math.round(((engineOilQuantity / 100) * OIL_QTY_MAX) / 0.5) * 0.5; // Engine oil quantity has a step of 0.2
+  const displayedEngineOilQuantity = MathUtils.clamp(MathUtils.round(engineOilQuantity, 0.5), 0, OIL_QTY_MAX); // Engine oil quantity has a step of 0.5
   const [quantityAtOrBelowLow, setQuantityAtOrBelowLow] = useState(false);
   const [shouldQuantityPulse, setShouldQuantityPulse] = useState(false);
 

--- a/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/EngineControlA32NX.h
+++ b/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/EngineControlA32NX.h
@@ -56,6 +56,10 @@ class EngineControl_A32NX {
   double prevThrustLimitType       = 0.0;
   double prevEngineMasterPos[2]    = {0, 0};
   bool   prevEngineStarterState[2] = {false, false};
+  double thermalEnergy[2]          = {
+      0.,
+      0.,
+  };
 
   // FLX->CLB thrust limit transition
   double transitionStartTime;
@@ -63,9 +67,10 @@ class EngineControl_A32NX {
   bool   wasFlexActive = false;
 
   // additional constants
-  static constexpr int    MAX_OIL             = 200;
-  static constexpr int    MIN_OIL             = 140;
-  static constexpr double FUEL_RATE_THRESHOLD = 661;  // lbs/sec for determining fuel ui tampering
+  static constexpr int    MAX_OIL              = 200;
+  static constexpr int    MIN_OIL              = 140;
+  static constexpr int    MAX_OIL_TEMP_NOMINAL = 86;
+  static constexpr double FUEL_RATE_THRESHOLD  = 661;  // lbs/sec for determining fuel ui tampering
 
   /**
    * @enum EngineState
@@ -335,6 +340,15 @@ class EngineControl_A32NX {
                           int    packs,
                           int    nai,
                           int    wai);
+
+  void updateOil(int         engine,
+                 EngineState engineState,
+                 double      imbalance,
+                 double      thrust,
+                 double      simN2,
+                 double      deltaTime,
+                 bool        isOnGround,
+                 double      ambientTemp);
 };
 
 #endif  // FLYBYWIRE_AIRCRAFT_ENGINECONTROL_A32NX_H

--- a/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/FadecSimData_A32NX.hpp
+++ b/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/FadecSimData_A32NX.hpp
@@ -120,6 +120,7 @@ class FadecSimData_A32NX {
     FLOAT64 pressureAltitude;          // Feet
     FLOAT64 simEngineN1[2];            // Percent
     FLOAT64 simEngineN2[2];            // Percent
+    FLOAT64 simEngineThrust[2];        // Percent
     FLOAT64 xFeedValve;                // Number
     FLOAT64 xfrCenterManual[2];        // Number
     FLOAT64 xfrValveCenterAuto[2];     // Number
@@ -158,6 +159,8 @@ class FadecSimData_A32NX {
       {"TURB ENG N1",                  2,  UNITS.Percent  }, // simEngineN1[1]
       {"TURB ENG N2",                  1,  UNITS.Percent  }, // simEngineN2[0]
       {"TURB ENG N2",                  2,  UNITS.Percent  }, // simEngineN2[1]
+      {"TURB ENG JET THRUST",          1,  UNITS.Pounds   }, // simEngineThrust[0]
+      {"TURB ENG JET THRUST",          2,  UNITS.Pounds   }, // simEngineThrust[1]
       {"FUELSYSTEM VALVE OPEN",        3,  UNITS.Number   }, // xFeedValve
       {"FUELSYSTEM JUNCTION SETTING",  4,  UNITS.Number   }, // xfrCenterManual[0]
       {"FUELSYSTEM JUNCTION SETTING",  5,  UNITS.Number   }, // xfrCenterManual[1]
@@ -197,8 +200,10 @@ class FadecSimData_A32NX {
   NamedVariablePtr engineImbalance;
   NamedVariablePtr engineN1[2];
   NamedVariablePtr engineN2[2];
-  NamedVariablePtr engineOilTotal[2];
-  NamedVariablePtr engineOil[2];
+  NamedVariablePtr engineOilPressure[2];
+  NamedVariablePtr engineOilTankQuantity[2];
+  NamedVariablePtr engineOilTemperature[2];
+  NamedVariablePtr engineOilTotalQuantity[2];
   NamedVariablePtr enginePreFF[2];
   NamedVariablePtr engineStarterPressurized[2];
   NamedVariablePtr engineState[2];
@@ -314,11 +319,17 @@ class FadecSimData_A32NX {
     engineN2[L] = dm->make_named_var("A32NX_ENGINE_N2:1", UNITS.Number, AUTO_READ_WRITE);
     engineN2[R] = dm->make_named_var("A32NX_ENGINE_N2:2", UNITS.Number, AUTO_READ_WRITE);
 
-    engineOil[L] = dm->make_named_var("A32NX_ENGINE_OIL_QTY:1", UNITS.Number, AUTO_READ_WRITE);
-    engineOil[R] = dm->make_named_var("A32NX_ENGINE_OIL_QTY:2", UNITS.Number, AUTO_READ_WRITE);
+    engineOilPressure[L] = dm->make_named_var("A32NX_ENGINE_OIL_PRESS:1", UNITS.Number, AUTO_READ_WRITE);
+    engineOilPressure[R] = dm->make_named_var("A32NX_ENGINE_OIL_PRESS:2", UNITS.Number, AUTO_READ_WRITE);
 
-    engineOilTotal[L] = dm->make_named_var("A32NX_ENGINE_OIL_TOTAL:1", UNITS.Number, AUTO_READ_WRITE);
-    engineOilTotal[R] = dm->make_named_var("A32NX_ENGINE_OIL_TOTAL:2", UNITS.Number, AUTO_READ_WRITE);
+    engineOilTankQuantity[L] = dm->make_named_var("A32NX_ENGINE_OIL_QTY:1", UNITS.Number, AUTO_READ_WRITE);
+    engineOilTankQuantity[R] = dm->make_named_var("A32NX_ENGINE_OIL_QTY:2", UNITS.Number, AUTO_READ_WRITE);
+
+    engineOilTemperature[L] = dm->make_named_var("A32NX_ENGINE_OIL_TEMP:1", UNITS.Number, AUTO_READ_WRITE);
+    engineOilTemperature[R] = dm->make_named_var("A32NX_ENGINE_OIL_TEMP:2", UNITS.Number, AUTO_READ_WRITE);
+
+    engineOilTotalQuantity[L] = dm->make_named_var("A32NX_ENGINE_OIL_TOTAL:1", UNITS.Number, AUTO_READ_WRITE);
+    engineOilTotalQuantity[R] = dm->make_named_var("A32NX_ENGINE_OIL_TOTAL:2", UNITS.Number, AUTO_READ_WRITE);
 
     enginePreFF[L] = dm->make_named_var("A32NX_ENGINE_PRE_FF:1", UNITS.Number, AUTO_READ_WRITE);
     enginePreFF[R] = dm->make_named_var("A32NX_ENGINE_PRE_FF:2", UNITS.Number, AUTO_READ_WRITE);
@@ -374,10 +385,10 @@ class FadecSimData_A32NX {
     engineN1[R]->setAndWriteToSim(0);
     engineN2[L]->setAndWriteToSim(0);
     engineN2[R]->setAndWriteToSim(0);
-    engineOilTotal[L]->setAndWriteToSim(0);
-    engineOilTotal[R]->setAndWriteToSim(0);
-    engineOil[L]->setAndWriteToSim(0);
-    engineOil[R]->setAndWriteToSim(0);
+    engineOilTotalQuantity[L]->setAndWriteToSim(0);
+    engineOilTotalQuantity[R]->setAndWriteToSim(0);
+    engineOilTankQuantity[L]->setAndWriteToSim(0);
+    engineOilTankQuantity[R]->setAndWriteToSim(0);
     enginePreFF[L]->setAndWriteToSim(0);
     enginePreFF[R]->setAndWriteToSim(0);
     engineState[L]->setAndWriteToSim(0);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Hook up the engine oil quantity and pressure code in the FADEC and into the SD.

The oil temp code doesn't make sense, so don't use it for now.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Try from cold and dark, through to airborne, with the ENG page open on the SD watching the oil pressure and quantity; ensure it is always reasonable.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
