### PR TITLE
fix(a32nx): error reporting popup being stuck

### DIFF
--- a/fbw-common/src/systems/shared/src/FbwAircraftSentryClient.ts
+++ b/fbw-common/src/systems/shared/src/FbwAircraftSentryClient.ts
@@ -10,6 +10,8 @@ import { CaptureConsole as CaptureConsoleIntegration } from '@sentry/integration
 import { Integration } from '@sentry/types';
 import { NXDataStore } from './persistence';
 import { PopUpDialog } from './popup';
+import { GameStateProvider, Wait } from '@microsoft/msfs-sdk';
+import { isMsfs2024 } from './MsfsDetect';
 
 export const SENTRY_CONSENT_KEY = 'SENTRY_CONSENT';
 
@@ -99,6 +101,25 @@ export class FbwAircraftSentryClient {
   private async runRootClientFlow(config: FbwAircraftSentryClientConfiguration): Promise<boolean> {
     const consentValue = NXDataStore.get(SENTRY_CONSENT_KEY, SentryConsentState.Unknown) as SentryConsentState;
 
+    const requestConsentCallback = async () => {
+      return FbwAircraftSentryClient.requestConsent()
+        .then((didConsent) => {
+          if (didConsent) {
+            NXDataStore.set(SENTRY_CONSENT_KEY, SentryConsentState.Given);
+
+            console.log('[SentryClient] User requested consent state Given. Initializing sentry');
+
+            return FbwAircraftSentryClient.attemptInitializeSentry(config);
+          }
+
+          NXDataStore.set(SENTRY_CONSENT_KEY, SentryConsentState.Refused);
+
+          console.log('[SentryClient] User requested consent state Refused. Doing nothing');
+
+          return false;
+        })
+        .catch(() => false);
+    };
     switch (consentValue) {
       case SentryConsentState.Given:
         console.log('[SentryClient] Consent state is Given. Initializing sentry');
@@ -113,30 +134,21 @@ export class FbwAircraftSentryClient {
           const instrument = document.querySelector('vcockpit-panel > *');
 
           if (instrument) {
-            instrument.addEventListener('FlightStart', () => {
-              // ...and give ourselves some breathing room
-              setTimeout(() => {
-                resolve(
-                  FbwAircraftSentryClient.requestConsent()
-                    .then((didConsent) => {
-                      if (didConsent) {
-                        NXDataStore.set(SENTRY_CONSENT_KEY, SentryConsentState.Given);
-
-                        console.log('[SentryClient] User requested consent state Given. Initializing sentry');
-
-                        return FbwAircraftSentryClient.attemptInitializeSentry(config);
-                      }
-
-                      NXDataStore.set(SENTRY_CONSENT_KEY, SentryConsentState.Refused);
-
-                      console.log('[SentryClient] User requested consent state Refused. Doing nothing');
-
-                      return false;
-                    })
-                    .catch(() => false),
-                );
-              }, 1_000);
-            });
+            // hack to work around MSFS 2024 trying to show the popup in walkaround mode
+            if (isMsfs2024()) {
+              Wait.awaitSubscribable(GameStateProvider.get(), (state) => state === GameState.briefing, true).then(
+                () => {
+                  resolve(requestConsentCallback());
+                },
+              );
+            } else {
+              instrument.addEventListener('FlightStart', () => {
+                // ...and give ourselves some breathing room
+                setTimeout(() => {
+                  resolve(requestConsentCallback());
+                }, 1_000);
+              });
+            }
           } else {
             reject(new Error('[SentryClient] Could not find an instrument element to hook onto'));
           }

--- a/fbw-common/src/systems/shared/src/PilotSeat.ts
+++ b/fbw-common/src/systems/shared/src/PilotSeat.ts
@@ -55,9 +55,10 @@ export class PilotSeatManager implements Instrument {
   }
 
   public onUpdate(): void {
+    const cameraPos: XYZ = SimVar.GetGameVarValue('CAMERA_POS_IN_PLANE', 'xyz');
+    const cameraState: number = SimVar.GetSimVarValue('CAMERA STATE', SimVarValueType.Enum);
+    this.inFlightDeck.set(this.isInFlightDeckBounds(cameraPos, cameraState));
     if (this.configSeat === PilotSeatConfig.Auto) {
-      const cameraPos: XYZ = SimVar.GetGameVarValue('CAMERA_POS_IN_PLANE', 'xyz');
-      this.inFlightDeck.set(this.isInFlightDeckBounds(cameraPos));
       // if we are not inside the flight deck, do not update the side
       if (this.inFlightDeck.get()) {
         const inRightSide = cameraPos.x < 0;
@@ -68,14 +69,15 @@ export class PilotSeatManager implements Instrument {
     }
   }
 
-  private isInFlightDeckBounds(pos: XYZ): boolean {
+  private isInFlightDeckBounds(pos: XYZ, cameraState: number): boolean {
     return (
       pos.x >= this.flightDeckBounds.minX &&
       pos.x <= this.flightDeckBounds.maxX &&
       pos.y >= this.flightDeckBounds.minY &&
       pos.y <= this.flightDeckBounds.maxY &&
       pos.z >= this.flightDeckBounds.minZ &&
-      pos.z <= this.flightDeckBounds.maxZ
+      pos.z <= this.flightDeckBounds.maxZ &&
+      (cameraState === 2 || cameraState === 3)
     );
   }
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This did not appear in QA as the sentry DSN is not set in QA builds..

MSFS2024 "ingame" status of the GameStateProvider appears to be starting when in walkaround mode. Unfortunately the popup is bugged there and cannot be clicked. In the briefing status it works fine, so I used that for now.

I did not change the MSFS2020 code (it also worked fine with the briefing state but I couldn't test enough).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
