### PR TITLE
fix: delay popups to avoid potential freeze

### DIFF
--- a/fbw-common/src/systems/shared/src/FbwAircraftSentryClient.ts
+++ b/fbw-common/src/systems/shared/src/FbwAircraftSentryClient.ts
@@ -119,25 +119,27 @@ export class FbwAircraftSentryClient {
               60,
               60000,
             ).then(() => {
-              resolve(
-                FbwAircraftSentryClient.requestConsent()
-                  .then((didConsent) => {
-                    if (didConsent) {
-                      NXDataStore.set(SENTRY_CONSENT_KEY, SentryConsentState.Given);
+              setTimeout(() => {
+                resolve(
+                  FbwAircraftSentryClient.requestConsent()
+                    .then((didConsent) => {
+                      if (didConsent) {
+                        NXDataStore.set(SENTRY_CONSENT_KEY, SentryConsentState.Given);
 
-                      console.log('[SentryClient] User requested consent state Given. Initializing sentry');
+                        console.log('[SentryClient] User requested consent state Given. Initializing sentry');
 
-                      return FbwAircraftSentryClient.attemptInitializeSentry(config);
-                    }
+                        return FbwAircraftSentryClient.attemptInitializeSentry(config);
+                      }
 
-                    NXDataStore.set(SENTRY_CONSENT_KEY, SentryConsentState.Refused);
+                      NXDataStore.set(SENTRY_CONSENT_KEY, SentryConsentState.Refused);
 
-                    console.log('[SentryClient] User requested consent state Refused. Doing nothing');
+                      console.log('[SentryClient] User requested consent state Refused. Doing nothing');
 
-                    return false;
-                  })
-                  .catch(() => false),
-              );
+                      return false;
+                    })
+                    .catch(() => false),
+                );
+              }, 1000);
             });
           } else {
             reject(new Error('[SentryClient] Could not find an instrument element to hook onto'));

--- a/fbw-common/src/systems/shared/src/TelexCheck.ts
+++ b/fbw-common/src/systems/shared/src/TelexCheck.ts
@@ -11,14 +11,16 @@ export class TelexCheck {
     const popup = new PopUpDialog();
 
     if (telexPopupState === 'false') {
-      popup.showPopUp(
-        'TELEX CONFIGURATION',
-        'You have not yet configured the telex option. Telex enables free text and live map. If enabled, aircraft position data is published for the duration of the flight. Messages are public and not moderated. USE AT YOUR OWN RISK. To learn more about telex and the features it enables, please go to https://docs.flybywiresim.com/telex. Would you like to enable telex?',
-        'small',
-        () => NXDataStore.set('CONFIG_ONLINE_FEATURES_STATUS', 'ENABLED'),
-        () => NXDataStore.set('CONFIG_ONLINE_FEATURES_STATUS', 'DISABLED'),
-      );
-      NXDataStore.set('TELEX_POPUP_SHOWN', 'true');
+      setTimeout(() => {
+        popup.showPopUp(
+          'TELEX CONFIGURATION',
+          'You have not yet configured the telex option. Telex enables free text and live map. If enabled, aircraft position data is published for the duration of the flight. Messages are public and not moderated. USE AT YOUR OWN RISK. To learn more about telex and the features it enables, please go to https://docs.flybywiresim.com/telex. Would you like to enable telex?',
+          'small',
+          () => NXDataStore.set('CONFIG_ONLINE_FEATURES_STATUS', 'ENABLED'),
+          () => NXDataStore.set('CONFIG_ONLINE_FEATURES_STATUS', 'DISABLED'),
+        );
+        NXDataStore.set('TELEX_POPUP_SHOWN', 'true');
+      }, 1000);
     }
   }
 }


### PR DESCRIPTION
…eeze

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

It seems like the popups for telex and error reporting can potentially freeze the sim (likely 2020 only) when they're shown right after entering the cockpit. This change adds a small timeout to reduce the risk of this happening. The error reporting popup already had this timeout but I had it removed in my previous change (thought it was not needed anymore but seems like we do).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
