### PR TITLE
fix(fms): use station declination for cr/vr legs referencing a vor

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -139,6 +139,7 @@
 1. [A32NX/FMS] Add terminal area database holds for MSFS2024 - @tracernz (Mike)
 1. [EFB] Set EFB Auto Brightness to default to On - @MrJigs7 (MrJigs)
 1. [FMS] Allow airport to be loaded as fixes in instrument procedures - @tracernz (Mike)
+1. [FMS] Make sure radials of CR/VR legs use the station declination as magvar - @BlueberryKing (BlueberryKing)
 
 ## 0.12.0
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -867,7 +867,6 @@ class CDUFlightPlanPage {
 
         try {
             await mcdu.flightPlanService.deleteElementAt(fpIndex, insertDiscontinuity, forPlan, forAlternate);
-            console.log("deleting element");
         } catch (e) {
             console.error(e);
             mcdu.logTroubleshootingError(e);

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/plans/BaseFlightPlan.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/plans/BaseFlightPlan.ts
@@ -2224,8 +2224,10 @@ export abstract class BaseFlightPlan<P extends FlightPlanPerformanceData = Fligh
       }
     }
 
-    if (this.enrouteSegment.allLegs[0]?.isDiscontinuity === false) {
-      // Insert disco otherwise
+    this.incrementVersion();
+
+    // Insert disco after departure segment if there is no disco already
+    if (this.allLegs[lastDepartureLegIndexInPlan + 1]?.isDiscontinuity === false) {
       this.enrouteSegment.allLegs.unshift({ isDiscontinuity: true });
       this.enqueueOperation(FlightPlanQueuedOperation.SyncSegmentLegs, lastDepartureSegment);
     }

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/segments/DepartureEnrouteTransitionSegment.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/segments/DepartureEnrouteTransitionSegment.ts
@@ -29,7 +29,8 @@ export class DepartureEnrouteTransitionSegment extends ProcedureSegment<Procedur
       if (!skipUpdateLegs) {
         this.allLegs.length = 0;
 
-        this.flightPlan.syncSegmentLegsChange(this);
+        this.flightPlan.enqueueOperation(FlightPlanQueuedOperation.Restring, RestringOptions.RestringDeparture);
+        this.flightPlan.enqueueOperation(FlightPlanQueuedOperation.SyncSegmentLegs, this);
       }
 
       return;

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/geometry/GeometryFactory.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/geometry/GeometryFactory.ts
@@ -257,7 +257,9 @@ function geometryLegFromFlightPlanLeg(
   const waypoint = flightPlanLeg.terminationWaypoint();
   const recommendedNavaid = flightPlanLeg.definition.recommendedNavaid;
   const trueCourse = flightPlanLeg.definition.magneticCourse + runningMagvar;
-  const trueTheta = flightPlanLeg.definition.theta + runningMagvar;
+  const magneticTheta = flightPlanLeg.definition.theta;
+  const radialMagVar = recommendedNavaid ? A32NX_Util.getRadialMagVar(recommendedNavaid) : runningMagvar;
+  const trueTheta = A32NX_Util.magneticToTrue(flightPlanLeg.definition.theta, radialMagVar);
   const length = flightPlanLeg.definition.length;
 
   switch (legType) {
@@ -293,7 +295,7 @@ function geometryLegFromFlightPlanLeg(
     case LegType.VR: // TODO VR leg in geometry
       return new CRLeg(
         trueCourse,
-        { ident: recommendedNavaid.ident, coordinates: recommendedNavaid.location, theta: trueTheta - runningMagvar },
+        { ident: recommendedNavaid.ident, coordinates: recommendedNavaid.location, theta: magneticTheta },
         trueTheta,
         metadata,
         SegmentType.Departure,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Another day, another magvar issue. 

- Makes sure to use the station declination to compute the true radial bearing for CR/VR legs referencing a VOR navaid.
- Also fixes an issue where two discontinuities would exist in the flight plan after removing a departure transition. This happened because the flight plan was not restrung when the transition was removed, so both the discontinuity between sid and en route transition as well as the discontinuity between en route transition and en route segment persisted.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://github.com/user-attachments/assets/fc2187bd-c499-459b-ae3b-2a22f9bfa0b6)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Try one of 
  - KEWR/04L EWR 5, 
  - EGGP/09 POL 5V, 
  - FACT/19 OKTED 1C, 
  - LDDU/29 BEVIS 3D
  - LGAV/03L ROPOX 1D
  - LIMC/35L IPCUC 7F
  - or any other procedure you know of containing a CR/VR leg
- Make sure that all fixes are where you would expect them according to the chart.
- Enter a flight plan with a departure transition (common in the US). Remove the departure transition, make sure you only see one discontinuity in the flight plan.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
