### PR TITLE
fix(nd): approach message alignment

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -172,7 +172,7 @@
 1. [A380X/ND] Fixed active leg label to be left aligned - @MrJigs7 (MrJigs)
 1. [A32NX/FMS] Sort runways by identifier in the runway selection page - @BlueberryKing (BlueberryKing)
 1. [A380X/MFD] Change flightplan uplink & initialize weights message logic - @BravoMike99 (bruno_pt99)
-1. [A32NX/ND] Fixed alignment of approach message - @tracernz (Mike)
+1. [ND] Fixed alignment of approach message - @tracernz (Mike)
 
 ## 0.12.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -172,6 +172,7 @@
 1. [A380X/ND] Fixed active leg label to be left aligned - @MrJigs7 (MrJigs)
 1. [A32NX/FMS] Sort runways by identifier in the runway selection page - @BlueberryKing (BlueberryKing)
 1. [A380X/MFD] Change flightplan uplink & initialize weights message logic - @BravoMike99 (bruno_pt99)
+1. [A32NX/ND] Fixed alignment of approach message - @tracernz (Mike)
 
 ## 0.12.0
 

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/GuidanceController.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/GuidanceController.ts
@@ -230,7 +230,7 @@ export class GuidanceController {
         if (phase > FmgcFlightPhase.Cruise || (phase === FmgcFlightPhase.Cruise && distanceToDestination < 250)) {
           const appr = this.flightPlanService.active.approach;
           // Nothing is shown on the ND for runway-by-itself approaches
-          apprMsg = appr && appr.type !== ApproachType.Unknown ? ApproachUtils.longApproachName(appr) : '';
+          apprMsg = appr && appr.type !== ApproachType.Unknown ? ApproachUtils.longApproachName(appr).padEnd(9) : '';
         }
       }
     }

--- a/fbw-common/src/systems/instruments/src/ND/ND.tsx
+++ b/fbw-common/src/systems/instruments/src/ND/ND.tsx
@@ -750,7 +750,7 @@ class TopMessages extends DisplayComponent<{ bus: EventBus; ndMode: Subscribable
         this.btvMessageValue.set(value);
       });
 
-    this.sub.on('simTime').whenChangedBy(100).handle(this.refreshToWptIdent.bind(this));
+    this.sub.on('simTime').whenChangedBy(100).handle(this.refreshApproachMessage.bind(this));
 
     this.sub.on('trueTrackRaw').handle((v) => this.trueTrackWord.setWord(v));
 
@@ -764,7 +764,7 @@ class TopMessages extends DisplayComponent<{ bus: EventBus; ndMode: Subscribable
       .handle((v) => this.trueRefActive.set(!!v));
   }
 
-  private refreshToWptIdent(): void {
+  private refreshApproachMessage(): void {
     if (this.needApprMessageUpdate) {
       const ident = SimVarString.unpack([this.apprMessage0, this.apprMessage1]);
 

--- a/fbw-common/src/systems/instruments/src/ND/ND.tsx
+++ b/fbw-common/src/systems/instruments/src/ND/ND.tsx
@@ -777,8 +777,9 @@ class TopMessages extends DisplayComponent<{ bus: EventBus; ndMode: Subscribable
     return (
       <>
         <Layer x={384} y={28}>
-          {/* TODO verify */}
-          <text class="Green FontIntermediate MiddleAlign">{this.approachMessageValue}</text>
+          <text class="Green FontIntermediate MiddleAlign" style="white-space: pre">
+            {this.approachMessageValue}
+          </text>
         </Layer>
         <Layer
           x={384}

--- a/fbw-common/src/systems/shared/src/simvar.spec.ts
+++ b/fbw-common/src/systems/shared/src/simvar.spec.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 FlyByWire Simulations
+// SPDX-License-Identifier: GPL-3.0
+
+import { describe, it, expect } from 'vitest';
+import { SimVarString } from './simvar';
+
+describe('SimVarString.pack', () => {
+  it('correctly packs arbitrary strings with invalid chars', () => {
+    expect(SimVarString.pack('A]c<C>d=:E4fGh5I j0K(l)^M%n$O"p!')).toEqual([
+      0x7807e4740fa2, 0xa9602801599b, 0xfca009b11001, 0x800f01401ae,
+    ]);
+    expect(SimVarString.pack('A]b<C>d=:E4fGh5I j0K(l)^M%n$O"p!', 9)).toEqual([0x7807e4740fa2, 0x1b]);
+  });
+  it('correctly packs 9-char strings', () => {
+    expect(SimVarString.pack('ILS22R', 9)).toEqual([0xcd34f4b6a, 0]);
+    expect(SimVarString.pack('ILS22R   ', 9)).toEqual([0x41cd34f4b6a, 0x1]);
+  });
+});
+
+describe('SimVarString.unpack', () => {
+  it('correctly unpacks arbitrary strings', () => {
+    expect(SimVarString.unpack([0x7807e4740fa2, 0xa9602801599b, 0xfca009b11001, 0x800f01401ae])).toEqual(
+      'A]<C>=:E4G5I 0K()^M%$O"!',
+    );
+    expect(SimVarString.unpack([0x7807e4740fa2, 0x1b])).toEqual('A]<C>=:');
+  });
+  it('correctly unpacks 9-char strings', () => {
+    expect(SimVarString.unpack([0xcd34f4b6a, 0])).toEqual('ILS22R');
+    expect(SimVarString.unpack([0x41cd34f4b6a, 0x1])).toEqual('ILS22R   ');
+  });
+});

--- a/fbw-common/src/systems/shared/src/simvar.ts
+++ b/fbw-common/src/systems/shared/src/simvar.ts
@@ -48,7 +48,7 @@ export class LocalSimVar<T> {
 export class SimVarString {
   /**
    * Pack a string into numbers for use in a simvar
-   * ASCII chars from dec 32-63 can be encoded, 6-bit per char, 8 chars per simvar
+   * ASCII chars from dec 32-94 can be encoded, 6-bit per char, 8 chars per simvar
    * IMPORTANT: write the values as strings to the simvars or you will have precision errors
    * @param value
    * @param maxLength if specified enough simvars will be returned to fit this length,
@@ -58,7 +58,8 @@ export class SimVarString {
   static pack(value: string, maxLength?: number): number[] {
     let word = -1;
     const ret = [];
-    for (let i = 0; i < Math.min(maxLength, value.length); i++) {
+    const length = Math.min(maxLength ?? Infinity, value.length);
+    for (let i = 0; i < length; i++) {
       const char = i % 8;
       if (char === 0) {
         word++;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fix alignment of the approach message. It's always 9-chars wide, left-aligned.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://github.com/user-attachments/assets/038e48a9-2303-4190-a301-98e7d1c91204)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![image](https://github.com/user-attachments/assets/cd762856-165c-4d78-a17f-e25bc017f5c1)
![image](https://github.com/user-attachments/assets/6c41ec10-cd85-4ee5-8ec2-c0295cf5112a)
![image](https://github.com/user-attachments/assets/33f6423f-38f6-42c1-a4b3-0f8c265020a8)
![image](https://github.com/user-attachments/assets/a7551762-f966-405b-9336-ddb147f8b997)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Load up an approach, get into at least cruise phase, and close to the destination, and check that the approach message appears correctly aligned (compare to the lubber line).

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
