### PR TITLE
fix(a32nx/fms): sort runways alphabetically

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -166,6 +166,7 @@
 1. [A380X/KCCU] Fix unclickable left directional arrow key on KCCU - @heclak (Heclak)
 1. [A380X/OIS] Initial implementation of OIS/OIT with charts and OFP - @flogross89 (floridude)
 1. [A380X/PFD] Add LS button reminder - @BravoMike99 (bruno_pt99)
+1. [A32NX/FMS] Sort runways by identifier in the runway selection page - @BlueberryKing (BlueberryKing)
 
 ## 0.12.0
 

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AvailableArrivalsPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AvailableArrivalsPage.ts
@@ -155,7 +155,7 @@ export class CDUAvailableArrivalsPage {
     }
 
     const approaches = targetPlan.availableApproaches;
-    const runways = targetPlan.availableDestinationRunways;
+    const runways = [...targetPlan.availableDestinationRunways].sort((a, b) => a.ident.localeCompare(b.ident));
 
     // Sort the approaches in Honeywell's documented order
     const sortedApproaches = approaches
@@ -508,7 +508,7 @@ export class CDUAvailableArrivalsPage {
             Math.ceil((matchingArrivals.length + 1) / ArrivalPagination.ARR_PAGE) - 1,
           )
         : Math.ceil((matchingArrivals.length + 1) / ArrivalPagination.ARR_PAGE) - 1
-      : Math.ceil(sortedApproaches.length / ArrivalPagination.ARR_PAGE) - 1;
+      : Math.ceil(allApproaches.length / ArrivalPagination.ARR_PAGE) - 1;
     if (pageCurrent < maxPage) {
       mcdu.onUp = () => {
         pageCurrent++;

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AvailableDeparturesPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AvailableDeparturesPage.ts
@@ -47,7 +47,7 @@ export class CDUAvailableDeparturesPage {
 
     const showEosid = selectedRunway && sidSelection;
 
-    const availableRunways = [...targetPlan.availableOriginRunways];
+    const availableRunways = [...targetPlan.availableOriginRunways].sort((a, b) => a.ident.localeCompare(b.ident));
     let availableSids = [...targetPlan.availableDepartures].sort((a, b) => a.ident.localeCompare(b.ident)) as (
       | Departure
       | (typeof Labels)['NO_SID']

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_LateralRevisionPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_LateralRevisionPage.ts
@@ -161,7 +161,7 @@ export class CDULateralRevisionPage {
             mcdu.setScratchpadMessage(NXFictionalMessages.internalError);
           }
 
-          CDUFlightPlanPage.ShowPage(mcdu, 0, forPlan);
+          mcdu.returnPageCallback();
         }
       };
     }
@@ -175,7 +175,7 @@ export class CDULateralRevisionPage {
       mcdu.onRightInput[3] = async (value) => {
         await mcdu.flightPlanService.newDest(legIndexFP, value, forPlan, inAlternate);
 
-        CDUFlightPlanPage.ShowPage(mcdu, 0, forPlan);
+        mcdu.returnPageCallback();
       };
     }
 
@@ -214,7 +214,7 @@ export class CDULateralRevisionPage {
       return mcdu.getDelaySwitchPage();
     };
     mcdu.onLeftInput[5] = () => {
-      CDUFlightPlanPage.ShowPage(mcdu, 0, forPlan);
+      mcdu.returnPageCallback();
     };
   }
 

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_LateralRevisionPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_LateralRevisionPage.ts
@@ -161,7 +161,7 @@ export class CDULateralRevisionPage {
             mcdu.setScratchpadMessage(NXFictionalMessages.internalError);
           }
 
-          mcdu.returnPageCallback();
+          CDUFlightPlanPage.ShowPage(mcdu, 0, forPlan);
         }
       };
     }
@@ -175,7 +175,7 @@ export class CDULateralRevisionPage {
       mcdu.onRightInput[3] = async (value) => {
         await mcdu.flightPlanService.newDest(legIndexFP, value, forPlan, inAlternate);
 
-        mcdu.returnPageCallback();
+        CDUFlightPlanPage.ShowPage(mcdu, 0, forPlan);
       };
     }
 

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_VerticalRevisionPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_VerticalRevisionPage.ts
@@ -495,7 +495,7 @@ export class CDUVerticalRevisionPage {
     }; // STEP ALTS
     if (!confirmConstraint) {
       mcdu.onLeftInput[5] = () => {
-        CDUFlightPlanPage.ShowPage(mcdu);
+        mcdu.returnPageCallback();
       };
     } else {
       mcdu.onLeftInput[5] = async () => {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Sort runways alphabetically in departure/arrival selection screen
- Fix not all runways being selectable as runway-only approaches because the list was too short
- Make "Return" button on lateral and vertical revision pages return to the previous flight plan position rather than the top

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![Screenshot 2025-02-26 222548](https://github.com/user-attachments/assets/ca1df3f3-d436-44ed-9bc3-37bf0742ac04)
![Screenshot 2025-02-26 222611](https://github.com/user-attachments/assets/88c21195-3c1d-4b06-af5c-52ecc2af289c)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Check departure/arrival runway selection is sorted alphabetically
- Check you can select all runways as approaches (no instrument approach, just the runway)
- Go to the lat/vert rev page from the flight plan page, ensure that pressing "Return" puts you back to the original position on the flight plan page

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
