### PR TITLE
fix(a32nx/pfd): only show mach flag if FW

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/PFD/SpeedIndicator.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/SpeedIndicator.tsx
@@ -1295,7 +1295,7 @@ export class MachNumber extends DisplayComponent<{ bus: ArincEventBus }> {
 
   private readonly mach = Arinc429LocalVarConsumerSubject.create(this.sub.on('mach'), Arinc429Register.empty().rawWord);
 
-  private readonly machPreMile = this.mach.map((w) =>
+  private readonly machPermille = this.mach.map((w) =>
     w.isNormalOperation() || w.isFunctionalTest() ? Math.round(w.value * 1000) : 0,
   );
 
@@ -1316,7 +1316,7 @@ export class MachNumber extends DisplayComponent<{ bus: ArincEventBus }> {
       this.machTextSub.set('');
     } else {
       this.machFlagVisible.set(false);
-      this.machTextSub.set(`.${this.machPreMile.get()}`);
+      this.machTextSub.set(`.${this.machPermille.get()}`);
     }
   }
 

--- a/fbw-a32nx/src/systems/instruments/src/PFD/SpeedIndicator.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/SpeedIndicator.tsx
@@ -1329,7 +1329,7 @@ export class MachNumber extends DisplayComponent<{ bus: ArincEventBus }> {
     this.machAr.sub((v) => this.mach.setWord(v.rawWord), true);
     this.mach.sub((v) => {
       this.handleMachDisplay(v);
-    });
+    }, true);
   }
 
   render(): VNode {

--- a/fbw-a32nx/src/systems/instruments/src/PFD/SpeedIndicator.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/SpeedIndicator.tsx
@@ -1,9 +1,10 @@
-// Copyright (c) 2021-2023 FlyByWire Simulations
+// Copyright (c) 2021-2025 FlyByWire Simulations
 //
 // SPDX-License-Identifier: GPL-3.0
 
 import {
   ClockEvents,
+  ConsumerSubject,
   DisplayComponent,
   FSComponent,
   MappedSubject,
@@ -12,7 +13,13 @@ import {
   Subscribable,
   VNode,
 } from '@microsoft/msfs-sdk';
-import { ArincEventBus, Arinc429Word, Arinc429WordData } from '@flybywiresim/fbw-sdk';
+import {
+  ArincEventBus,
+  Arinc429Word,
+  Arinc429WordData,
+  Arinc429Register,
+  Arinc429RegisterSubject,
+} from '@flybywiresim/fbw-sdk';
 
 import { FgBus } from 'instruments/src/PFD/shared/FgBusProvider';
 import { FcuBus } from 'instruments/src/PFD/shared/FcuBusProvider';
@@ -1279,32 +1286,36 @@ class SpeedMargins extends DisplayComponent<{ bus: ArincEventBus }> {
 }
 
 export class MachNumber extends DisplayComponent<{ bus: ArincEventBus }> {
-  private machTextSub = Subject.create('');
+  private readonly sub = this.props.bus.getArincSubscriber<Arinc429Values & PFDSimvars>();
+
+  private readonly machTextSub = Subject.create('');
 
   private readonly machFlagVisible = Subject.create(false);
 
   private machHysteresis = false;
 
-  private mach = new Arinc429Word(0);
+  private readonly machAr = ConsumerSubject.create(this.sub.on('machAr').withArinc429Precision(3), Arinc429Register.empty());
 
-  private handleMachDisplay() {
-    if (this.mach.value > 0.5) {
+  private readonly mach = Arinc429RegisterSubject.createEmpty();
+
+  private handleMachDisplay(mach: Arinc429Register) {
+    if (mach.value > 0.5) {
       this.machHysteresis = true;
-    } else if (this.mach.value < 0.45) {
+    } else if (mach.value < 0.45) {
       this.machHysteresis = false;
     }
 
-    const hideMachDisplay = !this.machHysteresis && (this.mach.isNormalOperation() || this.mach.isFunctionalTest());
+    const hideMachDisplay = !this.machHysteresis && !mach.isFailureWarning();
 
     if (hideMachDisplay) {
       this.machFlagVisible.set(false);
       this.machTextSub.set('');
-    } else if (!this.mach.isNormalOperation() && !this.mach.isFunctionalTest()) {
+    } else if (mach.isFailureWarning()) {
       this.machFlagVisible.set(true);
       this.machTextSub.set('');
     } else {
       this.machFlagVisible.set(false);
-      const machPermille = Math.round(this.mach.value * 1000);
+      const machPermille = Math.round(mach.value * 1000);
       this.machTextSub.set(`.${machPermille}`);
     }
   }
@@ -1312,15 +1323,10 @@ export class MachNumber extends DisplayComponent<{ bus: ArincEventBus }> {
   onAfterRender(node: VNode): void {
     super.onAfterRender(node);
 
-    const sub = this.props.bus.getArincSubscriber<Arinc429Values & PFDSimvars & FcuBus>();
-
-    sub
-      .on('machAr')
-      .withArinc429Precision(3)
-      .handle((mach) => {
-        this.mach = mach;
-        this.handleMachDisplay();
-      });
+    this.machAr.sub((v) => this.mach.setWord(v.rawWord), true);
+    this.mach.sub((v) => {
+      this.handleMachDisplay(v);
+    });
   }
 
   render(): VNode {

--- a/fbw-a32nx/src/systems/instruments/src/PFD/SpeedIndicator.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/SpeedIndicator.tsx
@@ -1294,7 +1294,10 @@ export class MachNumber extends DisplayComponent<{ bus: ArincEventBus }> {
 
   private machHysteresis = false;
 
-  private readonly machAr = ConsumerSubject.create(this.sub.on('machAr').withArinc429Precision(3), Arinc429Register.empty());
+  private readonly machAr = ConsumerSubject.create(
+    this.sub.on('machAr').withArinc429Precision(3),
+    Arinc429Register.empty(),
+  );
 
   private readonly mach = Arinc429RegisterSubject.createEmpty();
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes red MACH flag shown on PFD when value is NCD. (regression introduced by #9894) 
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
bruno_pt99
## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Spawn on the runway and verify no red MACH flag is visible.
With ADR failed, ensure red "MACH" flag appears on PFD. Verify it doesn't appear in other conditions.
Verify mach value appears once > 0.5 during acceleration and disappears once < 0.45 during deceleration
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
