### PR TITLE
fix(fms): add runway designator and filter runways, sort approaches, add missed app rnp flag

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -177,6 +177,8 @@
 1. [A32NX/FMS] Fixed an error preventing the RETURN LSK from working on the create waypoint page in some cases - @tracernz (Mike)
 1. [A32NX/FMS] Disallow editing of waypoint ident on the create waypoint page - @tracernz (Mike)
 1. [A380X/MFD] Changed flightplan time header to show correct TIME or UTC - @MrJigs7 (MrJigs.)
+1. [A32NX/FMS] Improved approach procedure sorting - @tracernz (Mike)
+1. [A380X/FMS] The (RNP) flag is now shown for approaches with only the missed approach segment as RNP AR on MSFS2024 - @tracernz (Mike)
 
 ## 0.12.0
 

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AvailableArrivalsPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AvailableArrivalsPage.ts
@@ -166,12 +166,19 @@ export class CDUAvailableArrivalsPage {
       // Approaches not going to a specific runway (i.e circling approaches are filtered out at DB level)
       .filter((a) => !!runways.find((rw) => rw.ident === a.runwayIdent))
       // Sort the approaches in Honeywell's documented order, and alphabetical in between
+      // Sort the approaches in Honeywell's documented order, then by runway number, runway designator, and finally approach suffix.
       .sort((a, b) =>
-        a.type != b.type ? ApproachTypeOrder[a.type] - ApproachTypeOrder[b.type] : a.ident.localeCompare(b.ident),
+        a.type != b.type
+          ? ApproachTypeOrder[a.type] - ApproachTypeOrder[b.type]
+          : a.runwayNumber !== b.runwayNumber
+            ? a.runwayNumber - b.runwayNumber
+            : a.runwayDesignator !== b.runwayDesignator
+              ? a.runwayDesignator - b.runwayDesignator
+              : a.multipleIndicator.localeCompare(b.multipleIndicator),
       );
     const allApproaches = (sortedApproaches as (Runway | Approach)[]).concat(
       // Runway-by-itself approaches
-      runways,
+      runways.slice().sort((a, b) => (a.number !== b.number ? a.number - b.number : a.designator - b.designator)),
     );
     const rows = [[''], [''], [''], [''], [''], [''], [''], ['']];
 

--- a/fbw-a380x/src/systems/instruments/src/MFD/shared/utils.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/shared/utils.ts
@@ -54,8 +54,9 @@ const approachTypeNames: Record<ApproachType, string> = {
 
 export function getApproachName(approach: Approach, withRnpSuffix = true): string {
   // we don't need to worry about circling approaches as they aren't available, so we can always expect a runway ident
-  // FIXME add (RNP) suffix for RNP-AR missed approaches (even on non-RNAV approaches)
-  const approachSuffix = approach.suffix ? `-${approach.suffix}` : '';
-  const arSuffix = withRnpSuffix && approach.authorisationRequired ? ' (RNP)' : '';
-  return `${approachTypeNames[approach.type]}${approach.runwayIdent?.substring(4)}${approachSuffix}${arSuffix}`;
+  // The (RNP) suffix is added RNP-AR approaches, and for RNP-AR missed approaches (even on non-RNAV approaches).
+  const approachSuffix = approach.multipleIndicator ? `-${approach.multipleIndicator}` : '';
+  const arSuffix =
+    withRnpSuffix && (approach.authorisationRequired || approach.missedApproachAuthorisationRequired) ? ' (RNP)' : '';
+  return `${approachTypeNames[approach.type]}${approach.runwayIdent.substring(4)}${approachSuffix}${arSuffix}`;
 }

--- a/fbw-common/src/systems/navdata/client/backends/Msfs/Mapping.ts
+++ b/fbw-common/src/systems/navdata/client/backends/Msfs/Mapping.ts
@@ -698,7 +698,6 @@ export class MsfsMapping {
         .map((approach) => {
           try {
             const approachName = this.mapApproachName(approach);
-            const suffix = approach.approachSuffix.length > 0 ? approach.approachSuffix : undefined;
 
             // The AR flag is only available from MSFS2024, so fall back to a heuristic based on analysing the MSFS2020 data if not available.
             const authorisationRequired =
@@ -721,7 +720,6 @@ export class MsfsMapping {
               databaseId: `P${icaoCode}${airportIdent}${approach.name}`,
               icaoCode,
               ident: approachName,
-              suffix,
               runwayIdent,
               runwayNumber: approach.runwayNumber,
               // we can assert the type here as we filtered out null designators earlier

--- a/fbw-common/src/systems/navdata/shared/types/Approach.ts
+++ b/fbw-common/src/systems/navdata/shared/types/Approach.ts
@@ -1,3 +1,4 @@
+import { RunwayDesignator } from 'navdata/shared/types/Runway';
 import { DatabaseItem, ProcedureTransition } from './Common';
 import { ProcedureLeg } from './ProcedureLeg';
 import { AirportSubsectionCode, SectionCode } from './SectionCode';
@@ -36,14 +37,14 @@ export enum LevelOfService {
 export interface Approach extends DatabaseItem<SectionCode.Airport> {
   subSectionCode: AirportSubsectionCode.ApproachProcedures;
 
-  /**
-   * Runway this approach is to, or not if multiple runways
-   */
-  runwayIdent?: string;
+  /** Runway this approach is for. */
+  runwayIdent: string;
+  /** Runway number this approach is for. */
+  runwayNumber: number;
+  /** Runway designator this approach is for.  */
+  runwayDesignator: RunwayDesignator;
 
-  /**
-   * Multiple indicator
-   */
+  /** Multiple indicator/suffix. Empty string when none. */
   multipleIndicator: string;
 
   /**

--- a/fbw-common/src/systems/navdata/shared/types/Approach.ts
+++ b/fbw-common/src/systems/navdata/shared/types/Approach.ts
@@ -52,9 +52,6 @@ export interface Approach extends DatabaseItem<SectionCode.Airport> {
    */
   type: ApproachType;
 
-  /** The approach suffix char for multiple approaches, or undefined if none. */
-  suffix?: string;
-
   /**
    * RNP-AR approach?
    */

--- a/fbw-common/src/systems/navdata/shared/types/Runway.ts
+++ b/fbw-common/src/systems/navdata/shared/types/Runway.ts
@@ -6,6 +6,9 @@ import { AirportSubsectionCode, SectionCode } from './SectionCode';
 export interface Runway extends BaseFix<SectionCode.Airport> {
   subSectionCode: AirportSubsectionCode.Runways;
 
+  number: number;
+  designator: RunwayDesignator;
+
   airportIdent: string;
   bearing: DegreesTrue;
   magneticBearing: DegreesMagnetic;
@@ -33,4 +36,12 @@ export enum RunwaySurfaceType {
   Hard = 1 << 1,
   Soft = 1 << 2,
   Water = 1 << 3,
+}
+
+export enum RunwayDesignator {
+  None = 0,
+  Left,
+  Centre,
+  Right,
+  True,
 }

--- a/fbw-common/src/systems/navdata/shared/types/Runway.ts
+++ b/fbw-common/src/systems/navdata/shared/types/Runway.ts
@@ -38,10 +38,11 @@ export enum RunwaySurfaceType {
   Water = 1 << 3,
 }
 
+// Maintain in sort order for FMS
 export enum RunwayDesignator {
   None = 0,
   Left,
-  Centre,
   Right,
+  Centre,
   True,
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Clean up some nits in navdata and add the runway designator for more efficient sorting etc.
- Invalid runways (like water, A, B, etc.) are now filtered out in the nav db.
- Sort approaches in the FMS. This is useful when you have navdata patch packages in community that add additional procedures.
- Add the (RNP) flag on A380X approaches where only the missed approach is RNP AR.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Ensure approaches load normally for your favourite airports.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
