### PR TITLE
fix(a380x/efb): add separate button for m4r door, fix interaction with catering

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -183,6 +183,7 @@
 1. [A32NX/FMS] Removed insert/erase prompts on approach via page - @tracernz (Mike)
 1. [ND] Fixed alignment of approach message - @tracernz (Mike)
 1. [A380X/OANS] Fix RWY AHEAD not disappearing when OANS Performance Mode is active - @flogross89 (floridude)
+1. [A380X/EFB] Add separate button for M4R door with open tag, don't block M5R button on catering - @dzoeteman (Deniz)
 
 ## 0.12.0
 

--- a/fbw-common/src/systems/instruments/src/EFB/Assets/GroundServiceOutline.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Assets/GroundServiceOutline.tsx
@@ -426,12 +426,14 @@ export const A380GroundServiceOutline = ({
   main1LeftStatus,
   main2LeftStatus,
   main4RightStatus,
+  main5RightStatus,
   upper1LeftStatus,
 }: {
   className: string;
   main1LeftStatus: boolean;
   main2LeftStatus: boolean;
   main4RightStatus: boolean;
+  main5RightStatus: boolean;
   upper1LeftStatus: boolean;
 }) => (
   <svg
@@ -1357,7 +1359,7 @@ export const A380GroundServiceOutline = ({
           style={{
             stroke: '#6bbe45',
             strokeWidth: 2,
-            fill: 'none',
+            fill: main4RightStatus ? '#6bbe45' : 'none',
             strokeMiterlimit: 10,
           }}
         />
@@ -1379,7 +1381,7 @@ export const A380GroundServiceOutline = ({
           style={{
             stroke: '#6bbe45',
             strokeWidth: 2,
-            fill: main4RightStatus ? '#6bbe45' : 'none',
+            fill: main5RightStatus ? '#6bbe45' : 'none',
             strokeMiterlimit: 10,
           }}
         />

--- a/fbw-common/src/systems/instruments/src/EFB/Ground/Pages/Services/A380_842/A380Services.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Ground/Pages/Services/A380_842/A380Services.tsx
@@ -15,6 +15,7 @@ import {
   setBoarding2DoorButtonState,
   setBoarding3DoorButtonState,
   setServiceDoorButtonState,
+  setServiceDoor2ButtonState,
   setBaggageButtonState,
   setCargo1DoorButtonState,
   setCateringButtonState,
@@ -50,6 +51,7 @@ enum ServiceButton {
   Gpu,
   FrontCargoDoor,
   BaggageTruck,
+  Main4Right,
   Main5Right,
   CateringTruck,
 }
@@ -137,6 +139,7 @@ export const A380Services: React.FC = () => {
   // Service events
   const toggleMain1LeftDoor = () => SimVar.SetSimVarValue('K:TOGGLE_AIRCRAFT_EXIT', 'enum', 1);
   const toggleMain2LeftDoor = () => SimVar.SetSimVarValue('K:TOGGLE_AIRCRAFT_EXIT', 'enum', 3);
+  const toggleMain4RightDoor = () => SimVar.SetSimVarValue('K:TOGGLE_AIRCRAFT_EXIT', 'enum', 8);
   const toggleMain5RightDoor = () => SimVar.SetSimVarValue('K:TOGGLE_AIRCRAFT_EXIT', 'enum', 10);
   const toggleUpper1LeftDoor = () => SimVar.SetSimVarValue('K:TOGGLE_AIRCRAFT_EXIT', 'enum', 11);
   const toggleJetBridgeAndStairs = () => {
@@ -155,6 +158,7 @@ export const A380Services: React.FC = () => {
     boarding2DoorButtonState,
     boarding3DoorButtonState,
     serviceDoorButtonState,
+    serviceDoor2ButtonState,
     cargo1DoorButtonState,
     jetWayButtonState,
     fuelTruckButtonState,
@@ -294,8 +298,12 @@ export const A380Services: React.FC = () => {
         handleDoors(boarding3DoorButtonState, setBoarding3DoorButtonState);
         toggleUpper1LeftDoor();
         break;
-      case ServiceButton.Main5Right:
+      case ServiceButton.Main4Right:
         handleDoors(serviceDoorButtonState, setServiceDoorButtonState);
+        toggleMain4RightDoor();
+        break;
+      case ServiceButton.Main5Right:
+        handleDoors(serviceDoor2ButtonState, setServiceDoor2ButtonState);
         toggleMain5RightDoor();
         break;
       case ServiceButton.FrontCargoDoor:
@@ -339,7 +347,7 @@ export const A380Services: React.FC = () => {
           setCateringButtonState,
           serviceDoorButtonState,
           setServiceDoorButtonState,
-          main5RightDoorOpen,
+          main4RightDoorOpen,
         );
         toggleCateringTruck();
         break;
@@ -425,8 +433,16 @@ export const A380Services: React.FC = () => {
     simpleServiceListenerHandling(boarding2DoorButtonState, setBoarding2DoorButtonState, main2LeftDoorOpen);
     simpleServiceListenerHandling(boarding3DoorButtonState, setBoarding3DoorButtonState, upper1LeftDoorOpen);
     simpleServiceListenerHandling(cargo1DoorButtonState, setCargo1DoorButtonState, frontCargoDoorOpen);
-    simpleServiceListenerHandling(serviceDoorButtonState, setServiceDoorButtonState, main5RightDoorOpen);
-  }, [main1LeftDoorOpen, main2LeftDoorOpen, main5RightDoorOpen, upper1LeftDoorOpen, frontCargoDoorOpen]);
+    simpleServiceListenerHandling(serviceDoorButtonState, setServiceDoorButtonState, main4RightDoorOpen);
+    simpleServiceListenerHandling(serviceDoor2ButtonState, setServiceDoor2ButtonState, main5RightDoorOpen);
+  }, [
+    main1LeftDoorOpen,
+    main2LeftDoorOpen,
+    upper1LeftDoorOpen,
+    frontCargoDoorOpen,
+    main4RightDoorOpen,
+    main5RightDoorOpen,
+  ]);
 
   // Fuel
   useEffect(() => {
@@ -467,9 +483,9 @@ export const A380Services: React.FC = () => {
       setCateringButtonState,
       serviceDoorButtonState,
       setServiceDoorButtonState,
-      main5RightDoorOpen,
+      main4RightDoorOpen,
     );
-  }, [main5RightDoorOpen]);
+  }, [main4RightDoorOpen]);
 
   // Pushback or movement start --> disable buttons and close doors
   // Enable buttons if all have been disabled before
@@ -479,6 +495,7 @@ export const A380Services: React.FC = () => {
       dispatch(setBoarding2DoorButtonState(ServiceButtonState.DISABLED));
       dispatch(setBoarding3DoorButtonState(ServiceButtonState.DISABLED));
       dispatch(setServiceDoorButtonState(ServiceButtonState.DISABLED));
+      dispatch(setServiceDoor2ButtonState(ServiceButtonState.DISABLED));
       dispatch(setCargo1DoorButtonState(ServiceButtonState.DISABLED));
       dispatch(setJetWayButtonState(ServiceButtonState.DISABLED));
       dispatch(setFuelTruckButtonState(ServiceButtonState.DISABLED));
@@ -494,6 +511,9 @@ export const A380Services: React.FC = () => {
       if (upper1LeftDoorOpen === 1) {
         toggleUpper1LeftDoor();
       }
+      if (main4RightDoorOpen === 1) {
+        toggleMain4RightDoor();
+      }
       if (main5RightDoorOpen === 1) {
         toggleMain5RightDoor();
       }
@@ -506,6 +526,7 @@ export const A380Services: React.FC = () => {
         boarding2DoorButtonState,
         boarding3DoorButtonState,
         serviceDoorButtonState,
+        serviceDoor2ButtonState,
         cargo1DoorButtonState,
         cateringButtonState,
         jetWayButtonState,
@@ -519,6 +540,7 @@ export const A380Services: React.FC = () => {
       dispatch(setBoarding2DoorButtonState(ServiceButtonState.INACTIVE));
       dispatch(setBoarding3DoorButtonState(ServiceButtonState.INACTIVE));
       dispatch(setServiceDoorButtonState(ServiceButtonState.INACTIVE));
+      dispatch(setServiceDoor2ButtonState(ServiceButtonState.INACTIVE));
       dispatch(setCargo1DoorButtonState(ServiceButtonState.INACTIVE));
       dispatch(setJetWayButtonState(ServiceButtonState.INACTIVE));
       dispatch(setFuelTruckButtonState(ServiceButtonState.INACTIVE));
@@ -630,10 +652,19 @@ export const A380Services: React.FC = () => {
           <ArchiveFill size={36} />
         </GroundServiceButton>
 
-        {/* AFT DOOR */}
+        {/* AFT DOOR M4R */}
         <GroundServiceButton
           name={t('Ground.Services.DoorAft')}
           state={serviceDoorButtonState}
+          onClick={() => handleButtonClick(ServiceButton.Main4Right)}
+        >
+          <DoorClosedFill size={36} />
+        </GroundServiceButton>
+
+        {/* AFT DOOR M5R */}
+        <GroundServiceButton
+          name={t('Ground.Services.DoorAft')}
+          state={serviceDoor2ButtonState}
           onClick={() => handleButtonClick(ServiceButton.Main5Right)}
         >
           <DoorClosedFill size={36} />

--- a/fbw-common/src/systems/instruments/src/EFB/Ground/Pages/Services/A380_842/A380Services.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Ground/Pages/Services/A380_842/A380Services.tsx
@@ -50,7 +50,7 @@ enum ServiceButton {
   Gpu,
   FrontCargoDoor,
   BaggageTruck,
-  Main4Right,
+  Main5Right,
   CateringTruck,
 }
 
@@ -111,7 +111,8 @@ export const A380Services: React.FC = () => {
   // Ground Services
   const [main1LeftDoorOpen] = useSimVar('A:INTERACTIVE POINT OPEN:0', 'Percent over 100', 200);
   const [main2LeftDoorOpen] = useSimVar('A:INTERACTIVE POINT OPEN:2', 'Percent over 100', 200);
-  const [main4RightDoorOpen] = useSimVar('A:INTERACTIVE POINT OPEN:9', 'Percent over 100', 200);
+  const [main4RightDoorOpen] = useSimVar('A:INTERACTIVE POINT OPEN:7', 'Percent over 100', 200);
+  const [main5RightDoorOpen] = useSimVar('A:INTERACTIVE POINT OPEN:9', 'Percent over 100', 200);
   const [upper1LeftDoorOpen] = useSimVar('A:INTERACTIVE POINT OPEN:10', 'Percent over 100', 200);
   const [frontCargoDoorOpen] = useSimVar('A:INTERACTIVE POINT OPEN:16', 'Percent over 100', 200);
   const [fuelingActive] = useSimVar('A:INTERACTIVE POINT OPEN:18', 'Percent over 100', 200);
@@ -136,7 +137,7 @@ export const A380Services: React.FC = () => {
   // Service events
   const toggleMain1LeftDoor = () => SimVar.SetSimVarValue('K:TOGGLE_AIRCRAFT_EXIT', 'enum', 1);
   const toggleMain2LeftDoor = () => SimVar.SetSimVarValue('K:TOGGLE_AIRCRAFT_EXIT', 'enum', 3);
-  const toggleMain4RightDoor = () => SimVar.SetSimVarValue('K:TOGGLE_AIRCRAFT_EXIT', 'enum', 10);
+  const toggleMain5RightDoor = () => SimVar.SetSimVarValue('K:TOGGLE_AIRCRAFT_EXIT', 'enum', 10);
   const toggleUpper1LeftDoor = () => SimVar.SetSimVarValue('K:TOGGLE_AIRCRAFT_EXIT', 'enum', 11);
   const toggleJetBridgeAndStairs = () => {
     SimVar.SetSimVarValue('K:TOGGLE_JETWAY', 'bool', false);
@@ -293,9 +294,9 @@ export const A380Services: React.FC = () => {
         handleDoors(boarding3DoorButtonState, setBoarding3DoorButtonState);
         toggleUpper1LeftDoor();
         break;
-      case ServiceButton.Main4Right:
+      case ServiceButton.Main5Right:
         handleDoors(serviceDoorButtonState, setServiceDoorButtonState);
-        toggleMain4RightDoor();
+        toggleMain5RightDoor();
         break;
       case ServiceButton.FrontCargoDoor:
         handleDoors(cargo1DoorButtonState, setCargo1DoorButtonState);
@@ -338,7 +339,7 @@ export const A380Services: React.FC = () => {
           setCateringButtonState,
           serviceDoorButtonState,
           setServiceDoorButtonState,
-          main4RightDoorOpen,
+          main5RightDoorOpen,
         );
         toggleCateringTruck();
         break;
@@ -424,8 +425,8 @@ export const A380Services: React.FC = () => {
     simpleServiceListenerHandling(boarding2DoorButtonState, setBoarding2DoorButtonState, main2LeftDoorOpen);
     simpleServiceListenerHandling(boarding3DoorButtonState, setBoarding3DoorButtonState, upper1LeftDoorOpen);
     simpleServiceListenerHandling(cargo1DoorButtonState, setCargo1DoorButtonState, frontCargoDoorOpen);
-    simpleServiceListenerHandling(serviceDoorButtonState, setServiceDoorButtonState, main4RightDoorOpen);
-  }, [main1LeftDoorOpen, main2LeftDoorOpen, main4RightDoorOpen, upper1LeftDoorOpen, frontCargoDoorOpen]);
+    simpleServiceListenerHandling(serviceDoorButtonState, setServiceDoorButtonState, main5RightDoorOpen);
+  }, [main1LeftDoorOpen, main2LeftDoorOpen, main5RightDoorOpen, upper1LeftDoorOpen, frontCargoDoorOpen]);
 
   // Fuel
   useEffect(() => {
@@ -466,9 +467,9 @@ export const A380Services: React.FC = () => {
       setCateringButtonState,
       serviceDoorButtonState,
       setServiceDoorButtonState,
-      main4RightDoorOpen,
+      main5RightDoorOpen,
     );
-  }, [main4RightDoorOpen]);
+  }, [main5RightDoorOpen]);
 
   // Pushback or movement start --> disable buttons and close doors
   // Enable buttons if all have been disabled before
@@ -493,8 +494,8 @@ export const A380Services: React.FC = () => {
       if (upper1LeftDoorOpen === 1) {
         toggleUpper1LeftDoor();
       }
-      if (main4RightDoorOpen === 1) {
-        toggleMain4RightDoor();
+      if (main5RightDoorOpen === 1) {
+        toggleMain5RightDoor();
       }
       if (frontCargoDoorOpen === 1) {
         toggleFrontCargoDoor();
@@ -536,6 +537,7 @@ export const A380Services: React.FC = () => {
         main1LeftStatus={main1LeftDoorOpen >= 1.0}
         main2LeftStatus={main2LeftDoorOpen >= 1.0}
         main4RightStatus={main4RightDoorOpen >= 1.0}
+        main5RightStatus={main5RightDoorOpen >= 1.0}
         upper1LeftStatus={upper1LeftDoorOpen >= 1.0}
         className="inset-x-0 mx-auto h-full w-full text-theme-text"
       />
@@ -619,15 +621,6 @@ export const A380Services: React.FC = () => {
       </ServiceButtonWrapper>
 
       <ServiceButtonWrapper xl={900} y={620} className="">
-        {/* AFT DOOR */}
-        <GroundServiceButton
-          name={t('Ground.Services.DoorAft')}
-          state={serviceDoorButtonState}
-          onClick={() => handleButtonClick(ServiceButton.Main4Right)}
-        >
-          <DoorClosedFill size={36} />
-        </GroundServiceButton>
-
         {/* CATERING TRUCK */}
         <GroundServiceButton
           name={t('Ground.Services.CateringTruck')}
@@ -635,6 +628,15 @@ export const A380Services: React.FC = () => {
           onClick={() => handleButtonClick(ServiceButton.CateringTruck)}
         >
           <ArchiveFill size={36} />
+        </GroundServiceButton>
+
+        {/* AFT DOOR */}
+        <GroundServiceButton
+          name={t('Ground.Services.DoorAft')}
+          state={serviceDoorButtonState}
+          onClick={() => handleButtonClick(ServiceButton.Main5Right)}
+        >
+          <DoorClosedFill size={36} />
         </GroundServiceButton>
       </ServiceButtonWrapper>
 
@@ -689,6 +691,11 @@ export const A380Services: React.FC = () => {
         </div>
       )}
       {main4RightDoorOpen >= 1.0 && (
+        <div className={doorOpenCss} style={{ position: 'absolute', left: 700, right: 0, top: 500 }}>
+          OPEN
+        </div>
+      )}
+      {main5RightDoorOpen >= 1.0 && (
         <div className={doorOpenCss} style={{ position: 'absolute', left: 700, right: 0, top: 593 }}>
           OPEN
         </div>

--- a/fbw-common/src/systems/instruments/src/EFB/Store/features/groundServicePage.ts
+++ b/fbw-common/src/systems/instruments/src/EFB/Store/features/groundServicePage.ts
@@ -17,6 +17,7 @@ interface ButtonSelectionState {
   boarding2DoorButtonState: ServiceButtonState;
   boarding3DoorButtonState: ServiceButtonState;
   serviceDoorButtonState: ServiceButtonState;
+  serviceDoor2ButtonState: ServiceButtonState;
   cargo1DoorButtonState: ServiceButtonState;
   jetWayButtonState: ServiceButtonState;
   fuelTruckButtonState: ServiceButtonState;
@@ -32,6 +33,7 @@ let initialState: ButtonSelectionState = {
   boarding2DoorButtonState: ServiceButtonState.DISABLED,
   boarding3DoorButtonState: ServiceButtonState.DISABLED,
   serviceDoorButtonState: ServiceButtonState.DISABLED,
+  serviceDoor2ButtonState: ServiceButtonState.DISABLED,
   cargo1DoorButtonState: ServiceButtonState.DISABLED,
   fuelTruckButtonState: ServiceButtonState.DISABLED,
   gpuButtonState: ServiceButtonState.DISABLED,
@@ -60,6 +62,10 @@ const setInitialState = () => {
         ? ServiceButtonState.ACTIVE
         : ServiceButtonState.INACTIVE,
     serviceDoorButtonState:
+      SimVar.GetSimVarValue('A:INTERACTIVE POINT OPEN:3', 'Percent over 100') === 1.0
+        ? ServiceButtonState.ACTIVE
+        : ServiceButtonState.INACTIVE,
+    serviceDoor2ButtonState:
       SimVar.GetSimVarValue('A:INTERACTIVE POINT OPEN:3', 'Percent over 100') === 1.0
         ? ServiceButtonState.ACTIVE
         : ServiceButtonState.INACTIVE,
@@ -104,6 +110,9 @@ export const buttonsSlice = createSlice({
     setServiceDoorButtonState: (state, action: PayloadAction<ServiceButtonState>) => {
       state.serviceDoorButtonState = action.payload;
     },
+    setServiceDoor2ButtonState: (state, action: PayloadAction<ServiceButtonState>) => {
+      state.serviceDoor2ButtonState = action.payload;
+    },
     setCargo1DoorButtonState: (state, action: PayloadAction<ServiceButtonState>) => {
       state.cargo1DoorButtonState = action.payload;
     },
@@ -133,6 +142,7 @@ export const {
   setBoarding2DoorButtonState,
   setBoarding3DoorButtonState,
   setServiceDoorButtonState,
+  setServiceDoor2ButtonState,
   setCargo1DoorButtonState,
   setJetWayButtonState,
   setFuelTruckButtonState,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9850

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Added separate button for M4R door (existing aft button was incorrectly labeled in code as being M4R, it was M5R)
- Catering service only blocks M4R door button, not M5R
- Added 'OPEN' tag for M4R door

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before only one aft door button, which is blocked by catering, and does not show 'OPEN' tag on M4R:
![1250410_20250328183134_1](https://github.com/user-attachments/assets/aeaa5556-ef28-48f0-95bc-c65539bd288a)

After, two aft door buttons, independently operable, with 'OPEN' tag shown for M4R too:
![1250410_20250328180530_1](https://github.com/user-attachments/assets/359f2551-9725-4870-807e-609fd4f9f204)

Catering correctly blocks M4R door button:
![1250410_20250328180317_1](https://github.com/user-attachments/assets/91278729-0a06-4339-a1f1-92b6aaf29fa9)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context

The services page probably needs a redesign at some point to include all doors, doesn't really fit at the moment. Maybe a separate doors page.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

- ensure GSX compatibility is not broken (cannot test myself)
- ensure changes in common code do not break existing a320nx efb services functionality

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
