### PR TITLE
fix(a380x/mfd): Show dist on DIR TO page, no access to DIR TO when TMPY plan

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/FlightPlanService.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/FlightPlanService.ts
@@ -90,6 +90,19 @@ export class FlightPlanService<P extends FlightPlanPerformanceData = FlightPlanP
     return this.flightPlanManager.has(FlightPlanIndex.FirstSecondary + index - 1);
   }
 
+  hasDirectToInTmpy() {
+    if (!this.hasTemporary) {
+      return false;
+    }
+
+    const temporaryPlan = this.flightPlanManager.get(FlightPlanIndex.Temporary);
+    const tmpyFromLeg = temporaryPlan.maybeElementAt(temporaryPlan.activeLegIndex - 1);
+    const directToInTmpy =
+      tmpyFromLeg?.isDiscontinuity === false && tmpyFromLeg.flags & FlightPlanLegFlags.DirectToTurningPoint;
+
+    return directToInTmpy && BitFlags.isAny(tmpyFromLeg.flags, FlightPlanLegFlags.PendingDirectToTurningPoint);
+  }
+
   get hasUplink() {
     return this.flightPlanManager.has(FlightPlanIndex.Uplink);
   }
@@ -123,14 +136,8 @@ export class FlightPlanService<P extends FlightPlanPerformanceData = FlightPlanP
 
     const tmpyFromLeg = temporaryPlan.maybeElementAt(temporaryPlan.activeLegIndex - 1);
 
-    const directToInTmpy =
-      tmpyFromLeg?.isDiscontinuity === false && tmpyFromLeg.flags & FlightPlanLegFlags.DirectToTurningPoint;
-
-    const directToBeingInserted =
-      directToInTmpy && BitFlags.isAny(tmpyFromLeg.flags, FlightPlanLegFlags.PendingDirectToTurningPoint);
-
     // Update T-P
-    if (directToBeingInserted) {
+    if (this.hasDirectToInTmpy() && tmpyFromLeg instanceof FlightPlanLeg) {
       temporaryPlan.editLegFlags(
         temporaryPlan.activeLegIndex - 1,
         (tmpyFromLeg.flags &= ~FlightPlanLegFlags.PendingDirectToTurningPoint),

--- a/fbw-a380x/src/systems/instruments/src/MFD/MFD.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/MFD.tsx
@@ -62,6 +62,8 @@ export interface MfdDisplayInterface {
   interactionMode: Subscribable<InteractionMode>;
 
   openMessageList(): void;
+
+  navigateTo(uri: string): void;
 }
 
 export class MfdComponent
@@ -228,42 +230,33 @@ export class MfdComponent
 
             switch (key) {
               case 'DIR':
-                if (this.props.fmcService.master?.flightPlanService.hasTemporary) {
-                  this.props.fmcService.master?.addMessageToQueue(
-                    NXSystemMessages.insertOrEraseTmpPlan,
-                    undefined,
-                    undefined,
-                  );
-                  break;
-                }
-
-                this.uiService.navigateTo('fms/active/f-pln-direct-to');
+                this.navigateTo('fms/active/f-pln-direct-to');
                 break;
               case 'PERF':
-                this.uiService.navigateTo('fms/active/perf');
+                this.navigateTo('fms/active/perf');
                 break;
               case 'INIT':
-                this.uiService.navigateTo('fms/active/init');
+                this.navigateTo('fms/active/init');
                 break;
               case 'NAVAID':
-                this.uiService.navigateTo('fms/position/navaids');
+                this.navigateTo('fms/position/navaids');
                 break;
               case 'MAILBOX': // Move cursor to SD mail box
                 break;
               case 'FPLN':
-                this.uiService.navigateTo('fms/active/f-pln/top');
+                this.navigateTo('fms/active/f-pln/top');
                 break;
               case 'DEST':
-                this.uiService.navigateTo('fms/active/f-pln/dest');
+                this.navigateTo('fms/active/f-pln/dest');
                 break;
               case 'SECINDEX':
-                this.uiService.navigateTo('fms/sec/index');
+                this.navigateTo('fms/sec/index');
                 break;
               case 'SURV':
-                this.uiService.navigateTo('surv/controls');
+                this.navigateTo('surv/controls');
                 break;
               case 'ATCCOM':
-                this.uiService.navigateTo('atccom/connect');
+                this.navigateTo('atccom/connect');
                 break;
               case 'ND': // Move cursor to ND
                 break;
@@ -286,6 +279,20 @@ export class MfdComponent
     this.topRef.instance.addEventListener('mousemove', this.onMouseMoveHandler);
 
     this.subs.push(this.fmsDataKnob, this.fmcAIsHealthy, this.fmcBIsHealthy, this.activeFmsSource);
+  }
+
+  public navigateTo(uri: string) {
+    const parsedUri = this.uiService.parseUri(uri);
+    if (
+      parsedUri?.page == 'f-pln-direct-to' &&
+      this.props.fmcService.master?.flightPlanService.hasTemporary &&
+      !this.props.fmcService.master?.flightPlanService.hasDirectToInTmpy()
+    ) {
+      this.props.fmcService.master?.addMessageToQueue(NXSystemMessages.insertOrEraseTmpPlan, undefined, undefined);
+      return;
+    }
+
+    this.uiService.navigateTo(uri);
   }
 
   private onMouseMove(ev: MouseEvent) {

--- a/fbw-a380x/src/systems/instruments/src/MFD/MFD.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/MFD.tsx
@@ -33,6 +33,7 @@ import { MfdFmsPageNotAvail } from 'instruments/src/MFD/pages/FMS/MfdFmsPageNotA
 
 import './pages/common/style.scss';
 import { InteractionMode } from 'instruments/src/MsfsAvionicsCommon/UiWidgets/InputField';
+import { NXSystemMessages } from './shared/NXSystemMessages';
 
 export const getDisplayIndex = () => {
   const url = document.getElementsByTagName('a380x-mfd')[0].getAttribute('url');
@@ -227,6 +228,15 @@ export class MfdComponent
 
             switch (key) {
               case 'DIR':
+                if (this.props.fmcService.master?.flightPlanService.hasTemporary) {
+                  this.props.fmcService.master?.addMessageToQueue(
+                    NXSystemMessages.insertOrEraseTmpPlan,
+                    undefined,
+                    undefined,
+                  );
+                  break;
+                }
+
                 this.uiService.navigateTo('fms/active/f-pln-direct-to');
                 break;
               case 'PERF':

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
@@ -35,6 +35,7 @@ import { MfdFmsFplnVertRev } from 'instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpl
 import { AltitudeConstraint, SpeedConstraint } from '@fmgc/flightplanning/data/constraint';
 import { ConditionalComponent } from '../../../../MsfsAvionicsCommon/UiWidgets/ConditionalComponent';
 import { InternalKccuKeyEvent } from 'instruments/src/MFD/shared/MFDSimvarPublisher';
+import { NXSystemMessages } from '../../../shared/NXSystemMessages';
 
 interface MfdFmsFplnProps extends AbstractMfdPageProps {}
 
@@ -835,6 +836,15 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
     return this.lineData.length - this.renderedLineData.length;
   }
 
+  private navigateDirTo(): void {
+    if (this.props.fmcService.master?.flightPlanService.hasTemporary) {
+      this.props.fmcService.master?.addMessageToQueue(NXSystemMessages.insertOrEraseTmpPlan, undefined, undefined);
+      return;
+    }
+
+    this.props.mfd.uiService.navigateTo(`fms/${this.props.mfd.uiService.activeUri.get().category}/f-pln-direct-to`);
+  }
+
   render(): VNode {
     return (
       <>
@@ -1056,15 +1066,7 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
                 },
               ] as ButtonMenuItem[])}
             />
-            <Button
-              label="DIR TO"
-              onClick={() =>
-                this.props.mfd.uiService.navigateTo(
-                  `fms/${this.props.mfd.uiService.activeUri.get().category}/f-pln-direct-to`,
-                )
-              }
-              buttonStyle="margin-right: 5px;"
-            />
+            <Button label="DIR TO" onClick={() => this.navigateDirTo()} buttonStyle="margin-right: 5px;" />
           </div>
           {/* end page content */}
         </div>

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpln.tsx
@@ -35,7 +35,6 @@ import { MfdFmsFplnVertRev } from 'instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFpl
 import { AltitudeConstraint, SpeedConstraint } from '@fmgc/flightplanning/data/constraint';
 import { ConditionalComponent } from '../../../../MsfsAvionicsCommon/UiWidgets/ConditionalComponent';
 import { InternalKccuKeyEvent } from 'instruments/src/MFD/shared/MFDSimvarPublisher';
-import { NXSystemMessages } from '../../../shared/NXSystemMessages';
 
 interface MfdFmsFplnProps extends AbstractMfdPageProps {}
 
@@ -836,15 +835,6 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
     return this.lineData.length - this.renderedLineData.length;
   }
 
-  private navigateDirTo(): void {
-    if (this.props.fmcService.master?.flightPlanService.hasTemporary) {
-      this.props.fmcService.master?.addMessageToQueue(NXSystemMessages.insertOrEraseTmpPlan, undefined, undefined);
-      return;
-    }
-
-    this.props.mfd.uiService.navigateTo(`fms/${this.props.mfd.uiService.activeUri.get().category}/f-pln-direct-to`);
-  }
-
   render(): VNode {
     return (
       <>
@@ -1066,7 +1056,13 @@ export class MfdFmsFpln extends FmsPage<MfdFmsFplnProps> {
                 },
               ] as ButtonMenuItem[])}
             />
-            <Button label="DIR TO" onClick={() => this.navigateDirTo()} buttonStyle="margin-right: 5px;" />
+            <Button
+              label="DIR TO"
+              onClick={() =>
+                this.props.mfd.navigateTo(`fms/${this.props.mfd.uiService.activeUri.get().category}/f-pln-direct-to`)
+              }
+              buttonStyle="margin-right: 5px;"
+            />
           </div>
           {/* end page content */}
         </div>

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnDirectTo.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnDirectTo.tsx
@@ -48,11 +48,9 @@ export class MfdFmsFplnDirectTo extends FmsPage<MfdFmsFplnDirectToProps> {
     it ? RadioButtonColor.Yellow : RadioButtonColor.Cyan,
   );
 
-  private activeDirToPlan: boolean = false;
-
   protected checkIfNewData() {
     super.checkIfNewData();
-    if (this.loadedFlightPlanIndex.get() === FlightPlanIndex.Temporary && this.activeDirToPlan) {
+    if (this.loadedFlightPlanIndex.get() === FlightPlanIndex.Temporary) {
       this.refreshTemporaryPlan();
     }
   }
@@ -93,8 +91,6 @@ export class MfdFmsFplnDirectTo extends FmsPage<MfdFmsFplnDirectToProps> {
         this.selectedWaypointIndex.set(null);
         this.dropdownMenuRef.instance.forceLabel(this.manualWptIdent);
       }
-    } else {
-      this.activeDirToPlan = false;
     }
   }
 
@@ -110,7 +106,6 @@ export class MfdFmsFplnDirectTo extends FmsPage<MfdFmsFplnDirectToProps> {
       if (legIndex !== undefined) {
         this.selectedWaypointIndex.set(idx);
         this.manualWptIdent = null;
-        this.activeDirToPlan = true;
         const trueTrack = ADIRS.getTrueTrack();
         await this.props.fmcService.master?.flightPlanService.directToLeg(
           this.props.fmcService.master.navigation.getPpos() ?? { lat: 0, long: 0 },
@@ -124,7 +119,6 @@ export class MfdFmsFplnDirectTo extends FmsPage<MfdFmsFplnDirectToProps> {
       const wpt = await WaypointEntryUtils.getOrCreateWaypoint(this.props.fmcService.master, text, true, undefined);
       if (wpt) {
         this.manualWptIdent = wpt.ident;
-        this.activeDirToPlan = true;
         await this.props.fmcService.master.flightPlanService.directToWaypoint(
           this.props.fmcService.master.navigation.getPpos() ?? { lat: 0, long: 0 },
           SimVar.GetSimVarValue('GPS GROUND TRUE TRACK', 'degree'),

--- a/fbw-a380x/src/systems/instruments/src/MFD/shared/NXSystemMessages.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/shared/NXSystemMessages.ts
@@ -97,6 +97,7 @@ export const NXSystemMessages = {
   stepAhead: new TypeIIMessage('STEP AHEAD'),
   stepDeleted: new TypeIIMessage('STEP DELETED'),
   tooSteepPathAhead: new TypeIIMessage('TOO STEEP PATH AHEAD'),
+  insertOrEraseTmpPlan: new TypeIIMessage('INSERT OR ERASE TMPY F-PLN FIRST'),
 };
 
 export const NXFictionalMessages = {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9118

## Summary of Changes
- Shows distance on DIR TO page when waypoint is selected
- Disallows access to DIR TO page when a temporary flight-plan is set, and the temp plan did not come from a DIR TO

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

Distance shown on fpln waypoint:
https://github.com/user-attachments/assets/e0b9bccd-430a-4d52-8712-f16ccb38b424

Distance shown on custom waypoint:
https://github.com/user-attachments/assets/c2c44ef0-4d4f-46b7-a297-3d4d7c45a0c1

Message pops up when trying to go to dir to page on temp plan (that's not dir to):
https://github.com/user-attachments/assets/33ba1f59-74db-47c5-a276-fb4e1e909317

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

FCOM

![dirto-noaccess](https://github.com/user-attachments/assets/31245b2b-608d-42fe-b957-12ca2ef4601c)

![dirto-msg](https://github.com/user-attachments/assets/2c0541a3-9c98-4f21-8091-3ff5c1c483a8)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

Would've liked something nicer than continuously updating the distance, but then again, it does continuously update the distance while you're moving. I'm just not sure if that's accurate with IRL - would be great to get some input on that.

Not 100% on the checking navigation in the MFD component, but it's the best place I could find for now - open for other suggestions.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Distance shown scenario:
1. Have active flight plan
2. Try to direct to waypoint
3. Notice distance is now shown on DIR TO page

Navigation scenario:
1. Have active flight plan
2. Try to make some other change to the plan, such as a departure set or deletion of waypoint
3. When the plan is in temporary mode, try to switch to DIR TO page
4. Notice message shown and MFD does not navigate to DIR TO page

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
