### PR TITLE
feat(a380x/ecam): add FLAPS LEVER NOT ZERO ecam message

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 1. [A380X/FMS] Fix speed margins being displayed in the wrong place for a Mach target - @BlueberryKing (BlueberryKing)
 1. [A380X/MFD] Visual update to reflect later avionics batches (overlapping tab selectors) - @flogross89 (floridude)
+1. [A380X/ECAM] Add FLAPS LEVER NOT ZERO ECAM message - @Jonny23787 (Jonathan)
 
 ## 0.13.0
 

--- a/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/EcamMessages/AbnormalSensed/ata27.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/EcamMessages/AbnormalSensed/ata27.tsx
@@ -431,7 +431,7 @@ export const EcamAbnormalSensedAta27: { [n: number]: AbnormalProcedure } = {
     items: [],
   },
   272800003: {
-    title: '\x1b<4m\x1b4mF/CTL\x1bm FLAPS LEVER NOT ZERO',
+    title: '\x1b<2m\x1b4mF/CTL\x1bm FLAPS LEVER NOT ZERO',
     sensed: true,
     items: [],
   },

--- a/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsAbnormalSensed.ts
+++ b/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsAbnormalSensed.ts
@@ -2476,6 +2476,18 @@ export class FwsAbnormalSensed {
       sysPage: SdPages.Fctl,
       inopSysAllPhases: () => [],
     },
+    272800003: {
+      // FLAPS LEVER NOT ZERO
+      flightPhaseInhib: [1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12],
+      auralWarning: this.fws.flapConfigAural.map((on) => (on ? FwcAuralWarning.Crc : FwcAuralWarning.None)),
+      simVarIsActive: this.fws.flapsLeverNotZeroWarning,
+      notActiveWhenFaults: [],
+      whichItemsToShow: () => [],
+      whichItemsChecked: () => [],
+      failure: 3,
+      sysPage: SdPages.Fctl,
+      inopSysAllPhases: () => [],
+    },
     272800028: {
       // TO FLAPS FMS DISAGREE
       flightPhaseInhib: [1, 4, 5, 6, 7, 8, 9, 10, 12],

--- a/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsAbnormalSensed.ts
+++ b/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsAbnormalSensed.ts
@@ -2479,7 +2479,7 @@ export class FwsAbnormalSensed {
     272800003: {
       // FLAPS LEVER NOT ZERO
       flightPhaseInhib: [1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12],
-      auralWarning: this.fws.flapConfigAural.map((on) => (on ? FwcAuralWarning.Crc : FwcAuralWarning.None)),
+      auralWarning: this.fws.flapsLeverNotZeroAural.map((on) => (on ? FwcAuralWarning.Crc : FwcAuralWarning.None)),
       simVarIsActive: this.fws.flapsLeverNotZeroWarning,
       notActiveWhenFaults: [],
       whichItemsToShow: () => [],

--- a/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsCore.ts
+++ b/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsCore.ts
@@ -853,6 +853,8 @@ export class FwsCore {
 
   public readonly flapsLeverNotZeroWarning = Subject.create(false);
 
+  public readonly flapsLeverNotZeroAural = Subject.create(false);
+
   public readonly speedBrakeCommand5sConfirm = new NXLogicConfirmNode(5, true);
 
   public readonly speedBrakeCommand50sConfirm = new NXLogicConfirmNode(50, true);
@@ -3641,6 +3643,7 @@ export class FwsCore {
         this.flightPhase.get() === 8 &&
         !this.slatFlapSelectionS0F0,
     );
+    this.flapsLeverNotZeroAural.set(this.flapsLeverNotZeroWarning.get());
 
     // spd brk still out
     this.speedBrakeCommand5sConfirm.write(this.speedBrakeCommand.get(), deltaTime);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes

- Adds FLAPS LEVER NOT ZERO ECAM message when flap lever is not zero at or above 22000ft.

<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
![Screenshot 2025-04-13 194825](https://github.com/user-attachments/assets/4fa622d8-a044-4519-9347-f474a79115fe)

<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
![image](https://github.com/user-attachments/assets/1e8a1487-e8ec-4a5b-85b1-b86e8051c619)

<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
The second triggering condition has not been added in this PR.
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
jonny_23

## Testing instructions

1. Take-off and climb with flaps 0 to at or above 22000ft.
2. Slow aircraft down to around 200kt to ensure an overspeed won't occur when flaps deployed.
3. Set flaps lever to position 1, confirm FLAPS LEVER NOT ZERO ecam message appears.
4. Set other flap positions at appropriate speeds while remaining above 22000ft.
5. Descend aircraft below 22000ft with warning present, ensure it disappears below 22000ft.

<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
