### PR TITLE
fix(a380x/pfd): Inhibit rudder trim amber/red in air

### DIFF
--- a/fbw-a380x/src/systems/instruments/src/PFD/LowerArea.tsx
+++ b/fbw-a380x/src/systems/instruments/src/PFD/LowerArea.tsx
@@ -553,16 +553,24 @@ class RudderTrimIndicator extends DisplayComponent<{ bus: ArincEventBus }> {
 
   private readonly rudderTrimIndicatorVisibilityStatus = Subject.create(false);
 
-  private readonly rudderTrimOrderTextClass = this.rudderTrimOrder.map((v) => {
-    const absTrim = Math.abs(v);
-    if (absTrim < 0.3) {
-      return 'HiddenElement';
-    } else if (absTrim < 3.6) {
-      return 'FontSmallest Amber';
-    } else {
-      return 'FontSmallest Red';
-    }
-  });
+  private readonly rudderTrimOrderTextClass = MappedSubject.create(
+    ([v, phase]) => {
+      const absTrim = Math.abs(v);
+      if (absTrim < 0.3) {
+        return 'HiddenElement';
+      } else if ([1, 2, 3, 4, 5, 10, 11, 12].includes(phase)) {
+        if (absTrim < 3.6) {
+          return 'FontSmallest Amber';
+        } else {
+          return 'FontSmallest Red';
+        }
+      } else {
+        return 'FontSmallest White';
+      }
+    },
+    this.rudderTrimOrder,
+    this.fwcFlightPhase,
+  );
 
   private readonly rudderTrimOrderTextVisibility = this.rudderTrimOrder.map((t) =>
     Math.abs(t) < 0.3 ? 'hidden' : 'inherit',


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9992 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
jonny_23

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
