### PR TITLE
fix(a380x/extras): set rmp brightness correctly

### DIFF
--- a/fbw-a380x/src/systems/extras-host/modules/light_sync/LightSync.ts
+++ b/fbw-a380x/src/systems/extras-host/modules/light_sync/LightSync.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
-import { ClockEvents, EventBus, GameStateProvider, Instrument, KeyEventManager, Wait } from '@microsoft/msfs-sdk';
+import { ClockEvents, EventBus, GameStateProvider, Instrument, KeyEventManager, SimVarValueType, Wait } from '@microsoft/msfs-sdk';
 import { FmgcFlightPhase } from '@shared/flightphase';
 
 enum TimeOfDayState {
@@ -88,9 +88,10 @@ export class LightSync implements Instrument {
     this.setPotentiometer(79, autoBrightness); // OIT
 
     // Pedestal
-    this.setPotentiometer(80, autoBrightness); // rmpCptLightLevel
-    this.setPotentiometer(81, autoBrightness); // rmpFoLightLevel
-    this.setPotentiometer(82, autoBrightness); // rmpOvhdLightLevel
+
+    this.setRmpBrightness(1, autoBrightness * 100); // rmpCptLightLevel
+    this.setRmpBrightness(2, autoBrightness * 100); // rmpFoLightLevel
+    this.setRmpBrightness(3, autoBrightness * 100); // rmpOvhdLightLevel
     this.setPotentiometer(92, autoBrightness); // ecamUpperLightLevel
     this.setPotentiometer(93, autoBrightness); // ecamLowerLightLevel
     this.setPotentiometer(76, autoBrightness); // pedFloodLightLevel
@@ -165,6 +166,20 @@ export class LightSync implements Instrument {
     }
   }
 
+  /**
+   * Sets the RMP brightness knobs.
+   * @param rmp The RMP to set.
+   * @param brightness The brighness value in percent [0, 100].
+   */
+  private setRmpBrightness(rmp: 1 | 2 | 3, brightness: number): void {
+    // FIXME should use the B events, but not supported in FS2020.
+    SimVar.SetSimVarValue(`L:A380X_RMP_#RMP_ID#_BRIGHTNESS_KNOB`, SimVarValueType.Number, brightness);
+  }
+
+  /**
+   * Gets the automatic brightness level from the sim.
+   * @returns Brightness in the range [0, 1].
+   */
   private getAutoBrightness(): number {
     /** automatic brightness based on ambient light, [0, 1] scale */
     return Math.max(15, Math.min(85, SimVar.GetSimVarValue('GLASSCOCKPIT AUTOMATIC BRIGHTNESS', 'percent')));

--- a/fbw-a380x/src/systems/extras-host/modules/light_sync/LightSync.ts
+++ b/fbw-a380x/src/systems/extras-host/modules/light_sync/LightSync.ts
@@ -2,7 +2,15 @@
 // Copyright (c) 2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
-import { ClockEvents, EventBus, GameStateProvider, Instrument, KeyEventManager, SimVarValueType, Wait } from '@microsoft/msfs-sdk';
+import {
+  ClockEvents,
+  EventBus,
+  GameStateProvider,
+  Instrument,
+  KeyEventManager,
+  SimVarValueType,
+  Wait,
+} from '@microsoft/msfs-sdk';
 import { FmgcFlightPhase } from '@shared/flightphase';
 
 enum TimeOfDayState {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9969

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Set the RMP brightness semi-correctly, as best as we can while we still support FS2020. The XML watches the localvar so will update the IE state when it's changed.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Spawn in the A380X, rotate the RMP knobs and make sure the brightness doesn't jump, per the linked issue.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
