### PR TITLE
fix(a32nx/fms): fix preselected cruise speed/mach value showing in the descent phase

### DIFF
--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -2159,6 +2159,16 @@ In the variables below, {number} should be replaced with one item in the set: { 
         - NAV mode is engaged
         - FINAL mode is armed
 
+- A32NX_SpeedPreselVal
+    - Number
+    - Indicates the preselected speed value, -1 if no value is preselected
+    - Internal to FM/FG communication, other avionics should use the FG bus var
+
+- A32NX_MachPreselVal
+    - Number
+    - Indicates the preselect mach value, -1 if no value is preselected
+    - Internal to FM/FG communication, other avionics should use the FG bus var
+
 ## Autothrust System
 
 - A32NX_3D_THROTTLE_LEVER_POSITION_{index}

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
@@ -826,9 +826,6 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
         }
 
         SimVar.SetSimVarValue('L:A32NX_GOAROUND_PASSED', 'bool', 0);
-        Coherent.call('GENERAL_ENG_THROTTLE_MANAGED_MODE_SET', ThrottleMode.AUTO)
-          .catch(console.error)
-          .catch(console.error);
 
         /** Activate pre selected speed/mach */
         if (prevPhase === FmgcFlightPhase.Climb) {
@@ -837,8 +834,7 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
         }
 
         /** Arm preselected speed/mach for next flight phase */
-        // FIXME implement pre-selected descent speed!
-        //this.updatePreSelSpeedMach(this.preSelectedDesSpeed);
+        this.updatePreSelSpeedMach(undefined);
 
         break;
       }
@@ -851,10 +847,6 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
         }
 
         this.checkDestData();
-
-        Coherent.call('GENERAL_ENG_THROTTLE_MANAGED_MODE_SET', ThrottleMode.AUTO)
-          .catch(console.error)
-          .catch(console.error);
 
         this.triggerCheckSpeedModeMessage(undefined);
 
@@ -870,10 +862,6 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
           this.tryUpdatePerfPage(prevPhase, nextPhase);
         }
 
-        // I think this is not necessary to port, as it only calls fs9gps stuff (fms-v2)
-        // this.flightPlanManager.activateApproach().catch(console.error);
-
-        Coherent.call('GENERAL_ENG_THROTTLE_MANAGED_MODE_SET', ThrottleMode.AUTO).catch(console.error);
         SimVar.SetSimVarValue('L:A32NX_GOAROUND_PASSED', 'bool', 0);
 
         this.checkDestData();
@@ -1334,7 +1322,7 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
     }
   }
 
-  private updatePreSelSpeedMach(preSel) {
+  private updatePreSelSpeedMach(preSel: number | undefined) {
     // The timeout is required to create a delay for the current value to be read and the new one to be set
     setTimeout(() => {
       if (preSel) {

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
@@ -833,7 +833,7 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
           this.activatePreSelSpeedMach(this.preSelectedCrzSpeed);
         }
 
-        /** Arm preselected speed/mach for next flight phase */
+        /** Disarm preselected speed/mach for next flight phase */
         this.updatePreSelSpeedMach(undefined);
 
         break;

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FlightManagementComputer.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FlightManagementComputer.ts
@@ -778,9 +778,6 @@ export class FlightManagementComputer implements FmcInterface {
 
       case FmgcFlightPhase.Cruise: {
         SimVar.SetSimVarValue('L:A32NX_GOAROUND_PASSED', 'bool', 0);
-        Coherent.call('GENERAL_ENG_THROTTLE_MANAGED_MODE_SET', ThrottleMode.AUTO)
-          .catch(console.error)
-          .catch(console.error);
 
         const cruisePreSel = this.fmgc.data.cruisePreSelSpeed.get();
         const cruisePreSelMach = this.fmgc.data.cruisePreSelMach.get();
@@ -804,10 +801,6 @@ export class FlightManagementComputer implements FmcInterface {
       case FmgcFlightPhase.Descent: {
         this.checkDestData();
 
-        Coherent.call('GENERAL_ENG_THROTTLE_MANAGED_MODE_SET', ThrottleMode.AUTO)
-          .catch(console.error)
-          .catch(console.error);
-
         /** Activate pre selected speed/mach */
         const desPreSel = this.fmgc.data.descentPreSelSpeed.get();
         if (prevPhase === FmgcFlightPhase.Cruise && desPreSel) {
@@ -824,7 +817,6 @@ export class FlightManagementComputer implements FmcInterface {
       }
 
       case FmgcFlightPhase.Approach: {
-        Coherent.call('GENERAL_ENG_THROTTLE_MANAGED_MODE_SET', ThrottleMode.AUTO).catch(console.error);
         SimVar.SetSimVarValue('L:A32NX_GOAROUND_PASSED', 'bool', 0);
 
         this.checkDestData();


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9854

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes an issue where the preselected cruise speed/mach value was shown during the descent phase. This happened because the value was not properly reset.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Go through the steps to reproduce the linked issue. Ensure the issue no longer occurs.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
