### PR TITLE
fix(a380x): fix speed margin display above crossover altitude

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/A320AircraftConfig.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/A320AircraftConfig.ts
@@ -22,13 +22,12 @@ const lnavConfig: LnavConfig = {
 const vnavConfig: VnavConfig = {
   VNAV_DESCENT_MODE: VnavDescentMode.NORMAL,
   VNAV_EMIT_CDA_FLAP_PWP: false,
-  DEBUG_PROFILE: false,
-  DEBUG_GUIDANCE: false,
-  ALLOW_DEBUG_PARAMETER_INJECTION: false,
   VNAV_USE_LATCHED_DESCENT_MODE: false,
   IDLE_N1_MARGIN: 2,
   MAXIMUM_FUEL_ESTIMATE: 40000,
   LIM_PSEUDO_WPT_LABEL: '(LIM)',
+  VMO: 350,
+  MMO: 0.82,
 };
 
 const flightModelParams: FlightModelParameters = {

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/A380AircraftConfig.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/A380AircraftConfig.ts
@@ -22,13 +22,12 @@ const lnavConfig: LnavConfig = {
 const vnavConfig: VnavConfig = {
   VNAV_DESCENT_MODE: VnavDescentMode.NORMAL,
   VNAV_EMIT_CDA_FLAP_PWP: false,
-  DEBUG_PROFILE: false,
-  DEBUG_GUIDANCE: false,
-  ALLOW_DEBUG_PARAMETER_INJECTION: false,
   VNAV_USE_LATCHED_DESCENT_MODE: false,
   IDLE_N1_MARGIN: 3,
   MAXIMUM_FUEL_ESTIMATE: 250_000,
   LIM_PSEUDO_WPT_LABEL: '(SPDLIM)',
+  VMO: 340,
+  MMO: 0.89,
 };
 
 const flightModelParams: FlightModelParameters = {

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/AircraftConfigTypes.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/AircraftConfigTypes.ts
@@ -29,27 +29,6 @@ export interface VnavConfig {
    */
   VNAV_EMIT_CDA_FLAP_PWP: boolean;
 
-  /**
-   * Whether to pring debug information and errors during the VNAV computation.
-   */
-  DEBUG_PROFILE: boolean;
-
-  /**
-   * Whether to print guidance debug information on the ND
-   */
-  DEBUG_GUIDANCE: boolean;
-
-  /**
-   * Whether to use debug simvars (VNAV_DEBUG_*) to determine aircraft position and state.
-   * This is useful for testing VNAV without having to fly the aircraft. This lets you put the aircraft some distance before destination at a given altitude and speed.
-   * The following simvars can be used:
-   * - A32NX_FM_VNAV_DEBUG_POINT: Indicates the distance from start (NM) at which to draw a debug pseudowaypoint on the ND
-   * - A32NX_FM_VNAV_DEBUG_ALTITUDE: Indicates the indicated altitude (ft) VNAV uses for predictions
-   * - A32NX_FM_VNAV_DEBUG_SPEED: Indicates the indicated airspeed (kts) VNAV uses for predictions
-   * - A32NX_FM_VNAV_DEBUG_DISTANCE_TO_END: Indicates the distance (NM) to end VNAV uses for predictions
-   */
-  ALLOW_DEBUG_PARAMETER_INJECTION: boolean;
-
   VNAV_USE_LATCHED_DESCENT_MODE: boolean;
 
   /**
@@ -70,6 +49,16 @@ export interface VnavConfig {
    * Configurable since different Airbus aircraft use different labels (e.g. A320 vs A380).
    */
   LIM_PSEUDO_WPT_LABEL: '(LIM)' | '(SPDLIM)';
+
+  /**
+   * The maximum operating speed in knots
+   */
+  VMO: number;
+
+  /**
+   * The maximum operating Mach number
+   */
+  MMO: number;
 }
 
 /** Only covers aircraft specific configs, no debug switches */

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/lnav/PseudoWaypoints.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/lnav/PseudoWaypoints.ts
@@ -116,7 +116,9 @@ export class PseudoWaypoints implements GuidanceComponent {
     const newPseudoWaypoints: PseudoWaypoint[] = [];
     const totalDistance = navGeometryProfile.totalFlightPlanDistance;
 
-    const shouldEmitCdaPwp = VnavConfig.VNAV_DESCENT_MODE === VnavDescentMode.CDA && VnavConfig.VNAV_EMIT_CDA_FLAP_PWP;
+    const shouldEmitCdaPwp =
+      this.acConfig.vnavConfig.VNAV_DESCENT_MODE === VnavDescentMode.CDA &&
+      this.acConfig.vnavConfig.VNAV_EMIT_CDA_FLAP_PWP;
 
     // We do this so we only draw the first of each waypoint type
     const waypointsLeftToDraw = new Set([...CHECKPOINTS_TO_PUT_IN_MCDU, ...CHECKPOINTS_TO_DRAW_ON_ND]);

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/CruiseToDescentCoordinator.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/CruiseToDescentCoordinator.ts
@@ -13,7 +13,6 @@ import { VerticalProfileComputationParametersObserver } from '@fmgc/guidance/vna
 import { HeadwindProfile } from '@fmgc/guidance/vnav/wind/HeadwindProfile';
 import { TemporaryCheckpointSequence } from '@fmgc/guidance/vnav/profile/TemporaryCheckpointSequence';
 import { ProfileInterceptCalculator } from '@fmgc/guidance/vnav/descent/ProfileInterceptCalculator';
-import { VnavConfig } from '@fmgc/guidance/vnav/VnavConfig';
 import { AircraftConfig } from '@fmgc/flightplanning/AircraftConfigTypes';
 
 export class CruiseToDescentCoordinator {
@@ -34,7 +33,7 @@ export class CruiseToDescentCoordinator {
 
     // Use INIT FUEL PRED entry as initial estimate for destination EFOB. Clamp it to avoid unrealistic entries from erroneous pilot input.
     this.lastEstimatedFuelAtDestination = Number.isFinite(estimatedDestinationFuel)
-      ? Math.min(Math.max(estimatedDestinationFuel, 0), VnavConfig.MAXIMUM_FUEL_ESTIMATE)
+      ? Math.min(Math.max(estimatedDestinationFuel, 0), this.acConfig.vnavConfig.MAXIMUM_FUEL_ESTIMATE)
       : 4000;
     this.lastEstimatedTimeAtDestination = 0;
   }

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VerticalProfileManager.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VerticalProfileManager.ts
@@ -37,7 +37,6 @@ import { HeadwindProfile } from '@fmgc/guidance/vnav/wind/HeadwindProfile';
 import { ProfileInterceptCalculator } from '@fmgc/guidance/vnav/descent/ProfileInterceptCalculator';
 import { BaseGeometryProfile } from '@fmgc/guidance/vnav/profile/BaseGeometryProfile';
 import { AircraftToDescentProfileRelation } from '@fmgc/guidance/vnav/descent/AircraftToProfileRelation';
-import { VnavConfig } from '@fmgc/guidance/vnav/VnavConfig';
 import { FlightPlanService } from '@fmgc/flightplanning/FlightPlanService';
 import { AircraftConfig } from '@fmgc/flightplanning/AircraftConfigTypes';
 import {
@@ -214,7 +213,7 @@ export class VerticalProfileManager {
     const { estimatedDestinationFuel } = this.observer.get();
     // Use INIT FUEL PRED entry as initial estimate for destination EFOB. Clamp it to avoid potentially crashing predictions entirely from erroneous pilot input.
     const fuelEstimation = Number.isFinite(estimatedDestinationFuel)
-      ? Math.min(Math.max(estimatedDestinationFuel, 0), VnavConfig.MAXIMUM_FUEL_ESTIMATE)
+      ? Math.min(Math.max(estimatedDestinationFuel, 0), this.acConfig.vnavConfig.MAXIMUM_FUEL_ESTIMATE)
       : 4000;
     const finalCruiseAltitude = this.cruisePathBuilder.getFinalCruiseAltitude(descentProfile.cruiseSteps);
 

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VnavConfig.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VnavConfig.ts
@@ -11,16 +11,6 @@ export enum VnavDescentMode {
 
 export const VnavConfig = {
   /**
-   * VNAV descent calculation mode (NORMAL, CDA or DPO)
-   */
-  VNAV_DESCENT_MODE: VnavDescentMode.NORMAL,
-
-  /**
-   * Whether to emit CDA flap1/2 pseudo-waypoints (only if VNAV_DESCENT_MODE is CDA)
-   */
-  VNAV_EMIT_CDA_FLAP_PWP: false,
-
-  /**
    * Whether to pring debug information and errors during the VNAV computation.
    */
   DEBUG_PROFILE: false,
@@ -40,18 +30,4 @@ export const VnavConfig = {
    * - A32NX_FM_VNAV_DEBUG_DISTANCE_TO_END: Indicates the distance (NM) to end VNAV uses for predictions
    */
   ALLOW_DEBUG_PARAMETER_INJECTION: false,
-
-  VNAV_USE_LATCHED_DESCENT_MODE: false,
-
-  /**
-   * Percent N1 to add to the predicted idle N1. The real aircraft does also use a margin for this, but I don't know how much
-   */
-  IDLE_N1_MARGIN: 3,
-
-  /**
-   * VNAV needs to make an initial estimate of the fuel on board at destination to compute the descent path.
-   * We don't want this figure to be too large as it might crash the predictions. So we clamp it to this value.
-   * This value is in lbs.
-   */
-  MAXIMUM_FUEL_ESTIMATE: 40000,
 };

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VnavDriver.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VnavDriver.ts
@@ -33,6 +33,7 @@ import {
 import { VMLeg } from '@fmgc/guidance/lnav/legs/VM';
 import { FMLeg } from '@fmgc/guidance/lnav/legs/FM';
 import { MathUtils } from '@flybywiresim/fbw-sdk';
+import { VnavConfig } from './VnavConfig';
 
 export class VnavDriver implements GuidanceComponent {
   version: number = 0;
@@ -87,12 +88,14 @@ export class VnavDriver implements GuidanceComponent {
     this.aircraftToDescentProfileRelation = new AircraftToDescentProfileRelation(this.computationParametersObserver);
     this.descentGuidance = this.acConfig.vnavConfig.VNAV_USE_LATCHED_DESCENT_MODE
       ? new LatchedDescentGuidance(
+          this.acConfig,
           this.guidanceController,
           this.aircraftToDescentProfileRelation,
           computationParametersObserver,
           this.atmosphericConditions,
         )
       : new DescentGuidance(
+          this.acConfig,
           this.guidanceController,
           this.aircraftToDescentProfileRelation,
           computationParametersObserver,
@@ -563,7 +566,7 @@ export class VnavDriver implements GuidanceComponent {
   }
 
   updateDebugInformation() {
-    if (!this.acConfig.vnavConfig.DEBUG_GUIDANCE) {
+    if (!VnavConfig.DEBUG_GUIDANCE) {
       return;
     }
 

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/cruise/CruisePathBuilder.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/cruise/CruisePathBuilder.ts
@@ -20,6 +20,7 @@ import {
   VerticalCheckpointReason,
 } from '../profile/NavGeometryProfile';
 import { AtmosphericConditions } from '../AtmosphericConditions';
+import { VnavConfig } from '../VnavConfig';
 
 export class CruisePathBuilder {
   constructor(
@@ -124,7 +125,7 @@ export class CruisePathBuilder {
       sequence.addCheckpointFromStep(accelerationStep, VerticalCheckpointReason.AtmosphericConditions);
     }
 
-    if (config.vnavConfig.DEBUG_PROFILE && targetDistanceFromStart < sequence.lastCheckpoint.distanceFromStart) {
+    if (VnavConfig.DEBUG_PROFILE && targetDistanceFromStart < sequence.lastCheckpoint.distanceFromStart) {
       console.warn(
         '[FMS/VNAV] An acceleration step in the cruise took us past T/D. This is not implemented properly yet. Blame BBK',
       );

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/DescentGuidance.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/DescentGuidance.ts
@@ -13,6 +13,7 @@ import { VerticalMode } from '@shared/autopilot';
 import { FmgcFlightPhase } from '@shared/flightphase';
 import { SpeedMargin } from './SpeedMargin';
 import { TodGuidance } from './TodGuidance';
+import { AircraftConfig } from '../../../flightplanning/AircraftConfigTypes';
 
 enum DescentVerticalGuidanceState {
   InvalidProfile,
@@ -102,12 +103,13 @@ export class DescentGuidance {
   private pathCaptureState: PathCaptureState = PathCaptureState.OffPath;
 
   constructor(
+    config: AircraftConfig,
     private guidanceController: GuidanceController,
     private aircraftToDescentProfileRelation: AircraftToDescentProfileRelation,
     private observer: VerticalProfileComputationParametersObserver,
     private atmosphericConditions: AtmosphericConditions,
   ) {
-    this.speedMargin = new SpeedMargin(this.observer);
+    this.speedMargin = new SpeedMargin(config, this.observer);
     this.todGuidance = new TodGuidance(
       this.aircraftToDescentProfileRelation,
       this.observer,

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/DescentStrategy.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/DescentStrategy.ts
@@ -13,7 +13,6 @@ import {
 import { EngineModel } from '@fmgc/guidance/vnav/EngineModel';
 import { Predictions, StepResults } from '@fmgc/guidance/vnav/Predictions';
 import { VerticalProfileComputationParametersObserver } from '@fmgc/guidance/vnav/VerticalProfileComputationParameters';
-import { VnavConfig } from '@fmgc/guidance/vnav/VnavConfig';
 import { WindComponent } from '@fmgc/guidance/vnav/wind';
 
 export interface DescentStrategy {
@@ -215,7 +214,7 @@ export class IdleDescentStrategy implements DescentStrategy {
     const computedMach = Math.min(this.atmosphericConditions.computeMachFromCas(midwayAltitude, speed), mach);
     const predictedN1 =
       EngineModel.getIdleCorrectedN1(this.acConfig.engineModelParameters, midwayAltitude, computedMach, tropoPause) +
-      VnavConfig.IDLE_N1_MARGIN;
+      this.acConfig.vnavConfig.IDLE_N1_MARGIN;
 
     return Predictions.altitudeStep(
       this.acConfig,
@@ -251,7 +250,7 @@ export class IdleDescentStrategy implements DescentStrategy {
     const computedMach = Math.min(this.atmosphericConditions.computeMachFromCas(initialAltitude, speed), mach);
     const predictedN1 =
       EngineModel.getIdleCorrectedN1(this.acConfig.engineModelParameters, initialAltitude, computedMach, tropoPause) +
-      VnavConfig.IDLE_N1_MARGIN;
+      this.acConfig.vnavConfig.IDLE_N1_MARGIN;
 
     return Predictions.distanceStep(
       this.acConfig,
@@ -287,7 +286,7 @@ export class IdleDescentStrategy implements DescentStrategy {
     const computedMach = Math.min(this.atmosphericConditions.computeMachFromCas(initialAltitude, initialSpeed), mach);
     const predictedN1 =
       EngineModel.getIdleCorrectedN1(this.acConfig.engineModelParameters, initialAltitude, computedMach, tropoPause) +
-      VnavConfig.IDLE_N1_MARGIN;
+      this.acConfig.vnavConfig.IDLE_N1_MARGIN;
 
     const initialMach = Math.min(this.atmosphericConditions.computeMachFromCas(initialAltitude, initialSpeed), mach);
     const finalMach = Math.min(this.atmosphericConditions.computeMachFromCas(initialAltitude, finalSpeed), mach);

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/LatchedDescentGuidance.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/descent/LatchedDescentGuidance.ts
@@ -12,6 +12,7 @@ import { FmgcFlightPhase } from '@shared/flightphase';
 import { GuidanceController } from '@fmgc/guidance/GuidanceController';
 import { TodGuidance } from './TodGuidance';
 import { SpeedMargin } from './SpeedMargin';
+import { AircraftConfig } from '../../../flightplanning/AircraftConfigTypes';
 
 enum DescentVerticalGuidanceState {
   InvalidProfile,
@@ -53,12 +54,13 @@ export class LatchedDescentGuidance {
   private isInOverspeedCondition: boolean = false;
 
   constructor(
+    config: AircraftConfig,
     private guidanceController: GuidanceController,
     private aircraftToDescentProfileRelation: AircraftToDescentProfileRelation,
     private observer: VerticalProfileComputationParametersObserver,
     private atmosphericConditions: AtmosphericConditions,
   ) {
-    this.speedMargin = new SpeedMargin(this.observer);
+    this.speedMargin = new SpeedMargin(config, this.observer);
     this.todGuidance = new TodGuidance(
       this.aircraftToDescentProfileRelation,
       this.observer,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The speed margins are upper-limited by VMO and MMO. Previously these values were hardcoded to the A320 values (350 kts and M.82). This PR makes them configurable per aircraft type.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before:
![image](https://github.com/user-attachments/assets/efd36642-82d5-4e4c-af53-dcba11a9be89)
After:
![Screenshot 2025-02-14 165742](https://github.com/user-attachments/assets/045e27f4-00eb-4259-b881-58c8d8c7ae81)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
