### PR TITLE
fix(a380x/pfd): Fix BARO text overlapping

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -171,6 +171,7 @@
 1. [A380X/MFD] Add ATCCOM MSG RECORD page layouts - @heclak (heclak)
 1. [A380X/ND] Fixed active leg label to be left aligned - @MrJigs7 (MrJigs)
 1. [A32NX/FMS] Sort runways by identifier in the runway selection page - @BlueberryKing (BlueberryKing)
+1. [A380X/PFD] Fix BARO text overlapping
 
 ## 0.12.0
 

--- a/fbw-a380x/src/systems/instruments/src/PFD/FMA.tsx
+++ b/fbw-a380x/src/systems/instruments/src/PFD/FMA.tsx
@@ -1663,6 +1663,7 @@ class D3Cell extends DisplayComponent<{ bus: EventBus }> {
         } else {
           this.textRef.instance.innerHTML = '';
         }
+        this.classNameSub.set(`FontSmallest MiddleAlign White`);
       });
 
     sub


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9203 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
`BARO` text on the PFD should not longer be displayed as misaligned in any case

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![Screenshot 2025-03-08 172408](https://github.com/user-attachments/assets/741d31db-312d-4953-a84e-e9cc8a5a069b)

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): pruznak

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
**Only test after #9666 is merged**

1. Spawn & start up, initialize any precision approach
2. Fill any value into the `BARO` field on the MFD PERF APPR page
3. Check that the `BARO` text on PFD is not misaligned (as per reference picture)
4. Delete the value and introduce any value into the `RADIO` field on the same MFD page
5. Check that the `RADIO` text on PFD is not overflowing (spacing from the sides of the cell is different from the `BARO` text - that is not an issue)
6. Delete the value and introduce any value into the `BARO` field.
7. Check that the `BARO` text on PFD is not misaligned (as per reference picture)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
