### PR TITLE
fix(a380x/oans): Fix compass rose/lubber line layer order & BTV fallback input field

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -156,6 +156,7 @@
 1. [A380X/BTV] Add EXIT MISSED indication on FMA and aural triple click - @flogross89 (floridude)
 1. [A380X/OANS] Add flags/crosses capability, change cursor to magenta, implement ARPT NAV reset button - @flogross89 (floridude)
 1. [A32NX/MCDU] Show ground & cruise temperature sign on init page if positive - @BravoMike99 (bruno_pt99)
+1. [A380X/OANS] Fix BTV fallback mode; Enable BTV fallback if ARPT NAV reset button is pulled - @flogross89 (floridude)
 
 ## 0.12.0
 

--- a/fbw-a380x/src/systems/instruments/src/ND/OansControlPanel.tsx
+++ b/fbw-a380x/src/systems/instruments/src/ND/OansControlPanel.tsx
@@ -82,7 +82,6 @@ export class OansControlPanel extends DisplayComponent<OansProps> {
 
   /** If navigraph not available, this class will compute BTV features */
   private readonly navigraphAvailable = Subject.create(false);
-
   private readonly oansResetPulled = ConsumerSubject.create(this.sub.on('a380x_reset_panel_arpt_nav'), false);
 
   private oansPerformanceModeSettingSub = () => {};
@@ -204,9 +203,9 @@ export class OansControlPanel extends DisplayComponent<OansProps> {
   );
 
   private readonly fmsLandingRunwayNotSelectedInFallback = MappedSubject.create(
-    ([ldgRwy, navigraph]) => !navigraph && ldgRwy === null,
+    ([ldgRwy, avail]) => !avail && ldgRwy === null,
     this.fmsDataStore.landingRunway,
-    this.navigraphAvailable,
+    this.oansAvailable,
   );
   private readonly fmsLandingRunwayVisibility = this.fmsLandingRunwayNotSelectedInFallback.map((notSelected) =>
     !notSelected ? 'inherit' : 'hidden',
@@ -323,7 +322,7 @@ export class OansControlPanel extends DisplayComponent<OansProps> {
         if (it) {
           // Load runway data
           const destination = this.fmsDataStore.destination.get();
-          if (destination && this.navigraphAvailable.get() === false) {
+          if (destination && this.oansAvailable.get() === false) {
             this.setBtvRunwayFromFmsRunway();
           }
         }
@@ -369,7 +368,7 @@ export class OansControlPanel extends DisplayComponent<OansProps> {
         .on('realTime')
         .atFrequency(5)
         .handle((_) => {
-          if (this.arpCoordinates && this.navigraphAvailable.get() === false) {
+          if (this.arpCoordinates && !this.oansAvailable.get()) {
             globalToAirportCoordinates(this.arpCoordinates, this.presentPos.get(), this.localPpos);
             this.props.bus.getPublisher<FmsOansData>().pub('oansAirportLocalCoordinates', this.localPpos, true);
           }
@@ -410,7 +409,7 @@ export class OansControlPanel extends DisplayComponent<OansProps> {
             this.runwayLda.set(this.mapDataFeatures[idx].properties.lda?.toFixed(0) ?? '');
             this.runwayTora.set(this.mapDataFeatures[idx].properties.tora?.toFixed(0) ?? '');
           }
-        } else {
+        } else if (this.oansAvailable.get()) {
           this.selectedEntityString.set('');
           this.runwayLda.set('');
           this.runwayTora.set('');
@@ -675,11 +674,13 @@ export class OansControlPanel extends DisplayComponent<OansProps> {
         destination,
         rwyIdent,
       );
+      this.runwayLda.set(this.landingRunwayNavdata.length.toFixed(0));
+      this.runwayTora.set(this.landingRunwayNavdata.length.toFixed(0));
     }
   }
 
   private async btvFallbackSetDistance(distance: number | null) {
-    if (this.navigraphAvailable.get() === false) {
+    if (!this.oansAvailable.get()) {
       if (distance && distance > MIN_TOUCHDOWN_ZONE_DISTANCE && this.landingRunwayNavdata && this.arpCoordinates) {
         const exitLocation = placeBearingDistance(
           this.landingRunwayNavdata.thresholdLocation,
@@ -1021,7 +1022,7 @@ export class OansControlPanel extends DisplayComponent<OansProps> {
                   <div class="oans-cp-status-2">
                     <Button
                       label="SWAP"
-                      disabled={this.navigraphAvailable}
+                      disabled={this.oansAvailable}
                       onClick={() => this.loadOansDb()}
                       buttonStyle="padding: 20px 30px 20px 30px;"
                     />

--- a/fbw-a380x/src/systems/instruments/src/ND/OansControlPanel.tsx
+++ b/fbw-a380x/src/systems/instruments/src/ND/OansControlPanel.tsx
@@ -203,8 +203,13 @@ export class OansControlPanel extends DisplayComponent<OansProps> {
     it.isNormalOperation() ? Math.round(it.value + MIN_TOUCHDOWN_ZONE_DISTANCE) : null,
   );
 
-  private readonly fmsLandingRunwayVisibility = this.fmsDataStore.landingRunway.map((rwy) =>
-    rwy ? 'inherit' : 'hidden',
+  private readonly fmsLandingRunwayNotSelectedInFallback = MappedSubject.create(
+    ([ldgRwy, navigraph]) => !navigraph && ldgRwy === null,
+    this.fmsDataStore.landingRunway,
+    this.navigraphAvailable,
+  );
+  private readonly fmsLandingRunwayVisibility = this.fmsLandingRunwayNotSelectedInFallback.map((notSelected) =>
+    !notSelected ? 'inherit' : 'hidden',
   );
 
   private arpCoordinates: Coordinates | undefined;
@@ -735,6 +740,7 @@ export class OansControlPanel extends DisplayComponent<OansProps> {
                       idPrefix="oanc-search-letter"
                       freeTextAllowed={false}
                       onModified={(i) => this.selectedEntityIndex.set(i)}
+                      inactive={this.fmsLandingRunwayNotSelectedInFallback}
                       hEventConsumer={this.hEventConsumer}
                       interactionMode={this.interactionMode}
                     />
@@ -864,7 +870,7 @@ export class OansControlPanel extends DisplayComponent<OansProps> {
                           dataHandlerDuringValidation={async (val) => this.btvFallbackSetDistance(val)}
                           readonlyValue={this.reqStoppingDistance}
                           mandatory={Subject.create(false)}
-                          inactive={this.selectedEntityString.map((it) => !it)}
+                          inactive={this.fmsLandingRunwayNotSelectedInFallback}
                           hEventConsumer={this.hEventConsumer}
                           interactionMode={this.interactionMode}
                         />

--- a/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
+++ b/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
@@ -475,7 +475,7 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
       if (hide) {
         this.unloadAirportMap(true);
       } else if (this.dataAirportIcao.get()) {
-        this.loadAirportMap(this.dataAirportIcao.get());
+        this.loadAirportMap(this.dataAirportIcao.get(), true);
       }
     });
 
@@ -618,9 +618,9 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
   public unloadAirportMap(performanceModeUnload: boolean = false) {
     if (!performanceModeUnload) {
       this.btvUtils.clearSelection();
-      this.markerManager.eraseAllCrosses();
-      this.markerManager.eraseAllFlags();
     }
+    this.markerManager.eraseAllCrosses();
+    this.markerManager.eraseAllFlags();
     this.clearMap();
     this.clearData();
 
@@ -634,11 +634,11 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
    * @param icao four letter ICAO code of airport to load
    * @returns
    */
-  public async loadAirportMap(icao: string) {
+  public async loadAirportMap(icao: string, performanceModeUnload: boolean = false) {
     this.dataLoading = true;
     this.airportLoading.set(true);
 
-    this.unloadAirportMap();
+    this.unloadAirportMap(performanceModeUnload);
 
     if (!icao) {
       this.dataLoading = false;
@@ -1086,8 +1086,6 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
     this.lastTime = now;
 
     if (this.data && this.resetPulled.get()) {
-      this.markerManager.eraseAllCrosses();
-      this.markerManager.eraseAllFlags();
       this.unloadAirportMap(true);
     }
 

--- a/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
+++ b/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
@@ -473,7 +473,7 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
 
     this.oansPerformanceModeHide.sub((hide) => {
       if (hide) {
-        this.unloadAirportMap();
+        this.unloadAirportMap(true);
       } else if (this.dataAirportIcao.get()) {
         this.loadAirportMap(this.dataAirportIcao.get());
       }
@@ -615,10 +615,12 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
     setTimeout(() => (this.labelManager.showLabels = true), ZOOM_TRANSITION_TIME_MS + 200);
   }
 
-  public unloadAirportMap() {
-    this.btvUtils.clearSelection();
-    this.markerManager.eraseAllCrosses();
-    this.markerManager.eraseAllFlags();
+  public unloadAirportMap(performanceModeUnload: boolean = false) {
+    if (!performanceModeUnload) {
+      this.btvUtils.clearSelection();
+      this.markerManager.eraseAllCrosses();
+      this.markerManager.eraseAllFlags();
+    }
     this.clearMap();
     this.clearData();
 
@@ -1084,7 +1086,9 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
     this.lastTime = now;
 
     if (this.data && this.resetPulled.get()) {
-      this.unloadAirportMap();
+      this.markerManager.eraseAllCrosses();
+      this.markerManager.eraseAllFlags();
+      this.unloadAirportMap(true);
     }
 
     if (!this.data || this.dataLoading || this.resetPulled.get()) return;

--- a/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
+++ b/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
@@ -1648,33 +1648,6 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
               >
                 <canvas ref={this.layerCanvasRefs[7]} width={this.canvasWidth} height={this.canvasHeight} />
               </div>
-
-              <OancAircraftIcon
-                isVisible={this.showAircraft}
-                x={this.aircraftX}
-                y={this.aircraftY}
-                rotation={this.aircraftRotation}
-              />
-
-              <svg
-                class="nd-svg nd-top-layer"
-                viewBox="0 0 768 768"
-                style={this.efisNDModeSub.map(
-                  (mode) => `transform: translateY(${mode === EfisNdMode.ARC ? -236 : 0}px);`,
-                )}
-              >
-                <LubberLine
-                  bus={this.props.bus}
-                  visible={MappedSubject.create(
-                    ([ac, mode]) => ac && mode !== EfisNdMode.PLAN,
-                    this.showAircraft,
-                    this.efisNDModeSub,
-                  )}
-                  rotation={Subject.create(0)}
-                  ndMode={this.efisNDModeSub}
-                  colorClass="Magenta"
-                />
-              </svg>
             </div>
           </div>
 
@@ -1683,20 +1656,59 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
             style={`position: absolute; width: ${OANC_RENDER_WIDTH}px; height: ${OANC_RENDER_HEIGHT}px; pointer-events: auto;`}
           />
 
+          <OancStaticModeOverlay
+            bus={this.props.bus}
+            oansRange={this.zoomLevelIndex.map((it) => this.props.zoomValues[it])}
+            ndMode={this.overlayNDModeSub}
+            rotation={this.interpolatedMapHeading}
+            isMapPanned={this.isMapPanned}
+            airportWithinRange={this.airportWithinRange}
+            airportBearing={this.airportBearing}
+            airportIcao={this.dataAirportIcao}
+          />
+
           <div
             ref={this.animationContainerRef[1]}
             style={`position: absolute; transition: transform ${ZOOM_TRANSITION_TIME_MS}ms linear; pointer-events: none;`}
           >
-            <div ref={this.panContainerRef[1]} style="position: absolute;">
-              <OancMovingModeOverlay
+            <OancMovingModeOverlay
+              bus={this.props.bus}
+              oansRange={this.zoomLevelIndex.map((it) => this.props.zoomValues[it])}
+              ndMode={this.overlayNDModeSub}
+              rotation={this.interpolatedMapHeading}
+              isMapPanned={this.isMapPanned}
+              airportWithinRange={this.airportWithinRange}
+              airportBearing={this.airportBearing}
+              airportIcao={this.dataAirportIcao}
+            />
+
+            <svg
+              class="nd-svg nd-top-layer"
+              viewBox="0 0 768 768"
+              style={this.efisNDModeSub.map(
+                (mode) =>
+                  `transform: translateY(${mode === EfisNdMode.ARC ? -236 : 0}px); pointer-events: none; z-index: 99;`,
+              )}
+            >
+              <LubberLine
                 bus={this.props.bus}
-                oansRange={this.zoomLevelIndex.map((it) => this.props.zoomValues[it])}
-                ndMode={this.overlayNDModeSub}
-                rotation={this.interpolatedMapHeading}
-                isMapPanned={this.isMapPanned}
-                airportWithinRange={this.airportWithinRange}
-                airportBearing={this.airportBearing}
-                airportIcao={this.dataAirportIcao}
+                visible={MappedSubject.create(
+                  ([ac, mode]) => ac && mode !== EfisNdMode.PLAN,
+                  this.showAircraft,
+                  this.efisNDModeSub,
+                )}
+                rotation={Subject.create(0)}
+                ndMode={this.efisNDModeSub}
+                colorClass="Magenta"
+              />
+            </svg>
+
+            <div ref={this.panContainerRef[1]} style="position: absolute;">
+              <OancAircraftIcon
+                isVisible={this.showAircraft}
+                x={this.aircraftX}
+                y={this.aircraftY}
+                rotation={this.aircraftRotation}
               />
             </div>
           </div>
@@ -1740,17 +1752,6 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
               ACTIVE F/PLN
             </span>
           </div>
-
-          <OancStaticModeOverlay
-            bus={this.props.bus}
-            oansRange={this.zoomLevelIndex.map((it) => this.props.zoomValues[it])}
-            ndMode={this.overlayNDModeSub}
-            rotation={this.interpolatedMapHeading}
-            isMapPanned={this.isMapPanned}
-            airportWithinRange={this.airportWithinRange}
-            airportBearing={this.airportBearing}
-            airportIcao={this.dataAirportIcao}
-          />
         </div>
       </>
     );

--- a/fbw-common/src/systems/instruments/src/OANC/OancMovingModeOverlay.tsx
+++ b/fbw-common/src/systems/instruments/src/OANC/OancMovingModeOverlay.tsx
@@ -58,7 +58,7 @@ export class OancMovingModeOverlay extends DisplayComponent<OancMapOverlayProps>
     this.subs.push(
       this.props.rotation.sub((r) => {
         this.rotationArinc429Word.setValueSsm(r, Arinc429SignStatusMatrix.NormalOperation);
-      }),
+      }, true),
     );
 
     this.subs.push(this.arcModeVisible, this.roseModeVisible);
@@ -124,7 +124,7 @@ export class OancStaticModeOverlay extends DisplayComponent<OancMapOverlayProps>
     this.subs.push(
       this.props.rotation.sub((r) => {
         this.rotationArinc429Word.setValueSsm(r, Arinc429SignStatusMatrix.NormalOperation);
-      }),
+      }, true),
     );
   }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes issue after #9725 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

- Reorder layers: Aircraft symbol over every part of the airport map, lubber line over compass rose, compass rose stays static w.r.t. to screen position (doesn't move when panning)
- Disable MAP DATA input field when navigraph not available
- Enable BTV fallback input field again when navigraph is not available

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://github.com/user-attachments/assets/34129b7a-6792-4286-a476-2e4c23bf41d4)
![image](https://github.com/user-attachments/assets/b1079057-c005-4142-8b67-d16dbe065e3d)
![image](https://github.com/user-attachments/assets/89f83245-7446-4136-89fa-183c6767ff28)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
**Important: You need to use a manual build which contains the Navigraph auth secrets for Scenario 2.** 
Download here: https://www.swisstransfer.com/d/84caa995-5956-4644-ad1d-ca51a59d5e52
and unzip to `flybywire-aircraft-a380-842\html_ui\Pages\VCockpit\Instruments\A380X` in community folder

**Scenario 1: No navigraph subscription, use BTV fallback only**
1. If you have a Navigraph ultimate sub, make sure to unlink it in the EFB
2. Set up FMS for landing (select landing runway), enter distance in BTV fallback stop distance field
3. Arm BTV
4. Perform landing, BTV should brake as expected

**Scenario 2: Performance mode auto-unload**
1. Make sure that Navigraph is linked via EFB, enable OANS Performance Mode in EFB
2. Set up FMS for landing (select landing runway)
3. Go to plan mode, select BTV exit via OANS
4. Go out of ZOOM range, wait at least one minute until OANS map is unloaded. BTV should **not** disarm in the FMA
5. Perform landing, BTV should brake as expected

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
