### PR TITLE
fix(a380x/nd): chrono and BTV indication not present on OANS

### DIFF
--- a/fbw-common/src/systems/instruments/src/ND/Chrono.tsx
+++ b/fbw-common/src/systems/instruments/src/ND/Chrono.tsx
@@ -94,15 +94,12 @@ export class Chrono extends DisplayComponent<ChronoProps> {
     return (
       <g
         class="chrono"
-        // Modify visibility logic to handle forced visibility
-        visibility={
-          this.props.forceVisible
-            ? 'inherit'
-            : this.state.map((state) => (state === ChronoState.Hidden ? 'hidden' : 'inherit'))
-        }
+        // Only show when running/stopped or in OANS mode
+        visibility={this.state.map((state) => (state === ChronoState.Hidden ? 'hidden' : 'inherit'))}
         style={{
           'margin-right': this.timeMargin.map((v) => (v ? '0.01px' : '0px')),
-          'z-index': '9999', // Ensure chrono stays on top
+          'z-index': '9999',
+          position: 'absolute', // Ensure proper layering
         }}
       >
         <rect x={0} y={632} width={104} height={30} class="Grey Fill" />

--- a/fbw-common/src/systems/instruments/src/ND/Chrono.tsx
+++ b/fbw-common/src/systems/instruments/src/ND/Chrono.tsx
@@ -21,6 +21,7 @@ enum ChronoState {
 
 export interface ChronoProps extends ComponentProps {
   bus: EventBus;
+  forceVisible?: boolean; // Add new prop to force visibility
 }
 
 export class Chrono extends DisplayComponent<ChronoProps> {
@@ -93,8 +94,16 @@ export class Chrono extends DisplayComponent<ChronoProps> {
     return (
       <g
         class="chrono"
-        visibility={this.state.map((state) => (state === ChronoState.Hidden ? 'hidden' : 'inherit'))}
-        style={{ 'margin-right': this.timeMargin.map((v) => (v ? '0.01px' : '0px')) }}
+        // Modify visibility logic to handle forced visibility
+        visibility={
+          this.props.forceVisible
+            ? 'inherit'
+            : this.state.map((state) => (state === ChronoState.Hidden ? 'hidden' : 'inherit'))
+        }
+        style={{
+          'margin-right': this.timeMargin.map((v) => (v ? '0.01px' : '0px')),
+          'z-index': '9999', // Ensure chrono stays on top
+        }}
       >
         <rect x={0} y={632} width={104} height={30} class="Grey Fill" />
         <text x={8} y={652} font-size={24} class="Green">

--- a/fbw-common/src/systems/instruments/src/ND/ND.tsx
+++ b/fbw-common/src/systems/instruments/src/ND/ND.tsx
@@ -360,20 +360,17 @@ export class NDComponent<T extends number> extends DisplayComponent<NDProps<T>> 
   render(): VNode | null {
     return (
       <>
-        {/* Always visible elements - outside of mode-specific containers */}
-        <svg class="nd-svg nd-top-layer" viewBox="0 0 768 768" style="transform: rotateX(0deg);">
-          <Chrono bus={this.props.bus} />
-          <Layer x={384} y={56}>
-            <text class="Green FontSmallest MiddleAlign">{this.btvMessageValue}</text>
-          </Layer>
-        </svg>
-
         {/* OANS Mode */}
         <div style={{ display: this.showOans.map((it) => (it ? 'block' : 'none')) }}>
           <div style={{ display: this.currentPageMode.map((it) => (it === EfisNdMode.PLAN ? 'none' : 'block')) }}>
             <svg class="nd-svg" viewBox="0 0 768 768" style="transform: rotateX(0deg);">
               <WindIndicator bus={this.props.bus} />
               <SpeedIndicator bus={this.props.bus} />
+              {/* Add Chrono and BTV for OANS mode */}
+              <Chrono bus={this.props.bus} />
+              <Layer x={384} y={56}>
+                <text class="Green FontSmallest MiddleAlign">{this.btvMessageValue}</text>
+              </Layer>
             </svg>
           </div>
           <div style={{ display: this.currentPageMode.map((it) => (it === EfisNdMode.PLAN ? 'block' : 'none')) }}>
@@ -391,8 +388,12 @@ export class NDComponent<T extends number> extends DisplayComponent<NDProps<T>> 
 
         {/* ND Mode */}
         <div style={{ display: this.showOans.map((it) => (it ? 'none' : 'block')) }}>
-          {/* ND Vector graphics - bottom layer */}
           <svg class="nd-svg" viewBox="0 0 768 768" style="transform: rotateX(0deg);">
+            {/* Add Chrono and BTV for ND mode */}
+            <Chrono bus={this.props.bus} />
+            <Layer x={384} y={56}>
+              <text class="Green FontSmallest MiddleAlign">{this.btvMessageValue}</text>
+            </Layer>
             <RoseLSPage
               bus={this.props.bus}
               ref={this.roseLSPage}

--- a/fbw-common/src/systems/instruments/src/ND/ND.tsx
+++ b/fbw-common/src/systems/instruments/src/ND/ND.tsx
@@ -155,6 +155,7 @@ export class NDComponent<T extends number> extends DisplayComponent<NDProps<T>> 
   );
 
   private showOans = Subject.create<boolean>(false);
+  btvMessageValue: any;
 
   onAfterRender(node: VNode) {
     super.onAfterRender(node);
@@ -359,6 +360,14 @@ export class NDComponent<T extends number> extends DisplayComponent<NDProps<T>> 
   render(): VNode | null {
     return (
       <>
+        {/* Move Chrono and BTV indication outside the OANS visibility check */}
+        <svg class="nd-svg nd-top-layer" viewBox="0 0 768 768" style="transform: rotateX(0deg);">
+          <Chrono bus={this.props.bus} />
+          <Layer x={384} y={56}>
+            <text class="Green FontSmallest MiddleAlign">{this.btvMessageValue}</text>
+          </Layer>
+        </svg>
+
         <div style={{ display: this.showOans.map((it) => (it ? 'block' : 'none')) }}>
           <div style={{ display: this.currentPageMode.map((it) => (it === EfisNdMode.PLAN ? 'none' : 'block')) }}>
             <svg class="nd-svg" viewBox="0 0 768 768" style="transform: rotateX(0deg);">
@@ -378,6 +387,7 @@ export class NDComponent<T extends number> extends DisplayComponent<NDProps<T>> 
             <RwyAheadAdvisory bus={this.props.bus} />
           </svg>
         </div>
+
         <div style={{ display: this.showOans.map((it) => (it ? 'none' : 'block')) }}>
           {/* ND Vector graphics - bottom layer */}
           <svg class="nd-svg" viewBox="0 0 768 768" style="transform: rotateX(0deg);">
@@ -489,8 +499,6 @@ export class NDComponent<T extends number> extends DisplayComponent<NDProps<T>> 
           {/* ND Vector graphics - top layer */}
           <svg class="nd-svg nd-top-layer" viewBox="0 0 768 768" style="transform: rotateX(0deg);">
             <Airplane bus={this.props.bus} ndMode={this.currentPageMode} />
-
-            <Chrono bus={this.props.bus} />
 
             <TcasWxrMessages bus={this.props.bus} mode={this.currentPageMode} />
             <FmMessages bus={this.props.bus} mode={this.currentPageMode} />

--- a/fbw-common/src/systems/instruments/src/ND/ND.tsx
+++ b/fbw-common/src/systems/instruments/src/ND/ND.tsx
@@ -360,7 +360,7 @@ export class NDComponent<T extends number> extends DisplayComponent<NDProps<T>> 
   render(): VNode | null {
     return (
       <>
-        {/* Move Chrono and BTV indication outside the OANS visibility check */}
+        {/* Always visible elements - outside of mode-specific containers */}
         <svg class="nd-svg nd-top-layer" viewBox="0 0 768 768" style="transform: rotateX(0deg);">
           <Chrono bus={this.props.bus} />
           <Layer x={384} y={56}>
@@ -368,6 +368,7 @@ export class NDComponent<T extends number> extends DisplayComponent<NDProps<T>> 
           </Layer>
         </svg>
 
+        {/* OANS Mode */}
         <div style={{ display: this.showOans.map((it) => (it ? 'block' : 'none')) }}>
           <div style={{ display: this.currentPageMode.map((it) => (it === EfisNdMode.PLAN ? 'none' : 'block')) }}>
             <svg class="nd-svg" viewBox="0 0 768 768" style="transform: rotateX(0deg);">
@@ -388,6 +389,7 @@ export class NDComponent<T extends number> extends DisplayComponent<NDProps<T>> 
           </svg>
         </div>
 
+        {/* ND Mode */}
         <div style={{ display: this.showOans.map((it) => (it ? 'none' : 'block')) }}>
           {/* ND Vector graphics - bottom layer */}
           <svg class="nd-svg" viewBox="0 0 768 768" style="transform: rotateX(0deg);">

--- a/fbw-common/src/systems/instruments/src/ND/ND.tsx
+++ b/fbw-common/src/systems/instruments/src/ND/ND.tsx
@@ -360,14 +360,17 @@ export class NDComponent<T extends number> extends DisplayComponent<NDProps<T>> 
   render(): VNode | null {
     return (
       <>
+        {/* Always visible layer for Chrono */}
+        <svg class="nd-svg nd-top-layer" viewBox="0 0 768 768" style="transform: rotateX(0deg);">
+          <Chrono bus={this.props.bus} />
+        </svg>
+
         {/* OANS Mode */}
         <div style={{ display: this.showOans.map((it) => (it ? 'block' : 'none')) }}>
           <div style={{ display: this.currentPageMode.map((it) => (it === EfisNdMode.PLAN ? 'none' : 'block')) }}>
             <svg class="nd-svg" viewBox="0 0 768 768" style="transform: rotateX(0deg);">
               <WindIndicator bus={this.props.bus} />
               <SpeedIndicator bus={this.props.bus} />
-              {/* Add Chrono and BTV for OANS mode */}
-              <Chrono bus={this.props.bus} />
               <Layer x={384} y={56}>
                 <text class="Green FontSmallest MiddleAlign">{this.btvMessageValue}</text>
               </Layer>
@@ -389,8 +392,6 @@ export class NDComponent<T extends number> extends DisplayComponent<NDProps<T>> 
         {/* ND Mode */}
         <div style={{ display: this.showOans.map((it) => (it ? 'none' : 'block')) }}>
           <svg class="nd-svg" viewBox="0 0 768 768" style="transform: rotateX(0deg);">
-            {/* Add Chrono and BTV for ND mode */}
-            <Chrono bus={this.props.bus} />
             <Layer x={384} y={56}>
               <text class="Green FontSmallest MiddleAlign">{this.btvMessageValue}</text>
             </Layer>

--- a/fbw-common/src/systems/instruments/src/ND/ND.tsx
+++ b/fbw-common/src/systems/instruments/src/ND/ND.tsx
@@ -361,8 +361,12 @@ export class NDComponent<T extends number> extends DisplayComponent<NDProps<T>> 
     return (
       <>
         {/* Always visible layer for Chrono */}
-        <svg class="nd-svg nd-top-layer" viewBox="0 0 768 768" style="transform: rotateX(0deg);">
-          <Chrono bus={this.props.bus} />
+        <svg
+          class="nd-svg nd-top-layer"
+          viewBox="0 0 768 768"
+          style="transform: rotateX(0deg); position: absolute; z-index: 1000;"
+        >
+          <Chrono bus={this.props.bus} forceVisible={true} />
         </svg>
 
         {/* OANS Mode */}


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9744 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
jonny_23

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
