### PR TITLE
fix(a380x/pfd): Pitch trim display: White line visibility only after landing when below 30kts GS

### DIFF
--- a/fbw-a380x/src/systems/instruments/src/PFD/PFD.tsx
+++ b/fbw-a380x/src/systems/instruments/src/PFD/PFD.tsx
@@ -11,7 +11,7 @@ import {
   VNode,
 } from '@microsoft/msfs-sdk';
 import { LowerArea } from 'instruments/src/PFD/LowerArea';
-import { Arinc429Word, ArincEventBus, FailuresConsumer } from '@flybywiresim/fbw-sdk';
+import { Arinc429LocalVarConsumerSubject, Arinc429Word, ArincEventBus, FailuresConsumer } from '@flybywiresim/fbw-sdk';
 
 import { AttitudeIndicatorWarnings } from '@flybywiresim/pfd';
 import { AttitudeIndicatorWarningsA380 } from 'instruments/src/PFD/AttitudeIndicatorWarningsA380';
@@ -76,7 +76,7 @@ export class PFDComponent extends DisplayComponent<PFDProps> {
 
   private failuresConsumer: FailuresConsumer;
 
-  private readonly groundSpeed = ConsumerSubject.create(this.sub.on('groundSpeed'), 0);
+  private readonly groundSpeed = Arinc429LocalVarConsumerSubject.create(this.sub.on('groundSpeed'), 0);
 
   private readonly spoilersArmed = ConsumerSubject.create(this.sub.on('spoilersArmed'), false);
 
@@ -104,7 +104,7 @@ export class PFDComponent extends DisplayComponent<PFDProps> {
   private readonly pitchTrimIndicatorVisible = Subject.create(false);
 
   private updatePitchTrimVisible(flapsRetracted = false) {
-    const gs = new Arinc429Word(this.groundSpeed.get()).valueOr(0);
+    const gs = this.groundSpeed.get().valueOr(0);
     if (this.filteredRadioAltitude.get() > 50) {
       this.pitchTrimIndicatorVisible.set(false);
     } else if (gs < 30) {

--- a/fbw-a380x/src/systems/instruments/src/PFD/PitchTrimDisplay.tsx
+++ b/fbw-a380x/src/systems/instruments/src/PFD/PitchTrimDisplay.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-import { MathUtils } from '@flybywiresim/fbw-sdk';
+import { Arinc429LocalVarConsumerSubject, MathUtils } from '@flybywiresim/fbw-sdk';
 import {
   ConsumerSubject,
   DisplayComponent,
@@ -52,7 +52,14 @@ export class PitchTrimDisplay extends DisplayComponent<{ bus: EventBus; visible:
   );
 
   private readonly fwcFlightPhase = ConsumerSubject.create(this.sub.on('fwcFlightPhase'), 0);
-  private readonly flightPhaseAfterTouchdown = this.fwcFlightPhase.map((fp) => (fp > 9 ? 'hidden' : 'inherit'));
+
+  private readonly groundSpeed = Arinc429LocalVarConsumerSubject.create(this.sub.on('groundSpeed'), 0);
+
+  private readonly maintenancePositionWhiteLineVisibility = MappedSubject.create(
+    ([fp, gs]) => (fp >= 11 && gs.isNormalOperation() && gs.value <= 30 ? 'inherit' : 'hidden'),
+    this.fwcFlightPhase,
+    this.groundSpeed,
+  );
 
   private readonly engOneRunning = ConsumerSubject.create(this.sub.on('engOneRunning'), false);
   private readonly engTwoRunning = ConsumerSubject.create(this.sub.on('engTwoRunning'), false);
@@ -183,7 +190,7 @@ export class PitchTrimDisplay extends DisplayComponent<{ bus: EventBus; visible:
       this.rightWheelY,
       this.trimAreasTransform,
       this.fwcFlightPhase,
-      this.flightPhaseAfterTouchdown,
+      this.maintenancePositionWhiteLineVisibility,
       this.anyEngRunning,
       this.cgPercent,
       this.cgPercentText,
@@ -314,7 +321,14 @@ export class PitchTrimDisplay extends DisplayComponent<{ bus: EventBus; visible:
                 stroke-width="4"
                 visibility={this.gwCgVisibility}
               />
-              <rect width="20" height="4" x="5" y="274" fill="white" visibility={this.flightPhaseAfterTouchdown} />
+              <rect
+                width="20"
+                height="4"
+                x="5"
+                y="274"
+                fill="white"
+                visibility={this.maintenancePositionWhiteLineVisibility}
+              />
             </g>
             <rect x="275" y="23" width="30" height="207" fill="url(#shadowGradient)" />
           </g>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes bug/regression with latest auto THS PR: 
The white line for demarking the maintenance position was visible before landing, which should not happen.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. During engine start, before take-off: White line in PFD pitch trim indicator should not be displayed
2. After landing, when GS below 30kts: White line should appear

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
