### PR TITLE
feat(a380x/fms): Add (auto) step climbs; Allow CLB/DES constraint selection

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -147,6 +147,8 @@
 1. [A380X/FMS] Add page scroll via soft keys & individual scroll via KCCU on MFD F-PLN - @BravoMike99 (bruno_pt99)
 1. [A32NX/FMS] Added nav database swap confirmation - @tracernz (Mike)
 1. [A380X/FMS] Add basic FIX INFO functionality - @Benjozork (Benjamin Dupont)
+1. [A380X/FMS] Add STEP ALTs tab on VERT REV page & auto step climb functionality - @flogross89 (floridude)
+1. [A380X/FMS] Add selection of CLB/DES constraint if constraint type is unknown - @flogross89 (floridude)
 
 ## 0.12.0
 

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/CruiseStep.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/CruiseStep.ts
@@ -9,6 +9,7 @@ export type CruiseStepEntry = {
   toAltitude: number;
   /**
    * Index of the waypoint to insert the step at.
+   * WARNING: Is not always updated, e.g. for DIRECT TOs
    */
   waypointIndex: number;
   /**

--- a/fbw-a32nx/src/systems/instruments/src/EFB/index.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/index.tsx
@@ -50,6 +50,7 @@ render(
         realism: {
           mcduKeyboard: true,
           pauseOnTod: true,
+          autoStepClimb: false,
           pilotAvatars: true,
           eclSoftKeys: false,
         },

--- a/fbw-a380x/README.md
+++ b/fbw-a380x/README.md
@@ -39,6 +39,7 @@ This list is divided into standardized ATA chapters, if there are no noteworthy 
 - Fuel planning on FMS/FUEL&LOAD page
 - ATC / datalink / CPDLC
 - FCU BKUP
+- STEP ALTs: Optimum step calculation
 
 ### ATA 23 Communication
 

--- a/fbw-a380x/src/systems/instruments/src/EFB/index.tsx
+++ b/fbw-a380x/src/systems/instruments/src/EFB/index.tsx
@@ -47,6 +47,7 @@ render(
         realism: {
           mcduKeyboard: false,
           pauseOnTod: true,
+          autoStepClimb: true,
           pilotAvatars: false,
           eclSoftKeys: true,
         },

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FlightManagementComputer.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FlightManagementComputer.ts
@@ -190,7 +190,7 @@ export class FlightManagementComputer implements FmcInterface {
   // TODO make private, and access methods through FmcInterface
   public acInterface!: FmcAircraftInterface;
 
-  public revisedWaypointIndex = Subject.create<number | null>(null);
+  public revisedWaypointLegIndex = Subject.create<number | null>(null);
 
   public revisedWaypointPlanIndex = Subject.create<FlightPlanIndex | null>(null);
 
@@ -294,7 +294,7 @@ export class FlightManagementComputer implements FmcInterface {
   }
 
   public revisedWaypoint(): Fix | undefined {
-    const revWptIdx = this.revisedWaypointIndex.get();
+    const revWptIdx = this.revisedWaypointLegIndex.get();
     const revPlanIdx = this.revisedWaypointPlanIndex.get();
     if (revWptIdx !== null && revPlanIdx !== null && this.flightPlanService.has(revPlanIdx)) {
       const flightPlan = this.revisedWaypointIsAltn.get()
@@ -310,11 +310,11 @@ export class FlightManagementComputer implements FmcInterface {
   public setRevisedWaypoint(index: number, planIndex: number, isAltn: boolean) {
     this.revisedWaypointPlanIndex.set(planIndex);
     this.revisedWaypointIsAltn.set(isAltn);
-    this.revisedWaypointIndex.set(index);
+    this.revisedWaypointLegIndex.set(index);
   }
 
   public resetRevisedWaypoint(): void {
-    this.revisedWaypointIndex.set(null);
+    this.revisedWaypointLegIndex.set(null);
     this.revisedWaypointIsAltn.set(null);
     this.revisedWaypointPlanIndex.set(null);
   }

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FlightManagementComputer.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FlightManagementComputer.ts
@@ -981,6 +981,7 @@ export class FlightManagementComputer implements FmcInterface {
         this.acInterface.updatePerfSpeeds();
         this.acInterface.updateWeights();
         this.acInterface.toSpeedsChecks();
+        this.acInterface.checkForStepClimb();
 
         const toFlaps = this.fmgc.getTakeoffFlapsSetting();
         if (toFlaps) {

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FlightManagementComputer.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FlightManagementComputer.ts
@@ -190,11 +190,11 @@ export class FlightManagementComputer implements FmcInterface {
   // TODO make private, and access methods through FmcInterface
   public acInterface!: FmcAircraftInterface;
 
-  public revisedWaypointLegIndex = Subject.create<number | null>(null);
+  public revisedLegIndex = Subject.create<number | null>(null);
 
-  public revisedWaypointPlanIndex = Subject.create<FlightPlanIndex | null>(null);
+  public revisedLegPlanIndex = Subject.create<FlightPlanIndex | null>(null);
 
-  public revisedWaypointIsAltn = Subject.create<boolean | null>(null);
+  public revisedLegIsAltn = Subject.create<boolean | null>(null);
 
   public enginesWereStarted = Subject.create<boolean>(false);
 
@@ -294,10 +294,10 @@ export class FlightManagementComputer implements FmcInterface {
   }
 
   public revisedWaypoint(): Fix | undefined {
-    const revWptIdx = this.revisedWaypointLegIndex.get();
-    const revPlanIdx = this.revisedWaypointPlanIndex.get();
+    const revWptIdx = this.revisedLegIndex.get();
+    const revPlanIdx = this.revisedLegPlanIndex.get();
     if (revWptIdx !== null && revPlanIdx !== null && this.flightPlanService.has(revPlanIdx)) {
-      const flightPlan = this.revisedWaypointIsAltn.get()
+      const flightPlan = this.revisedLegIsAltn.get()
         ? this.flightPlanService.get(revPlanIdx).alternateFlightPlan
         : this.flightPlanService.get(revPlanIdx);
       if (flightPlan.hasElement(revWptIdx) && flightPlan.elementAt(revWptIdx)?.isDiscontinuity === false) {
@@ -308,15 +308,15 @@ export class FlightManagementComputer implements FmcInterface {
   }
 
   public setRevisedWaypoint(index: number, planIndex: number, isAltn: boolean) {
-    this.revisedWaypointPlanIndex.set(planIndex);
-    this.revisedWaypointIsAltn.set(isAltn);
-    this.revisedWaypointLegIndex.set(index);
+    this.revisedLegPlanIndex.set(planIndex);
+    this.revisedLegIsAltn.set(isAltn);
+    this.revisedLegIndex.set(index);
   }
 
   public resetRevisedWaypoint(): void {
-    this.revisedWaypointLegIndex.set(null);
-    this.revisedWaypointIsAltn.set(null);
-    this.revisedWaypointPlanIndex.set(null);
+    this.revisedLegIndex.set(null);
+    this.revisedLegIsAltn.set(null);
+    this.revisedLegPlanIndex.set(null);
   }
 
   public latLongStoredWaypoints: Waypoint[] = [];

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcAircraftInterface.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcAircraftInterface.ts
@@ -1805,6 +1805,14 @@ export class FmcAircraftInterface {
         this.stepAheadTriggeredForAltitude = approachingCruiseStep.toAltitude;
       }
     }
+
+    // Check for STEP DELETED message
+    if (SimVar.GetSimVarValue('L:A32NX_FM_VNAV_TRIGGER_STEP_DELETED', SimVarValueType.Bool) === 1) {
+      // Add message
+      this.fmc.addMessageToQueue(NXSystemMessages.stepDeleted, undefined, undefined);
+
+      SimVar.SetSimVarValue('L:A32NX_FM_VNAV_TRIGGER_STEP_DELETED', SimVarValueType.Bool, false);
+    }
   }
 
   //-----------------------------------------------------------------------------------

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcInterface.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcInterface.ts
@@ -88,17 +88,17 @@ export interface FmcInterface extends FlightPhaseManagerProxyInterface, DataInte
   /**
    * Returns leg index (in the flight plan) of currently revised waypoint
    */
-  get revisedWaypointLegIndex(): Subject<number | null>;
+  get revisedLegIndex(): Subject<number | null>;
 
   /**
    * Returns flight plan index of currently revised waypoint
    */
-  get revisedWaypointPlanIndex(): Subject<FlightPlanIndex | null>;
+  get revisedLegPlanIndex(): Subject<FlightPlanIndex | null>;
 
   /**
    * Returns, whether currently revised waypoint is part of ALTN flight plan
    */
-  get revisedWaypointIsAltn(): Subject<boolean | null>;
+  get revisedLegIsAltn(): Subject<boolean | null>;
 
   /**
    * Returns, whether number 2&3 engines were started

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcInterface.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcInterface.ts
@@ -88,7 +88,7 @@ export interface FmcInterface extends FlightPhaseManagerProxyInterface, DataInte
   /**
    * Returns leg index (in the flight plan) of currently revised waypoint
    */
-  get revisedWaypointIndex(): Subject<number | null>;
+  get revisedWaypointLegIndex(): Subject<number | null>;
 
   /**
    * Returns flight plan index of currently revised waypoint

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/fmgc.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/fmgc.ts
@@ -53,8 +53,8 @@ export enum ClimbDerated {
  * Temporary place for data which is found nowhere else. Not associated to flight plans right now, which should be the case for some of these values
  */
 export class FmgcData {
-  static fmcFormatSpeed(sub: Subscribable<number | null>) {
-    return sub.map((it) => (it !== null ? it.toFixed(0) : '---'));
+  static fmcFormatValue(sub: Subscribable<number | null>, numberDashes = 3) {
+    return sub.map((it) => (it !== null ? it.toFixed(0) : '-'.repeat(numberDashes)));
   }
 
   public readonly cpnyFplnAvailable = Subject.create(false);

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/DestinationWindow.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/DestinationWindow.tsx
@@ -24,13 +24,13 @@ export class DestinationWindow extends DisplayComponent<DestinationWindowProps> 
 
   private onModified(newDest: string | null): void {
     if (newDest) {
-      const revWpt = this.props.fmcService.master?.revisedWaypointLegIndex.get();
+      const revWpt = this.props.fmcService.master?.revisedLegIndex.get();
       if (newDest.length === 4 && revWpt) {
         this.props.fmcService.master?.flightPlanService.newDest(
           revWpt,
           newDest,
-          this.props.fmcService.master.revisedWaypointPlanIndex.get() ?? undefined,
-          this.props.fmcService.master.revisedWaypointIsAltn.get() ?? undefined,
+          this.props.fmcService.master.revisedLegPlanIndex.get() ?? undefined,
+          this.props.fmcService.master.revisedLegIsAltn.get() ?? undefined,
         );
         this.props.fmcService.master?.acInterface.updateOansAirports();
       }
@@ -54,7 +54,7 @@ export class DestinationWindow extends DisplayComponent<DestinationWindowProps> 
 
     if (this.props.fmcService.master) {
       this.subs.push(
-        this.props.fmcService.master.revisedWaypointLegIndex.sub(() => {
+        this.props.fmcService.master.revisedLegIndex.sub(() => {
           if (this.props.fmcService.master?.revisedWaypoint()) {
             this.identRef.instance.innerText = this.props.fmcService.master?.revisedWaypoint()?.ident ?? '';
           }

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/DestinationWindow.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/DestinationWindow.tsx
@@ -24,7 +24,7 @@ export class DestinationWindow extends DisplayComponent<DestinationWindowProps> 
 
   private onModified(newDest: string | null): void {
     if (newDest) {
-      const revWpt = this.props.fmcService.master?.revisedWaypointIndex.get();
+      const revWpt = this.props.fmcService.master?.revisedWaypointLegIndex.get();
       if (newDest.length === 4 && revWpt) {
         this.props.fmcService.master?.flightPlanService.newDest(
           revWpt,
@@ -54,7 +54,7 @@ export class DestinationWindow extends DisplayComponent<DestinationWindowProps> 
 
     if (this.props.fmcService.master) {
       this.subs.push(
-        this.props.fmcService.master.revisedWaypointIndex.sub(() => {
+        this.props.fmcService.master.revisedWaypointLegIndex.sub(() => {
           if (this.props.fmcService.master?.revisedWaypoint()) {
             this.identRef.instance.innerText = this.props.fmcService.master?.revisedWaypoint()?.ident ?? '';
           }

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/FplnRevisionsMenu.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/FplnRevisionsMenu.tsx
@@ -16,9 +16,9 @@ export enum FplnRevisionsMenuType {
 }
 
 export function getRevisionsMenu(fpln: MfdFmsFpln, type: FplnRevisionsMenuType): ContextMenuElement[] {
-  const legIndex = fpln.props.fmcService.master?.revisedWaypointLegIndex.get();
-  const planIndex = fpln.props.fmcService.master?.revisedWaypointPlanIndex.get();
-  const altnFlightPlan = fpln.props.fmcService.master?.revisedWaypointIsAltn.get();
+  const legIndex = fpln.props.fmcService.master?.revisedLegIndex.get();
+  const planIndex = fpln.props.fmcService.master?.revisedLegPlanIndex.get();
+  const altnFlightPlan = fpln.props.fmcService.master?.revisedLegIsAltn.get();
 
   if (legIndex == null || planIndex == null || altnFlightPlan == null) {
     return [];
@@ -119,7 +119,7 @@ export function getRevisionsMenu(fpln: MfdFmsFpln, type: FplnRevisionsMenuType):
             altnFlightPlan,
           );
 
-          fpln.props.fmcService.master?.revisedWaypointLegIndex.set(legIndex + 1); // We just inserted a new HOLD leg
+          fpln.props.fmcService.master?.revisedLegIndex.set(legIndex + 1); // We just inserted a new HOLD leg
         }
         fpln.props.mfd.uiService.navigateTo(`fms/${fpln.props.mfd.uiService.activeUri.get().category}/f-pln-hold`);
       },

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/FplnRevisionsMenu.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/FplnRevisionsMenu.tsx
@@ -16,7 +16,7 @@ export enum FplnRevisionsMenuType {
 }
 
 export function getRevisionsMenu(fpln: MfdFmsFpln, type: FplnRevisionsMenuType): ContextMenuElement[] {
-  const legIndex = fpln.props.fmcService.master?.revisedWaypointIndex.get();
+  const legIndex = fpln.props.fmcService.master?.revisedWaypointLegIndex.get();
   const planIndex = fpln.props.fmcService.master?.revisedWaypointPlanIndex.get();
   const altnFlightPlan = fpln.props.fmcService.master?.revisedWaypointIsAltn.get();
 
@@ -119,7 +119,7 @@ export function getRevisionsMenu(fpln: MfdFmsFpln, type: FplnRevisionsMenuType):
             altnFlightPlan,
           );
 
-          fpln.props.fmcService.master?.revisedWaypointIndex.set(legIndex + 1); // We just inserted a new HOLD leg
+          fpln.props.fmcService.master?.revisedWaypointLegIndex.set(legIndex + 1); // We just inserted a new HOLD leg
         }
         fpln.props.mfd.uiService.navigateTo(`fms/${fpln.props.mfd.uiService.activeUri.get().category}/f-pln-hold`);
       },

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/InsertNextWptFrom.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/InsertNextWptFrom.tsx
@@ -48,15 +48,15 @@ export class InsertNextWptFromWindow extends DisplayComponent<InsertNextWptFromW
   private availableWaypointsString = ArraySubject.create<string>([]);
 
   private async onModified(idx: number | null, text: string): Promise<void> {
-    const revWptPlanIndex = this.props.fmcService.master?.revisedWaypointPlanIndex.get();
+    const revWptPlanIndex = this.props.fmcService.master?.revisedLegPlanIndex.get();
     if (!this.props.fmcService.master || revWptPlanIndex == null) {
       return;
     }
 
     if (idx !== null && idx >= 0) {
       const wptInfo = this.props.availableWaypoints.get(idx);
-      const revWpt = this.props.fmcService.master.revisedWaypointLegIndex.get();
-      const fpln = this.props.fmcService.master.revisedWaypointIsAltn.get()
+      const revWpt = this.props.fmcService.master.revisedLegIndex.get();
+      const fpln = this.props.fmcService.master.revisedLegIsAltn.get()
         ? this.props.fmcService.master.flightPlanService.get(revWptPlanIndex).alternateFlightPlan
         : this.props.fmcService.master.flightPlanService.get(revWptPlanIndex);
       const wptToInsert = fpln?.legElementAt(wptInfo.originalLegIndex).definition.waypoint;
@@ -72,20 +72,20 @@ export class InsertNextWptFromWindow extends DisplayComponent<InsertNextWptFromW
         await this.props.fmcService.master.flightPlanService.nextWaypoint(
           revWpt,
           wptToInsert,
-          this.props.fmcService.master.revisedWaypointPlanIndex.get() ?? undefined,
-          this.props.fmcService.master.revisedWaypointIsAltn.get() ?? undefined,
+          this.props.fmcService.master.revisedLegPlanIndex.get() ?? undefined,
+          this.props.fmcService.master.revisedLegIsAltn.get() ?? undefined,
         );
       }
     } else {
       try {
         const wpt = await WaypointEntryUtils.getOrCreateWaypoint(this.props.fmcService.master, text, true, undefined);
-        const revWpt = this.props.fmcService.master.revisedWaypointLegIndex.get();
+        const revWpt = this.props.fmcService.master.revisedLegIndex.get();
         if (wpt && revWpt) {
           await this.props.fmcService.master.flightPlanService.nextWaypoint(
             revWpt,
             wpt,
-            this.props.fmcService.master.revisedWaypointPlanIndex.get() ?? undefined,
-            this.props.fmcService.master.revisedWaypointIsAltn.get() ?? undefined,
+            this.props.fmcService.master.revisedLegPlanIndex.get() ?? undefined,
+            this.props.fmcService.master.revisedLegIsAltn.get() ?? undefined,
           );
         }
       } catch (msg: unknown) {
@@ -113,10 +113,10 @@ export class InsertNextWptFromWindow extends DisplayComponent<InsertNextWptFromW
 
     if (this.props.fmcService.master) {
       this.subs.push(
-        this.props.fmcService.master.revisedWaypointLegIndex.sub((wptIdx) => {
+        this.props.fmcService.master.revisedLegIndex.sub((wptIdx) => {
           if (wptIdx && this.props.fmcService.master?.revisedWaypoint()) {
             const fpln = this.props.fmcService.master.flightPlanService.get(
-              this.props.fmcService.master.revisedWaypointPlanIndex.get() ?? FlightPlanIndex.Active,
+              this.props.fmcService.master.revisedLegPlanIndex.get() ?? FlightPlanIndex.Active,
             );
 
             if (

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/InsertNextWptFrom.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/InsertNextWptFrom.tsx
@@ -55,7 +55,7 @@ export class InsertNextWptFromWindow extends DisplayComponent<InsertNextWptFromW
 
     if (idx !== null && idx >= 0) {
       const wptInfo = this.props.availableWaypoints.get(idx);
-      const revWpt = this.props.fmcService.master.revisedWaypointIndex.get();
+      const revWpt = this.props.fmcService.master.revisedWaypointLegIndex.get();
       const fpln = this.props.fmcService.master.revisedWaypointIsAltn.get()
         ? this.props.fmcService.master.flightPlanService.get(revWptPlanIndex).alternateFlightPlan
         : this.props.fmcService.master.flightPlanService.get(revWptPlanIndex);
@@ -79,7 +79,7 @@ export class InsertNextWptFromWindow extends DisplayComponent<InsertNextWptFromW
     } else {
       try {
         const wpt = await WaypointEntryUtils.getOrCreateWaypoint(this.props.fmcService.master, text, true, undefined);
-        const revWpt = this.props.fmcService.master.revisedWaypointIndex.get();
+        const revWpt = this.props.fmcService.master.revisedWaypointLegIndex.get();
         if (wpt && revWpt) {
           await this.props.fmcService.master.flightPlanService.nextWaypoint(
             revWpt,
@@ -113,7 +113,7 @@ export class InsertNextWptFromWindow extends DisplayComponent<InsertNextWptFromW
 
     if (this.props.fmcService.master) {
       this.subs.push(
-        this.props.fmcService.master.revisedWaypointIndex.sub((wptIdx) => {
+        this.props.fmcService.master.revisedWaypointLegIndex.sub((wptIdx) => {
           if (wptIdx && this.props.fmcService.master?.revisedWaypoint()) {
             const fpln = this.props.fmcService.master.flightPlanService.get(
               this.props.fmcService.master.revisedWaypointPlanIndex.get() ?? FlightPlanIndex.Active,

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
@@ -569,12 +569,12 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
   }
 
   public openInsertNextWptFromWindow() {
-    const flightPlan = this.props.fmcService.master?.revisedWaypointIsAltn.get()
+    const flightPlan = this.props.fmcService.master?.revisedLegIsAltn.get()
       ? this.loadedFlightPlan?.alternateFlightPlan
       : this.loadedFlightPlan;
     const wpt: NextWptInfo[] = flightPlan?.allLegs
       .map((el, idx) => {
-        const revWptIdx = this.props.fmcService.master?.revisedWaypointLegIndex.get();
+        const revWptIdx = this.props.fmcService.master?.revisedLegIndex.get();
         if (el instanceof FlightPlanLeg && el.isXF() && revWptIdx && idx >= revWptIdx + 1) {
           return { ident: el.ident, originalLegIndex: idx };
         }

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
@@ -574,7 +574,7 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
       : this.loadedFlightPlan;
     const wpt: NextWptInfo[] = flightPlan?.allLegs
       .map((el, idx) => {
-        const revWptIdx = this.props.fmcService.master?.revisedWaypointIndex.get();
+        const revWptIdx = this.props.fmcService.master?.revisedWaypointLegIndex.get();
         if (el instanceof FlightPlanLeg && el.isXF() && revWptIdx && idx >= revWptIdx + 1) {
           return { ident: el.ident, originalLegIndex: idx };
         }

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnArr.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnArr.tsx
@@ -83,7 +83,7 @@ export class MfdFmsFplnArr extends FmsPage<MfdFmsFplnArrProps> {
       return;
     }
 
-    const isAltn = this.props.fmcService.master.revisedWaypointIsAltn.get() ?? false;
+    const isAltn = this.props.fmcService.master.revisedLegIsAltn.get() ?? false;
     const flightPlan = isAltn ? this.loadedFlightPlan.alternateFlightPlan : this.loadedFlightPlan;
 
     if (flightPlan.destinationAirport) {

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnDep.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnDep.tsx
@@ -40,7 +40,7 @@ export class MfdFmsFplnDep extends FmsPage<MfdFmsFplnDepProps> {
   private tmpyInsertButtonDiv = FSComponent.createRef<HTMLDivElement>();
 
   protected onNewData(): void {
-    const isAltn = this.props.fmcService.master?.revisedWaypointIsAltn.get();
+    const isAltn = this.props.fmcService.master?.revisedLegIsAltn.get();
     const flightPlan = isAltn ? this.loadedFlightPlan?.alternateFlightPlan : this.loadedFlightPlan;
 
     if (flightPlan?.originAirport) {

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnDirectTo.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnDirectTo.tsx
@@ -109,7 +109,7 @@ export class MfdFmsFplnDirectTo extends FmsPage<MfdFmsFplnDirectToProps> {
           FlightPlanIndex.Active,
         );
       }
-    } else if (this.props.fmcService.master) {
+    } else if (this.props.fmcService.master && text !== null) {
       const wpt = await WaypointEntryUtils.getOrCreateWaypoint(this.props.fmcService.master, text, true, undefined);
       if (wpt) {
         this.manualWptIdent = wpt.ident;

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnDirectTo.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnDirectTo.tsx
@@ -8,7 +8,7 @@ import { FmsPage } from 'instruments/src/MFD/pages/common/FmsPage';
 import { DropdownMenu } from 'instruments/src/MsfsAvionicsCommon/UiWidgets/DropdownMenu';
 import { FlightPlanLeg } from '@fmgc/flightplanning/legs/FlightPlanLeg';
 import { FlightPlanIndex, WaypointEntryUtils } from '@fmgc/index';
-import { RadioButtonGroup } from 'instruments/src/MsfsAvionicsCommon/UiWidgets/RadioButtonGroup';
+import { RadioButtonColor, RadioButtonGroup } from 'instruments/src/MsfsAvionicsCommon/UiWidgets/RadioButtonGroup';
 import { ADIRS } from 'instruments/src/MFD/shared/Adirs';
 
 interface MfdFmsFplnDirectToProps extends AbstractMfdPageProps {}
@@ -220,7 +220,7 @@ export class MfdFmsFplnDirectTo extends FmsPage<MfdFmsFplnDirectToProps> {
                   values={['DIRECT', 'DIRECT WITH ABEAM', 'CRS IN', 'CRS OUT']}
                   valuesDisabled={Subject.create([false, true, true, true])}
                   selectedIndex={this.directToOption}
-                  color={this.tmpyActive.map((it) => (it ? 'yellow' : 'cyan'))}
+                  color={this.tmpyActive.map((it) => (it ? RadioButtonColor.Yellow : RadioButtonColor.Cyan))}
                 />
               </div>
             </div>

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnHold.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnHold.tsx
@@ -46,7 +46,7 @@ export class MfdFmsFplnHold extends FmsPage<MfdFmsFplnHoldProps> {
   );
 
   protected onNewData(): void {
-    const revWptIdx = this.props.fmcService.master?.revisedWaypointLegIndex.get();
+    const revWptIdx = this.props.fmcService.master?.revisedLegIndex.get();
     if (this.props.fmcService.master?.revisedWaypoint() && revWptIdx) {
       const leg = this.loadedFlightPlan?.legElementAt(revWptIdx);
       const hold = leg?.modifiedHold !== undefined ? leg.modifiedHold : leg?.defaultHold;
@@ -76,7 +76,7 @@ export class MfdFmsFplnHold extends FmsPage<MfdFmsFplnHoldProps> {
   }
 
   private async modifyHold() {
-    const revWptIdx = this.props.fmcService.master?.revisedWaypointLegIndex.get();
+    const revWptIdx = this.props.fmcService.master?.revisedLegIndex.get();
     if (revWptIdx && this.props.fmcService.master?.revisedWaypoint()) {
       const desiredHold: HoldData = {
         type: HoldType.Pilot,
@@ -99,8 +99,8 @@ export class MfdFmsFplnHold extends FmsPage<MfdFmsFplnHoldProps> {
         { ...desiredHold },
         desiredHold,
         this.loadedFlightPlan?.legElementAt(revWptIdx).defaultHold ?? fallbackDefaultHold,
-        this.props.fmcService.master.revisedWaypointPlanIndex.get() ?? undefined,
-        this.props.fmcService.master.revisedWaypointIsAltn.get() ?? undefined,
+        this.props.fmcService.master.revisedLegPlanIndex.get() ?? undefined,
+        this.props.fmcService.master.revisedLegIsAltn.get() ?? undefined,
       );
       this.onNewData();
     }
@@ -242,12 +242,12 @@ export class MfdFmsFplnHold extends FmsPage<MfdFmsFplnHoldProps> {
             <Button
               label="COMPUTED"
               onClick={() => {
-                const revWptIdx = this.props.fmcService.master?.revisedWaypointLegIndex.get();
+                const revWptIdx = this.props.fmcService.master?.revisedLegIndex.get();
                 if (revWptIdx && this.props.fmcService.master?.revisedWaypoint()) {
                   this.props.fmcService.master.flightPlanService.revertHoldToComputed(
                     revWptIdx,
-                    this.props.fmcService.master.revisedWaypointPlanIndex.get() ?? undefined,
-                    this.props.fmcService.master.revisedWaypointIsAltn.get() ?? undefined,
+                    this.props.fmcService.master.revisedLegPlanIndex.get() ?? undefined,
+                    this.props.fmcService.master.revisedLegIsAltn.get() ?? undefined,
                   );
                 }
               }}

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnHold.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnHold.tsx
@@ -8,7 +8,7 @@ import { Button } from 'instruments/src/MsfsAvionicsCommon/UiWidgets/Button';
 import { FmsPage } from 'instruments/src/MFD/pages/common/FmsPage';
 import { InputField } from 'instruments/src/MsfsAvionicsCommon/UiWidgets/InputField';
 import { HoldDistFormat, HoldTimeFormat, InboundCourseFormat } from 'instruments/src/MFD/pages/common/DataEntryFormats';
-import { RadioButtonGroup } from 'instruments/src/MsfsAvionicsCommon/UiWidgets/RadioButtonGroup';
+import { RadioButtonColor, RadioButtonGroup } from 'instruments/src/MsfsAvionicsCommon/UiWidgets/RadioButtonGroup';
 import { HoldData, HoldType } from '@fmgc/flightplanning/data/flightplan';
 import { TurnDirection } from '@flybywiresim/fbw-sdk';
 
@@ -40,6 +40,10 @@ export class MfdFmsFplnHold extends FmsPage<MfdFmsFplnHoldProps> {
   private returnButtonDiv = FSComponent.createRef<HTMLDivElement>();
 
   private tmpyInsertButtonDiv = FSComponent.createRef<HTMLDivElement>();
+
+  private readonly radioButtonColor = this.tmpyActive.map((it) =>
+    it ? RadioButtonColor.Yellow : RadioButtonColor.Cyan,
+  );
 
   protected onNewData(): void {
     const revWptIdx = this.props.fmcService.master?.revisedWaypointLegIndex.get();
@@ -177,7 +181,7 @@ export class MfdFmsFplnHold extends FmsPage<MfdFmsFplnHoldProps> {
                 idPrefix={`${this.props.mfd.uiService.captOrFo}_MFD_holdTurnRadio`}
                 selectedIndex={this.turnSelectedIndex}
                 values={['LEFT', 'RIGHT']}
-                color={this.tmpyActive.map((it) => (it ? 'yellow' : 'cyan'))}
+                color={this.radioButtonColor}
               />
             </div>
             <span class="mfd-label" style="margin-top: 50px; margin-bottom: 20px;">
@@ -188,7 +192,7 @@ export class MfdFmsFplnHold extends FmsPage<MfdFmsFplnHoldProps> {
                 idPrefix={`${this.props.mfd.uiService.captOrFo}_MFD_holdDefiningParameterRadio`}
                 selectedIndex={this.legDefiningParameterSelectedIndex}
                 values={['TIME', 'DIST']}
-                color={this.tmpyActive.map((it) => (it ? 'yellow' : 'cyan'))}
+                color={this.radioButtonColor}
               />
               <div class="mfd-fpln-hold-timedist-box">
                 <div ref={this.legTimeRef}>

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnHold.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnHold.tsx
@@ -42,7 +42,7 @@ export class MfdFmsFplnHold extends FmsPage<MfdFmsFplnHoldProps> {
   private tmpyInsertButtonDiv = FSComponent.createRef<HTMLDivElement>();
 
   protected onNewData(): void {
-    const revWptIdx = this.props.fmcService.master?.revisedWaypointIndex.get();
+    const revWptIdx = this.props.fmcService.master?.revisedWaypointLegIndex.get();
     if (this.props.fmcService.master?.revisedWaypoint() && revWptIdx) {
       const leg = this.loadedFlightPlan?.legElementAt(revWptIdx);
       const hold = leg?.modifiedHold !== undefined ? leg.modifiedHold : leg?.defaultHold;
@@ -72,7 +72,7 @@ export class MfdFmsFplnHold extends FmsPage<MfdFmsFplnHoldProps> {
   }
 
   private async modifyHold() {
-    const revWptIdx = this.props.fmcService.master?.revisedWaypointIndex.get();
+    const revWptIdx = this.props.fmcService.master?.revisedWaypointLegIndex.get();
     if (revWptIdx && this.props.fmcService.master?.revisedWaypoint()) {
       const desiredHold: HoldData = {
         type: HoldType.Pilot,
@@ -238,7 +238,7 @@ export class MfdFmsFplnHold extends FmsPage<MfdFmsFplnHoldProps> {
             <Button
               label="COMPUTED"
               onClick={() => {
-                const revWptIdx = this.props.fmcService.master?.revisedWaypointIndex.get();
+                const revWptIdx = this.props.fmcService.master?.revisedWaypointLegIndex.get();
                 if (revWptIdx && this.props.fmcService.master?.revisedWaypoint()) {
                   this.props.fmcService.master.flightPlanService.revertHoldToComputed(
                     revWptIdx,

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnVertRev.scss
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnVertRev.scss
@@ -29,6 +29,15 @@
   border-right: 2px solid $display-light-grey;
 }
 
+.mfd-vert-rev-alt-cstr-sel {
+  display: flex;
+  flex-direction: column;
+  align-self: flex-end;
+  justify-content: center;
+  align-items: center;
+  padding-bottom: 20px;
+}
+
 .mfd-vert-rev-alt-window-label {
   display: flex;
   justify-content: flex-end;
@@ -43,4 +52,14 @@
   align-items: center;
   margin-top: 20px;
   visibility: hidden;
+}
+
+.mfd-vert-rev-alt-right-container {
+  display: flex;
+  flex-direction: column;
+  margin: 0px 20px 20px 0px;
+}
+
+.mfd-vert-rev-clbdes {
+  margin-top: 20px;
 }

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnVertRev.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnVertRev.tsx
@@ -141,8 +141,9 @@ export class MfdFmsFplnVertRev extends FmsPage<MfdFmsFplnVertRevProps> {
         this.availableWaypoints.set(wpt);
       }
 
-      const revWptIdx = this.props.fmcService.master?.revisedWaypointIndex.get();
-      if (revWptIdx && this.props.fmcService.master?.revisedWaypointIndex.get() !== undefined) {
+      const revWptIdx = this.props.fmcService.master?.revisedWaypointLegIndex.get();
+      if (revWptIdx && this.props.fmcService.master?.revisedWaypointLegIndex.get() !== undefined) {
+        const wptIndex = this.availableWaypointsToLegIndex.indexOf(revWptIdx);
         this.selectedWaypointIndex.set(revWptIdx - activeLegIndex - 1);
       }
     }
@@ -329,7 +330,7 @@ export class MfdFmsFplnVertRev extends FmsPage<MfdFmsFplnVertRevProps> {
     this.selectedWaypointIndex.set(idx);
 
     if (idx !== null) {
-      this.props.fmcService.master?.revisedWaypointIndex.set(
+      this.props.fmcService.master?.revisedWaypointLegIndex.set(
         this.props.fmcService.master.flightPlanService.get(this.loadedFlightPlanIndex.get()).activeLegIndex + idx + 1,
       );
       this.updateConstraints();

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnVertRev.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnVertRev.tsx
@@ -341,6 +341,10 @@ export class MfdFmsFplnVertRev extends FmsPage<MfdFmsFplnVertRevProps> {
         this.stepAltsLineVisibility[i].set('hidden');
       }
 
+      if (this.stepAltsNumberOfCruiseSteps.get() !== cruiseSteps.length) {
+        this.forceRebuildList = true;
+      }
+
       this.stepAltsNumberOfCruiseSteps.set(cruiseSteps.length);
       this.stepAltsScrollUpDisabled.set(this.stepAltsStartAtStepIndex.get() === 0);
       this.stepAltsScrollDownDisabled.set(cruiseSteps.length - this.stepAltsStartAtStepIndex.get() <= 4);

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnVertRev.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnVertRev.tsx
@@ -957,7 +957,7 @@ export class MfdFmsFplnVertRev extends FmsPage<MfdFmsFplnVertRevProps> {
                                 'grid-column': 'span 2',
                               }}
                             >
-                              <span class="mfd-label">IGNORED</span>
+                              <span class="mfd-label">{this.stepAltsMessage[li]}</span>
                             </div>
                             <div
                               class="fr aic jcc"

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnVertRev.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnVertRev.tsx
@@ -418,12 +418,6 @@ export class MfdFmsFplnVertRev extends FmsPage<MfdFmsFplnVertRevProps> {
   }
 
   private async tryUpdateAltitudeConstraint(newAlt?: number) {
-    console.log(
-      this.props.fmcService.master,
-      this.loadedFlightPlan,
-      this.selectedLegIndex,
-      this.altConstraintTypeRadioSelected.get(),
-    );
     if (
       !this.props.fmcService.master ||
       !this.loadedFlightPlan ||

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsInit.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsInit.tsx
@@ -94,6 +94,8 @@ export class MfdFmsInit extends FmsPage<MfdFmsInitProps> {
 
   private readonly crzFl = Subject.create<number | null>(null);
 
+  private readonly crzFlIsMandatory = Subject.create(true);
+
   private readonly costIndex = Subject.create<number | null>(null);
 
   private readonly costIndexDisabled = MappedSubject.create(
@@ -172,16 +174,15 @@ export class MfdFmsInit extends FmsPage<MfdFmsInitProps> {
       this.altnIcao.set(this.loadedFlightPlan.originAirport && this.loadedFlightPlan.destinationAirport ? 'NONE' : '');
     }
 
+    this.crzFl.set(this.loadedFlightPlan.performanceData.cruiseFlightLevel);
+    this.crzFlIsMandatory.set(this.props.fmcService.master.fmgc.getFlightPhase() < FmgcFlightPhase.Descent);
     if (this.loadedFlightPlan.performanceData.cruiseFlightLevel) {
-      this.crzFl.set(this.loadedFlightPlan.performanceData.cruiseFlightLevel);
       this.props.fmcService.master.fmgc.data.cruiseTemperatureIsaTemp.set(
         A380AltitudeUtils.getIsaTemp(this.loadedFlightPlan.performanceData.cruiseFlightLevel * 100),
       );
     }
 
-    if (this.loadedFlightPlan.performanceData.costIndex) {
-      this.costIndex.set(this.loadedFlightPlan.performanceData.costIndex);
-    }
+    this.costIndex.set(this.loadedFlightPlan.performanceData.costIndex);
 
     // Set some empty fields with pre-defined values
     if (this.fromIcao.get() && this.toIcao.get()) {
@@ -448,7 +449,7 @@ export class MfdFmsInit extends FmsPage<MfdFmsInitProps> {
                 dataHandlerDuringValidation={async (v) =>
                   v ? this.props.fmcService.master?.acInterface.setCruiseFl(v) : false
                 }
-                mandatory={Subject.create(true)}
+                mandatory={this.crzFlIsMandatory}
                 disabled={this.altnDisabled}
                 canBeCleared={Subject.create(false)}
                 value={this.crzFl}

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
@@ -1957,7 +1957,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                       componentIfFalse={
                         <Button
                           label="SPD CSTR"
-                          onClick={() => this.props.mfd.uiService.navigateTo('fms/active/f-pln-vert-rev')}
+                          onClick={() => this.props.mfd.uiService.navigateTo('fms/active/f-pln-vert-rev/spd')}
                         >
                           SPD CSTR
                         </Button>
@@ -2410,9 +2410,8 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                   </div>
                   <div style="display: flex; flex-direction: row;">
                     <Button
-                      disabled={Subject.create(true)}
                       label="SPD CSTR"
-                      onClick={() => this.props.mfd.uiService.navigateTo('fms/active/f-pln-vert-rev')}
+                      onClick={() => this.props.mfd.uiService.navigateTo('fms/active/f-pln-vert-rev/spd')}
                     />
                   </div>
                 </div>

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
@@ -812,14 +812,12 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                 this.crzPredStepAheadRef.instance.style.display = 'none';
 
                 if (this.props.fmcService.master?.flightPlanService.active) {
-                  const approachingCruiseStep = MfdFmsFplnVertRev.nextCruiseStep(
+                  const [approachingCruiseStep, cruiseStepLegIndex] = MfdFmsFplnVertRev.nextCruiseStep(
                     this.props.fmcService.master.flightPlanService.active,
                   );
                   this.crzPredWaypoint.set(
-                    approachingCruiseStep
-                      ? this.props.fmcService.master?.flightPlanService.active.legElementAt(
-                          approachingCruiseStep.waypointIndex,
-                        ).ident
+                    cruiseStepLegIndex && approachingCruiseStep
+                      ? this.props.fmcService.master?.flightPlanService.active.legElementAt(cruiseStepLegIndex).ident
                       : '',
                   );
                   this.crzPredAltitudeTarget.set(approachingCruiseStep ? approachingCruiseStep.toAltitude / 100 : null);

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
@@ -1056,7 +1056,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                     <div class="mfd-label-value-container">
                       <div ref={this.vSpeedsConfirmationRef[0]}>
                         <span class="mfd-value tmpy">
-                          {FmgcData.fmcFormatSpeed(this.props.fmcService.master.fmgc.data.v1ToBeConfirmed)}
+                          {FmgcData.fmcFormatValue(this.props.fmcService.master.fmgc.data.v1ToBeConfirmed)}
                         </span>
                         <span class="mfd-label-unit mfd-unit-trailing">KT</span>
                       </div>
@@ -1096,7 +1096,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                     <div ref={this.flapSpeedsRef[0]} class="mfd-label-value-container">
                       <span class="mfd-label mfd-spacing-right">F</span>
                       <span class="mfd-value">
-                        {FmgcData.fmcFormatSpeed(this.props.fmcService.master.fmgc.data.flapRetractionSpeed)}
+                        {FmgcData.fmcFormatValue(this.props.fmcService.master.fmgc.data.flapRetractionSpeed)}
                       </span>
                       <span class="mfd-label-unit mfd-unit-trailing">KT</span>
                     </div>
@@ -1120,7 +1120,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                     <div class="mfd-label-value-container">
                       <div ref={this.vSpeedsConfirmationRef[1]}>
                         <span class="mfd-value tmpy">
-                          {FmgcData.fmcFormatSpeed(this.props.fmcService.master.fmgc.data.vrToBeConfirmed)}
+                          {FmgcData.fmcFormatValue(this.props.fmcService.master.fmgc.data.vrToBeConfirmed)}
                         </span>
                         <span class="mfd-label-unit mfd-unit-trailing">KT</span>
                       </div>
@@ -1128,7 +1128,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                     <div ref={this.flapSpeedsRef[1]} class="mfd-label-value-container">
                       <span class="mfd-label mfd-spacing-right">S</span>
                       <span class="mfd-value">
-                        {FmgcData.fmcFormatSpeed(this.props.fmcService.master.fmgc.data.slatRetractionSpeed)}
+                        {FmgcData.fmcFormatValue(this.props.fmcService.master.fmgc.data.slatRetractionSpeed)}
                       </span>
                       <span class="mfd-label-unit mfd-unit-trailing">KT</span>
                     </div>
@@ -1152,7 +1152,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                     <div class="mfd-label-value-container">
                       <div ref={this.vSpeedsConfirmationRef[2]}>
                         <span class="mfd-value tmpy">
-                          {FmgcData.fmcFormatSpeed(this.props.fmcService.master.fmgc.data.v2ToBeConfirmed)}
+                          {FmgcData.fmcFormatValue(this.props.fmcService.master.fmgc.data.v2ToBeConfirmed)}
                         </span>
                         <span class="mfd-label-unit mfd-unit-trailing">KT</span>
                       </div>
@@ -1164,7 +1164,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                         </svg>
                       </span>
                       <span class="mfd-value">
-                        {FmgcData.fmcFormatSpeed(this.props.fmcService.master.fmgc.data.greenDotSpeed)}
+                        {FmgcData.fmcFormatValue(this.props.fmcService.master.fmgc.data.greenDotSpeed)}
                       </span>
                       <span class="mfd-label-unit mfd-unit-trailing">KT</span>
                     </div>
@@ -2570,28 +2570,28 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                           </svg>
                         </span>
                         <span class="mfd-value">
-                          {FmgcData.fmcFormatSpeed(this.props.fmcService.master.fmgc.data.approachGreenDotSpeed)}
+                          {FmgcData.fmcFormatValue(this.props.fmcService.master.fmgc.data.approachGreenDotSpeed)}
                         </span>
                         <span class="mfd-label-unit mfd-unit-trailing">KT</span>
                       </div>
                       <div class="mfd-label-value-container">
                         <span class="mfd-label mfd-spacing-right mfd-fms-perf-appr-flap-speeds">S</span>
                         <span class="mfd-value">
-                          {FmgcData.fmcFormatSpeed(this.props.fmcService.master.fmgc.data.approachSlatRetractionSpeed)}
+                          {FmgcData.fmcFormatValue(this.props.fmcService.master.fmgc.data.approachSlatRetractionSpeed)}
                         </span>
                         <span class="mfd-label-unit mfd-unit-trailing">KT</span>
                       </div>
                       <div class="mfd-label-value-container">
                         <span class="mfd-label mfd-spacing-right mfd-fms-perf-appr-flap-speeds">F</span>
                         <span class="mfd-value">
-                          {FmgcData.fmcFormatSpeed(this.props.fmcService.master.fmgc.data.approachFlapRetractionSpeed)}
+                          {FmgcData.fmcFormatValue(this.props.fmcService.master.fmgc.data.approachFlapRetractionSpeed)}
                         </span>
                         <span class="mfd-label-unit mfd-unit-trailing">KT</span>
                       </div>
                       <div class="mfd-label-value-container" style="padding-top: 15px;">
                         <span class="mfd-label mfd-spacing-right mfd-fms-perf-appr-flap-speeds">VREF</span>
                         <span class="mfd-value">
-                          {FmgcData.fmcFormatSpeed(this.props.fmcService.master.fmgc.data.approachVref)}
+                          {FmgcData.fmcFormatValue(this.props.fmcService.master.fmgc.data.approachVref)}
                         </span>
                         <span class="mfd-label-unit mfd-unit-trailing">KT</span>
                       </div>
@@ -2611,7 +2611,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                       <div class="mfd-label-value-container" style="margin-top: 10px;">
                         <span class="mfd-label mfd-spacing-right">VLS</span>
                         <span class="mfd-value">
-                          {FmgcData.fmcFormatSpeed(this.props.fmcService.master.fmgc.data.approachVls)}
+                          {FmgcData.fmcFormatValue(this.props.fmcService.master.fmgc.data.approachVls)}
                         </span>
                         <span class="mfd-label-unit mfd-unit-trailing">KT</span>
                       </div>
@@ -2672,14 +2672,14 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                   <div class="mfd-label-value-container">
                     <span class="mfd-label mfd-spacing-right">F</span>
                     <span class="mfd-value">
-                      {FmgcData.fmcFormatSpeed(this.props.fmcService.master.fmgc.data.approachFlapRetractionSpeed)}
+                      {FmgcData.fmcFormatValue(this.props.fmcService.master.fmgc.data.approachFlapRetractionSpeed)}
                     </span>
                     <span class="mfd-label-unit mfd-unit-trailing">KT</span>
                   </div>
                   <div class="mfd-label-value-container">
                     <span class="mfd-label mfd-spacing-right">S</span>
                     <span class="mfd-value">
-                      {FmgcData.fmcFormatSpeed(this.props.fmcService.master.fmgc.data.approachSlatRetractionSpeed)}
+                      {FmgcData.fmcFormatValue(this.props.fmcService.master.fmgc.data.approachSlatRetractionSpeed)}
                     </span>
                     <span class="mfd-label-unit mfd-unit-trailing">KT</span>
                   </div>
@@ -2690,7 +2690,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                       </svg>
                     </span>
                     <span class="mfd-value">
-                      {FmgcData.fmcFormatSpeed(this.props.fmcService.master.fmgc.data.approachGreenDotSpeed)}
+                      {FmgcData.fmcFormatValue(this.props.fmcService.master.fmgc.data.approachGreenDotSpeed)}
                     </span>
                     <span class="mfd-label-unit mfd-unit-trailing">KT</span>
                   </div>

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
@@ -54,6 +54,8 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
   // Subjects
   private crzFl = Subject.create<number | null>(null);
 
+  private readonly crzFlIsMandatory = Subject.create(true);
+
   private recMaxFl = Subject.create<string>('---');
 
   private optFl = Subject.create<string>('---');
@@ -430,9 +432,10 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
 
     console.time('PERF:onNewData');
 
-    if (pd.cruiseFlightLevel) {
-      this.crzFl.set(pd.cruiseFlightLevel);
-    }
+    this.crzFl.set(pd.cruiseFlightLevel);
+    this.crzFlIsMandatory.set(
+      (this.props.fmcService.master?.fmgc.getFlightPhase() ?? FmgcFlightPhase.Preflight) < FmgcFlightPhase.Descent,
+    );
 
     if (pd.costIndex) {
       this.costIndex.set(pd.costIndex);
@@ -999,7 +1002,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                   dataHandlerDuringValidation={async (v) =>
                     v ? this.props.fmcService.master?.acInterface.setCruiseFl(v) : false
                   }
-                  mandatory={Subject.create(false)}
+                  mandatory={this.crzFlIsMandatory}
                   value={this.crzFl}
                   errorHandler={(e) => this.props.fmcService.master?.showFmsErrorMessage(e)}
                   hEventConsumer={this.props.mfd.hEventConsumer}

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/SURV/MfdSurvControls.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/SURV/MfdSurvControls.tsx
@@ -18,7 +18,7 @@ import { Footer } from 'instruments/src/MFD/pages/common/Footer';
 import { InputField } from 'instruments/src/MsfsAvionicsCommon/UiWidgets/InputField';
 import { SquawkFormat } from 'instruments/src/MFD/pages/common/DataEntryFormats';
 import { Button } from 'instruments/src/MsfsAvionicsCommon/UiWidgets/Button';
-import { RadioButtonGroup } from 'instruments/src/MsfsAvionicsCommon/UiWidgets/RadioButtonGroup';
+import { RadioButtonColor, RadioButtonGroup } from 'instruments/src/MsfsAvionicsCommon/UiWidgets/RadioButtonGroup';
 import { MfdSimvars } from 'instruments/src/MFD/shared/MFDSimvarPublisher';
 import { SurvButton } from 'instruments/src/MsfsAvionicsCommon/UiWidgets/SurvButton';
 
@@ -251,7 +251,9 @@ export class MfdSurvControls extends DisplayComponent<MfdSurvControlsProps> {
                   selectedIndex={this.xpdrStatusSelectedIndex}
                   idPrefix={`${this.props.mfd.uiService.captOrFo}_MFD_survControlsXpdrStatus`}
                   additionalVerticalSpacing={50}
-                  color={this.xpdrStatusSelectedIndex.map((it) => (it === 0 ? 'green' : 'white'))}
+                  color={this.xpdrStatusSelectedIndex.map((it) =>
+                    it === 0 ? RadioButtonColor.Green : RadioButtonColor.White,
+                  )} // FIXME subscription leak
                 />
               </div>
             </div>
@@ -267,7 +269,7 @@ export class MfdSurvControls extends DisplayComponent<MfdSurvControlsProps> {
                   idPrefix={`${this.props.mfd.uiService.captOrFo}_MFD_survControlsTcasTara`}
                   additionalVerticalSpacing={10}
                   valuesDisabled={this.tcasRadioGroupDisabled}
-                  color={Subject.create('green')}
+                  color={Subject.create(RadioButtonColor.Green)}
                 />
               </div>
               <div class="mfd-surv-controls-tcas-right">
@@ -280,7 +282,7 @@ export class MfdSurvControls extends DisplayComponent<MfdSurvControlsProps> {
                   valuesDisabled={this.tcasRadioGroupDisabled}
                   idPrefix={`${this.props.mfd.uiService.captOrFo}_MFD_survControlsTcasNormAbvBlw`}
                   additionalVerticalSpacing={10}
-                  color={Subject.create('green')}
+                  color={Subject.create(RadioButtonColor.Green)}
                 />
               </div>
             </div>
@@ -296,7 +298,7 @@ export class MfdSurvControls extends DisplayComponent<MfdSurvControlsProps> {
                 selectedIndex={this.wxrElevnTiltSelectedIndex}
                 idPrefix={`${this.props.mfd.uiService.captOrFo}_MFD_survControlswxrElevnTilt`}
                 additionalVerticalSpacing={10}
-                color={Subject.create('green')}
+                color={Subject.create(RadioButtonColor.Green)}
                 valuesDisabled={Subject.create(Array(3).fill(true))}
               />
             </div>

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/common/widget-style.scss
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/common/widget-style.scss
@@ -378,6 +378,10 @@
   background: $display-green;
 }
 
+.mfd-radio-button.amber input[type="radio"]:checked {
+  background: $display-amber;
+}
+
 .mfd-radio-button.white input[type="radio"]:checked {
   background: $display-white;
 }
@@ -406,6 +410,10 @@
 
 .mfd-radio-button.green input[type="radio"]:checked ~ * {
   color: $display-green;
+}
+
+.mfd-radio-button.amber input[type="radio"]:checked ~ * {
+  color: $display-amber;
 }
 
 .mfd-radio-button.white input[type="radio"]:checked ~ * {

--- a/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/UiWidgets/InputField.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/UiWidgets/InputField.tsx
@@ -119,7 +119,7 @@ export class InputField<
     if (this.modifiedFieldValue.get() !== null) {
       this.modifiedFieldValue.set(null);
     }
-    if (this.readValue.get() != null) {
+    if (this.readValue.get() !== null) {
       if (this.props.canOverflow) {
         // If item was overflowing, check whether overflow is still needed
         this.overflow((this.readValue.get()?.toString().length ?? 0) > this.props.dataEntryFormat.maxDigits);
@@ -135,7 +135,7 @@ export class InputField<
   private updateDisplayElement() {
     // If input was not modified, render props' value
     if (this.modifiedFieldValue.get() == null) {
-      if (this.readValue.get() == null) {
+      if (this.readValue.get() === null) {
         this.populatePlaceholders();
       } else {
         const [formatted, leadingUnit, trailingUnit] = this.props.dataEntryFormat.format(this.readValue.get());
@@ -302,8 +302,7 @@ export class InputField<
       this.updateDisplayElement();
 
       if (validateAndUpdate) {
-        if (this.modifiedFieldValue.get() == null && this.readValue.get() != null) {
-          console.log('Enter pressed after no modification');
+        if (this.modifiedFieldValue.get() == null && this.readValue.get() !== null) {
           // Enter is pressed after no modification
           const [formatted] = this.props.dataEntryFormat.format(this.readValue.get());
           await this.validateAndUpdate(formatted ?? '');

--- a/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/UiWidgets/RadioButtonGroup.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/UiWidgets/RadioButtonGroup.tsx
@@ -33,7 +33,10 @@ export class RadioButtonGroup extends DisplayComponent<RadioButtonGroupProps> {
   // Make sure to collect all subscriptions here, otherwise page navigation doesn't work.
   private subs = [] as Subscription[];
 
-  private readonly valueRefs = Array.from(Array(this.props.values.length), () =>
+  private readonly labelRefs = Array.from(Array(this.props.values.length), () =>
+    FSComponent.createRef<HTMLLabelElement>(),
+  );
+  private readonly inputRefs = Array.from(Array(this.props.values.length), () =>
     FSComponent.createRef<HTMLLabelElement>(),
   );
 
@@ -55,13 +58,13 @@ export class RadioButtonGroup extends DisplayComponent<RadioButtonGroupProps> {
       this.props.valuesDisabled = Subject.create<boolean[]>(this.props.values.map(() => false));
     }
 
-    this.valueRefs.forEach((ref, index) =>
+    this.inputRefs.forEach((ref, index) =>
       ref.instance.addEventListener('change', this.changeEventHandler.bind(this, index)),
     );
 
     this.subs.push(
       this.props.selectedIndex.sub((val) => {
-        this.valueRefs.forEach((ref, index) => {
+        this.inputRefs.forEach((ref, index) => {
           if (index === val) {
             ref.instance.setAttribute('checked', 'checked');
           } else {
@@ -73,7 +76,7 @@ export class RadioButtonGroup extends DisplayComponent<RadioButtonGroupProps> {
 
     this.subs.push(
       this.props.valuesDisabled.sub((val) => {
-        this.valueRefs.forEach((ref, index) => {
+        this.inputRefs.forEach((ref, index) => {
           if (val[index]) {
             ref.instance.setAttribute('disabled', 'disabled');
           } else {
@@ -85,7 +88,7 @@ export class RadioButtonGroup extends DisplayComponent<RadioButtonGroupProps> {
 
     this.subs.push(
       this.props.color.sub((v) => {
-        this.valueRefs.forEach((ref) => {
+        this.labelRefs.forEach((ref) => {
           ref.instance.classList.toggle('yellow', v === RadioButtonColor.Yellow);
           ref.instance.classList.toggle('green', v === RadioButtonColor.Green);
           ref.instance.classList.toggle('amber', v === RadioButtonColor.Amber);
@@ -100,7 +103,7 @@ export class RadioButtonGroup extends DisplayComponent<RadioButtonGroupProps> {
     // Destroy all subscriptions to remove all references to this instance.
     this.subs.forEach((x) => x.destroy());
 
-    this.valueRefs.forEach((ref, index) =>
+    this.inputRefs.forEach((ref, index) =>
       ref.instance.removeEventListener('change', this.changeEventHandler.bind(this, index)),
     );
 
@@ -112,13 +115,18 @@ export class RadioButtonGroup extends DisplayComponent<RadioButtonGroupProps> {
       <form>
         {this.props.values.map((el, idx) => (
           <label
-            ref={this.valueRefs[idx]}
+            ref={this.labelRefs[idx]}
             class="mfd-radio-button"
             htmlFor={`${this.props.idPrefix}_${idx}`}
             style={this.props.additionalVerticalSpacing ? `margin-top: ${this.props.additionalVerticalSpacing}px;` : ''}
             id={`${this.props.idPrefix}_label_${idx}`}
           >
-            <input type="radio" name={`${this.props.idPrefix}`} id={`${this.props.idPrefix}_${idx}`} />
+            <input
+              ref={this.inputRefs[idx]}
+              type="radio"
+              name={`${this.props.idPrefix}`}
+              id={`${this.props.idPrefix}_${idx}`}
+            />
             <span>{el}</span>
           </label>
         ))}

--- a/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/UiWidgets/RadioButtonGroup.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/UiWidgets/RadioButtonGroup.tsx
@@ -11,7 +11,13 @@ import {
   VNode,
 } from '@microsoft/msfs-sdk';
 
-type RADIO_BUTTON_COLOR = 'yellow' | 'green' | 'cyan' | 'white';
+export enum RadioButtonColor {
+  Yellow,
+  Green,
+  Amber,
+  Cyan,
+  White,
+}
 
 interface RadioButtonGroupProps extends ComponentProps {
   values: string[];
@@ -21,7 +27,7 @@ interface RadioButtonGroupProps extends ComponentProps {
   /** If this function is defined, selectedIndex is not automatically updated. This function should take care of that. */
   onModified?: (newSelectedIndex: number) => void;
   additionalVerticalSpacing?: number;
-  color?: Subscribable<RADIO_BUTTON_COLOR>;
+  color?: Subscribable<RadioButtonColor>;
 }
 export class RadioButtonGroup extends DisplayComponent<RadioButtonGroupProps> {
   // Make sure to collect all subscriptions here, otherwise page navigation doesn't work.
@@ -39,7 +45,7 @@ export class RadioButtonGroup extends DisplayComponent<RadioButtonGroupProps> {
     super.onAfterRender(node);
 
     if (this.props.color === undefined) {
-      this.props.color = Subject.create<RADIO_BUTTON_COLOR>('cyan');
+      this.props.color = Subject.create<RadioButtonColor>(RadioButtonColor.Cyan);
     }
     if (this.props.valuesDisabled === undefined) {
       this.props.valuesDisabled = Subject.create<boolean[]>(this.props.values.map(() => false));
@@ -78,12 +84,21 @@ export class RadioButtonGroup extends DisplayComponent<RadioButtonGroupProps> {
     this.subs.push(
       this.props.color.sub((v) => {
         this.props.values.forEach((val, idx) => {
-          document.getElementById(`${this.props.idPrefix}_label_${idx}`)?.classList.remove('yellow');
-          document.getElementById(`${this.props.idPrefix}_label_${idx}`)?.classList.remove('green');
-          document.getElementById(`${this.props.idPrefix}_label_${idx}`)?.classList.remove('cyan');
-          document.getElementById(`${this.props.idPrefix}_label_${idx}`)?.classList.remove('white');
-
-          document.getElementById(`${this.props.idPrefix}_label_${idx}`)?.classList.add(v);
+          document
+            .getElementById(`${this.props.idPrefix}_label_${idx}`)
+            ?.classList.toggle('yellow', v === RadioButtonColor.Yellow);
+          document
+            .getElementById(`${this.props.idPrefix}_label_${idx}`)
+            ?.classList.toggle('green', v === RadioButtonColor.Green);
+          document
+            .getElementById(`${this.props.idPrefix}_label_${idx}`)
+            ?.classList.toggle('amber', v === RadioButtonColor.Amber);
+          document
+            .getElementById(`${this.props.idPrefix}_label_${idx}`)
+            ?.classList.toggle('cyan', v === RadioButtonColor.Cyan);
+          document
+            .getElementById(`${this.props.idPrefix}_label_${idx}`)
+            ?.classList.toggle('white', v === RadioButtonColor.White);
         });
       }, true),
     );

--- a/fbw-common/src/systems/instruments/src/EFB/AircraftContext.ts
+++ b/fbw-common/src/systems/instruments/src/EFB/AircraftContext.ts
@@ -41,6 +41,7 @@ interface PinProgramOptions {
 interface RealismOptions {
   mcduKeyboard: boolean;
   pauseOnTod: boolean;
+  autoStepClimb: boolean;
   pilotAvatars: boolean;
   eclSoftKeys: boolean;
 }
@@ -92,6 +93,7 @@ export const AircraftContext = createContext<AircraftEfbContext>({
     realism: {
       mcduKeyboard: false,
       pauseOnTod: false,
+      autoStepClimb: false,
       pilotAvatars: false,
       eclSoftKeys: false,
     },

--- a/fbw-common/src/systems/instruments/src/EFB/Localization/data/en.json
+++ b/fbw-common/src/systems/instruments/src/EFB/Localization/data/en.json
@@ -631,6 +631,7 @@
     "Realism": {
       "AdirsAlignTime": "ADIRS Align Time",
       "AutofillChecklists": "Autofill Checklists",
+      "AutoStepClimb": "Automatic Step Climb",
       "BoardingTime": "Boarding Time",
       "DmcSelfTestTime": "DMC Self Test Time",
       "EclSoftKeys": "Show Soft Keys for EWD Electronic Checklists",

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/RealismPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/RealismPage.tsx
@@ -32,6 +32,7 @@ export const RealismPage = () => {
   const [mcduTimeout, setMcduTimeout] = usePersistentProperty('CONFIG_MCDU_KB_TIMEOUT', '60');
   const [pauseAtTod, setPauseAtTod] = usePersistentBooleanProperty('PAUSE_AT_TOD', false);
   const [todOffset, setTodOffset] = usePersistentNumberProperty('PAUSE_AT_TOD_DISTANCE', 10);
+  const [autoStepClimb, setAutoStepClimb] = usePersistentBooleanProperty('AUTO_STEP_CLIMB', false);
   const [realisticTiller, setRealisticTiller] = usePersistentNumberProperty('REALISTIC_TILLER_ENABLED', 0);
   const [autoFillChecklists, setAutoFillChecklists] = usePersistentNumberProperty('EFB_AUTOFILL_CHECKLISTS', 0);
   const [syncEfis, setFoEfis] = usePersistentNumberProperty('FO_SYNC_EFIS_ENABLED', 0);
@@ -178,6 +179,12 @@ export const RealismPage = () => {
             </SettingItem>
           )}
         </SettingGroup>
+      )}
+
+      {aircraftContext.settingsPages.realism.autoStepClimb && (
+        <SettingItem name={t('Settings.Realism.AutoStepClimb')} unrealistic groupType="parent">
+          <Toggle value={autoStepClimb} onToggle={(value) => setAutoStepClimb(value)} />
+        </SettingItem>
       )}
 
       {aircraftContext.settingsPages.realism.eclSoftKeys && (


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9486 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Adds step climbs to A380X.

Changes:
- [x] STEP ALTs tab of VERT REV page implemented
- [x] Interface to flight plan correctly integrated
- [x] Allow selection of CLB/DES constraint for SPD and ALT constraints
- [x] Add "auto step climb" QoL function
- [x] Add "ABOVE MAX FL" / "STEP DELETED" messages

Out of scope (i.e. not implemented):
- Optimum step point (requires deeper FMS changes)
- Subscriptions cleanup for pages other than VERT REV to be done in #9807 

Changelog will be added shortly before merge.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://github.com/user-attachments/assets/aafccd89-8d96-4c5b-98af-32a28941a92c)
![image](https://github.com/user-attachments/assets/2a4ea29f-78d1-479e-a785-4c69d71c89ce)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1) Load up cold&dark at airport, plan long enough flight (>3h) in Simbrief; Enable "Auto Step Climb" in EFB Realism Settings
2) Fill in FMS as per normal procedures
3) Insert step climbs or step descends (not too close to T/C or T/D, otherwise they'll get ignored)
4) Delete step climbs or descends (clear altitude and/or waypoint field), see whether that works
5) Enter step climb above max FL, should be ignored with "ABOVE MAX FL" message
6) Start flight, take-off, fast forward to cruise (sim rate can be increased)
7) When approaching S/C waypoint (at 20nm distance), the aircraft should display "STEP AHEAD" in the FMS message field. If Auto Step climb is enabled, the FCU alt should be automatically set to the new value, and CLB/DES should be engaged
8) Verify that step climbs or descends work as intended, with or without Auto Step Climbs enabled

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
