### PR TITLE
fix(a380x/mfd): Change soft key behaviour to page & add individual line scroll through KCCU in FPLN

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -140,6 +140,7 @@
 1. [EFB] Set EFB Auto Brightness to default to On - @MrJigs7 (MrJigs)
 1. [FMS] Allow airport to be loaded as fixes in instrument procedures - @tracernz (Mike)
 1. [A380X/ND] Fix Terr text wrong position on terrain radar - @MrJigs7 (MrJigs.)
+1. [A380X/FMS] Add page scroll via soft keys & individual scroll via KCCU on MFD F-PLN - @BravoMike99 (bruno_pt99)
 
 ## 0.12.0
 

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
@@ -118,8 +118,6 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
       return;
     }
 
-    console.time('F-PLN:onNewData');
-
     // update(...) is the most costly function. First performance improvement: Don't render everything completely new every time, just update with refs
     // Delete and re-render FPLN lines only if:
     // a) activeLegIndex changes
@@ -177,7 +175,6 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
       );
     }
     this.checkScrollButtons();
-    console.timeEnd('F-PLN:onNewData');
   }
 
   private update(startAtIndex: number, onlyUpdatePredictions = true): void {

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
@@ -650,7 +650,9 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
         if (k === 'UP') {
           this.displayFplnFromLineIndex.set(this.displayFplnFromLineIndex.get() - 1);
         } else if (k === 'DOWN') {
-          this.displayFplnFromLineIndex.set(this.displayFplnFromLineIndex.get() + 1);
+          this.displayFplnFromLineIndex.set(
+            Math.min(this.displayFplnFromLineIndex.get() + 1, this.getLastAllowableIndex()),
+          );
         }
       }),
     );
@@ -661,7 +663,7 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
     this.disabledScrollUp.set(
       !this.lineData || this.displayFplnFromLineIndex.get() <= (this.loadedFlightPlan?.activeLegIndex ?? 1) - 1,
     );
-    this.disabledScrollDown.set(!this.lineData || this.displayFplnFromLineIndex.get() >= this.lineData.length - 1);
+    this.disabledScrollDown.set(!this.lineData || this.displayFplnFromLineIndex.get() >= this.getLastAllowableIndex());
   }
 
   private spdAltButton(): VNode {
@@ -793,19 +795,17 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
         targetIndex = this.displayFplnFromLineIndex.get() + 1 - this.renderedFplnLines.length;
       } else {
         targetIndex = this.displayFplnFromLineIndex.get() + this.renderedFplnLines.length - 1;
-        if (targetIndex > this.lineData.length) {
-          targetIndex = this.lineData.findIndex(
-            (it) =>
-              it &&
-              it.originalLegIndex ===
-                (this.loadedFlightPlan?.alternateFlightPlan
-                  ? this.loadedFlightPlan.alternateFlightPlan.lastIndex
-                  : this.loadedFlightPlan?.lastIndex),
-          );
+        const maxBottomIndex = this.getLastAllowableIndex();
+        if (targetIndex > maxBottomIndex) {
+          targetIndex = maxBottomIndex;
         }
       }
       this.displayFplnFromLineIndex.set(Math.max(targetIndex, 0));
     }
+  }
+
+  private getLastAllowableIndex() {
+    return this.lineData.length - this.renderedFplnLines.length;
   }
 
   render(): VNode {

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
@@ -134,6 +134,13 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
       return;
     }
 
+    // If we ended beyond flightplan end due to TMPY deletion, scroll back to fit the flightplan
+    const lastAllowableIndex = this.getLastDisplayAllowableIndex();
+    if (this.displayFplnFromLineIndex.get() > this.getLastDisplayAllowableIndex()) {
+      this.displayFplnFromLineIndex.set(lastAllowableIndex);
+      return;
+    }
+
     this.update(this.displayFplnFromLineIndex.get(), onlyUpdatePredictions);
 
     this.lastRenderedActiveLegIndex = this.loadedFlightPlan.activeLegIndex ?? null;
@@ -651,7 +658,7 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
           this.displayFplnFromLineIndex.set(this.displayFplnFromLineIndex.get() - 1);
         } else if (k === 'DOWN') {
           this.displayFplnFromLineIndex.set(
-            Math.min(this.displayFplnFromLineIndex.get() + 1, this.getLastAllowableIndex()),
+            Math.min(this.displayFplnFromLineIndex.get() + 1, this.getLastDisplayAllowableIndex()),
           );
         }
       }),
@@ -663,7 +670,9 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
     this.disabledScrollUp.set(
       !this.lineData || this.displayFplnFromLineIndex.get() <= (this.loadedFlightPlan?.activeLegIndex ?? 1) - 1,
     );
-    this.disabledScrollDown.set(!this.lineData || this.displayFplnFromLineIndex.get() >= this.getLastAllowableIndex());
+    this.disabledScrollDown.set(
+      !this.lineData || this.displayFplnFromLineIndex.get() >= this.getLastDisplayAllowableIndex(),
+    );
   }
 
   private spdAltButton(): VNode {
@@ -792,10 +801,10 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
     if (this.lineData) {
       let targetIndex;
       if (up) {
-        targetIndex = this.displayFplnFromLineIndex.get() + 1 - this.renderedFplnLines.length;
+        targetIndex = this.displayFplnFromLineIndex.get() + 1 - this.renderedLineData.length;
       } else {
-        targetIndex = this.displayFplnFromLineIndex.get() + this.renderedFplnLines.length - 1;
-        const maxBottomIndex = this.getLastAllowableIndex();
+        targetIndex = this.displayFplnFromLineIndex.get() + this.renderedLineData.length - 1;
+        const maxBottomIndex = this.getLastDisplayAllowableIndex();
         if (targetIndex > maxBottomIndex) {
           targetIndex = maxBottomIndex;
         }
@@ -804,8 +813,8 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
     }
   }
 
-  private getLastAllowableIndex() {
-    return this.lineData.length - this.renderedFplnLines.length;
+  private getLastDisplayAllowableIndex() {
+    return this.lineData.length - this.renderedLineData.length;
   }
 
   render(): VNode {

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
@@ -787,19 +787,25 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
       return;
     }
 
-    let targetIndex;
-    if (up) {
-      targetIndex = this.displayFplnFromLineIndex.get() - this.renderedFplnLines.length;
-      if (targetIndex < 0) {
-        this.displayFplnFromLineIndex.set(0);
+    if (this.lineData) {
+      let targetIndex;
+      if (up) {
+        targetIndex = this.displayFplnFromLineIndex.get() + 1 - this.renderedFplnLines.length;
+      } else {
+        targetIndex = this.displayFplnFromLineIndex.get() + this.renderedFplnLines.length - 1;
+        if (targetIndex > this.lineData.length) {
+          targetIndex = this.lineData.findIndex(
+            (it) =>
+              it &&
+              it.originalLegIndex ===
+                (this.loadedFlightPlan?.alternateFlightPlan
+                  ? this.loadedFlightPlan.alternateFlightPlan.lastIndex
+                  : this.loadedFlightPlan?.lastIndex),
+          );
+        }
       }
-    } else {
-      targetIndex = this.displayFplnFromLineIndex.get() + this.renderedFplnLines.length;
-      if (targetIndex > this.lineData.length) {
-        targetIndex = this.lineData.length;
-      }
+      this.displayFplnFromLineIndex.set(Math.max(targetIndex, 0));
     }
-    this.displayFplnFromLineIndex.set(targetIndex);
   }
 
   render(): VNode {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Changes softkey navigation in F-PLN page to scroll through "pages".
Disables down navigation softkey once the end of the flightplan is in view.
Adds individual line scroll navigation through KCCU (old softkey behavior).
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

https://github.com/user-attachments/assets/4e46853f-4350-4b59-99c0-b2dbdf9ea169


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
https://youtu.be/AI8yFhuEa4Q?t=5201
<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
bruno_pt99
## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1) Program a flight plan of your choice and go to the F-PLN page on the MFD.
2) Using the arrow up and arrow down keys on the KCCU verify that the FPLN page scrolls line by line.
2.1 Once the start of the flightplan is visible, the up arrow up key does nothing. 
2.2 Once the end of the flightplan is displayed (if you have an alternate, it will be the end of it instead), the arrow down key does nothing. Verify that the down soft key is disabled/greyed out on the bottom right of the MFD.
3) By using the up or down soft keys, verify that it is possible to navigate through "pages". This means, when going "down" the last waypoint of the current list will be the first one of the next list. When going up, the opposite applies, the first waypoint of the "current" list becomes the last after pressing the up soft key. The exception to this is when the start or end of flightplan (includes alternate if present) are reached, at which point the page should display the start or end of the flightplan data.  Feel free to mix this one with 2). 
4) Perform a modification in your flight plan such that a temporary is created and scroll down the page to a list of waypoints which did not exist before/only exist on temporary. After doing so erase the temporary flightplan and the page should update to fit the existing waypoints like the example video.


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
