### PR TITLE
feat(a380x/sd): Improve SD BLEED page visuals and logic

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -34,6 +34,7 @@
 1. [A32NX/FMS] Add approach via auto-selection. - @tracernz (Mike)
 1. [A380X/MFD] Fixed ENTER DEST DATA message not clearing automatically - @BravoMike99 (bruno_pt99)
 1. [A380X/FCU] Fix selected speed initial target not being managed speed in non SRS - @BravoMike99 (bruno_pt99)
+1. [A380X/SD] Adjust BLEED page visuals and indications logic - @lukecologne (luke)
 
 ## 0.13.0
 

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/BleedPage.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/BleedPage.tsx
@@ -70,7 +70,7 @@ export const BleedPage = () => {
       <BleedGnd />
 
       {/* APU */}
-      <BleedApu isPack1Operative={isPack1Operative} isPack2Operative={isPack2Operative} />
+      <BleedApu />
     </>
   );
 };

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/BleedPage.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/BleedPage.tsx
@@ -34,34 +34,34 @@ export const BleedPage = () => {
         BLEED
       </PageTitle>
 
-      <BleedMixerUnit x={384} y={30} _sdacDatum={sdacDatum} />
+      <BleedMixerUnit x={164} y={34} _sdacDatum={sdacDatum} />
 
-      <text x={344} y={70} className="White F23 MiddleAlign">
+      <text x={356} y={72} className="White F22 MiddleAlign">
         RAM
       </text>
-      <text x={404} y={70} className="White F23 MiddleAlign">
+      <text x={415} y={72} className="White F22 MiddleAlign">
         AIR
       </text>
 
       {/* Hot Air */}
-      <BleedHotAir x={238} y={204} hotAir={1} _sdacDatum={sdacDatum} />
-      <BleedHotAir x={514} y={204} hotAir={2} _sdacDatum={sdacDatum} />
+      <BleedHotAir x={247} y={207} hotAir={1} _sdacDatum={sdacDatum} />
+      <BleedHotAir x={520} y={207} hotAir={2} _sdacDatum={sdacDatum} />
 
-      <text x={344} y={190} className="White F23 MiddleAlign">
+      <text x={355} y={193} className="White F22 MiddleAlign">
         HOT
       </text>
-      <text x={404} y={190} className="White F23 MiddleAlign">
+      <text x={414} y={193} className="White F22 MiddleAlign">
         AIR
       </text>
 
-      <BleedEngine x={75} y={525} engine={1} sdacDatum={sdacDatum} />
-      <BleedEngine x={209} y={525} engine={2} sdacDatum={sdacDatum} />
-      <BleedEngine x={485} y={525} engine={3} sdacDatum={sdacDatum} />
-      <BleedEngine x={619} y={525} engine={4} sdacDatum={sdacDatum} />
+      <BleedEngine x={78} y={528} engine={1} sdacDatum={sdacDatum} />
+      <BleedEngine x={215} y={528} engine={2} sdacDatum={sdacDatum} />
+      <BleedEngine x={490} y={528} engine={3} sdacDatum={sdacDatum} />
+      <BleedEngine x={627} y={528} engine={4} sdacDatum={sdacDatum} />
 
       {/* Packs */}
-      <BleedPack x={115} y={90} pack={1} isPackOperative={isPack1Operative} />
-      <BleedPack x={525} y={90} pack={2} isPackOperative={isPack2Operative} />
+      <BleedPack x={100} y={93} pack={1} isPackOperative={isPack1Operative} />
+      <BleedPack x={512} y={93} pack={2} isPackOperative={isPack2Operative} />
 
       {/* Crossbleed */}
       <BleedCrossbleed />

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedApu.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedApu.tsx
@@ -12,19 +12,41 @@ const BleedApu: FC<BleedApuProps> = ({ isPack1Operative, isPack2Operative }) => 
   const [apuMasterSwitchPbIsOn] = useSimVar('L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON', 'bool', 500);
 
   // The bleed valve and isolation valve operate "simulatneously" according to the FCOM
+  // Not fully correct, according to other sources, APU bleed valve is closed on ground without any bleed users,
+  // while the isolation valve is then open
   const apuIsolationValveOpen = apuBleedAirValveOpen;
 
+  const x = 360;
+  const y = 602;
+
   return (
-    <g id="ApuBleed">
-      <Valve x={352} y={446} radius={19} css="Green SW2" position={apuIsolationValveOpen ? 'V' : 'H'} sdacDatum />
+    <g id="ApuBleed" style={{ transform: `translate3d(${x}px, ${y}px, 0px)` }}>
+      <Valve
+        x={0}
+        y={-150}
+        radius={19.5}
+        css="Green SW2 NoFill"
+        position={apuIsolationValveOpen ? 'V' : 'H'}
+        sdacDatum
+      />
+
+      {/* Why would this depend on the packs? */}
       <path
         className={`${apuIsolationValveOpen && (isPack1Operative || isPack2Operative) ? 'Show' : 'Hide'} Line Green NoFill`}
-        d={`M${352},${325} l 0,201`}
+        d="M0,-69 l 0,-61"
       />
+
       <g className={apuMasterSwitchPbIsOn ? 'Show' : 'Hide'}>
-        <Valve x={352} y={546} radius={19} css="Green SW2" position={apuBleedAirValveOpen ? 'V' : 'H'} sdacDatum />
-        <path className="Green SW2" d="M 352,565 l 0,30" />
-        <text x={352} y={610} className="White F23 MiddleAlign">
+        <Valve
+          x={0}
+          y={-49}
+          radius={19.5}
+          css="Green SW2 NoFill"
+          position={apuBleedAirValveOpen ? 'V' : 'H'}
+          sdacDatum
+        />
+        <path className="Green SW2" d="M 0,0 l 0,-30" />
+        <text x={1} y={16} className="White F23 MiddleAlign">
           APU
         </text>
       </g>

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedApu.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedApu.tsx
@@ -2,12 +2,7 @@ import React, { FC } from 'react';
 import { useSimVar } from '@instruments/common/simVars';
 import Valve from './Valve';
 
-interface BleedApuProps {
-  isPack1Operative: boolean;
-  isPack2Operative: boolean;
-}
-
-const BleedApu: FC<BleedApuProps> = ({ isPack1Operative, isPack2Operative }) => {
+const BleedApu: FC = () => {
   const [apuBleedAirValveOpen] = useSimVar('L:A32NX_APU_BLEED_AIR_VALVE_OPEN', 'bool', 500);
   const [apuMasterSwitchPbIsOn] = useSimVar('L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON', 'bool', 500);
 
@@ -30,11 +25,11 @@ const BleedApu: FC<BleedApuProps> = ({ isPack1Operative, isPack2Operative }) => 
         sdacDatum
       />
 
-      {/* Why would this depend on the packs? */}
-      <path
-        className={`${apuIsolationValveOpen && (isPack1Operative || isPack2Operative) ? 'Show' : 'Hide'} Line Green NoFill`}
-        d="M0,-69 l 0,-61"
-      />
+      {/* APU Bleed valve to APU isolation valve */}
+      <path className={`${apuIsolationValveOpen ? 'Show' : 'Hide'} Line Green NoFill`} d="M0,-69 l 0,-61" />
+
+      {/* APU isolation valve to crossbleed line */}
+      <path className={`${apuIsolationValveOpen ? 'Show' : 'Hide'} Line Green NoFill`} d="M0,-170 l 0,-101" />
 
       <g className={apuMasterSwitchPbIsOn ? 'Show' : 'Hide'}>
         <Valve

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedCrossbleed.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedCrossbleed.tsx
@@ -15,13 +15,14 @@ const BleedCrossbleed: FC = () => {
   const [pack2FlowValve2Open] = useSimVar('L:A32NX_COND_PACK_2_FLOW_VALVE_2_IS_OPEN', 'bool', 500);
 
   const sdacDatum = true;
+  const x = 0;
   const y = 325;
 
   return (
-    <g id="CrossBleed">
+    <g id="CrossBleed" style={{ transform: `translate3d(${x}px, ${y}px, 0px)` }}>
       <Valve
         x={283}
-        y={y}
+        y={0}
         radius={19}
         css="Green SW2"
         position={lhCrossBleedValveOpen ? 'H' : 'V'}
@@ -29,7 +30,7 @@ const BleedCrossbleed: FC = () => {
       />
       <Valve
         x={385}
-        y={y}
+        y={0}
         radius={19}
         css="Green SW2"
         position={centreCrossBleedValveOpen ? 'H' : 'V'}
@@ -37,7 +38,7 @@ const BleedCrossbleed: FC = () => {
       />
       <Valve
         x={470}
-        y={y}
+        y={0}
         radius={19}
         css="Green SW2"
         position={rhCrossBleedValveOpen ? 'H' : 'V'}
@@ -45,19 +46,19 @@ const BleedCrossbleed: FC = () => {
       />
       <path
         className={`${allCrossBleedValveOpen && pack1FlowValve1Open && pack1FlowValve2Open ? 'Show' : 'Hide'} Line Green NoFill`}
-        d={`M${240},${y} l 112,0`}
+        d={`M${240},${0} l 112,0`}
       />
       <path
         className={`${allCrossBleedValveOpen && pack2FlowValve1Open && pack2FlowValve2Open ? 'Show' : 'Hide'} Line Green NoFill`}
-        d={`M${352},${y} l 162,0`}
+        d={`M${352},${0} l 162,0`}
       />
       <path
         className={`${allCrossBleedValveOpen && pack1FlowValve1Open && pack1FlowValve2Open ? 'Show' : 'Hide'} Line Green NoFill`}
-        d={`M${315},${y} l 0,40 l -60,0 M${105},${y + 40} l 115,0 M${217},${y + 47.5} l 8,-15 M${250},${y + 47.5} l 8,-15`}
+        d={`M${315},${0} l 0,40 l -60,0 M${105},${40} l 115,0 M${217},${47.5} l 8,-15 M${250},${47.5} l 8,-15`}
       />
       <path
         className={`${allCrossBleedValveOpen && pack2FlowValve1Open && pack2FlowValve2Open ? 'Show' : 'Hide'} Line Green NoFill`}
-        d={`M${435},${y} l 0,40 l 60,0 M${533},${y + 40} l 115,0 M${492},${y + 47.5} l 8,-15 M${530},${y + 47.5} l 8,-15`}
+        d={`M${435},${0} l 0,40 l 60,0 M${533},${40} l 115,0 M${492},${47.5} l 8,-15 M${530},${47.5} l 8,-15`}
       />
     </g>
   );

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedCrossbleed.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedCrossbleed.tsx
@@ -6,60 +6,69 @@ const BleedCrossbleed: FC = () => {
   const [lhCrossBleedValveOpen] = useSimVar('L:A32NX_PNEU_XBLEED_VALVE_L_OPEN', 'bool', 500);
   const [centreCrossBleedValveOpen] = useSimVar('L:A32NX_PNEU_XBLEED_VALVE_C_OPEN', 'bool', 500);
   const [rhCrossBleedValveOpen] = useSimVar('L:A32NX_PNEU_XBLEED_VALVE_R_OPEN', 'bool', 500);
-  const allCrossBleedValveOpen = lhCrossBleedValveOpen && centreCrossBleedValveOpen && rhCrossBleedValveOpen;
-
-  // FIXME cover more combinations of crossbleed and pack flow valve status (assuming all flow valves from one pack are operative atm)
-  const [pack1FlowValve1Open] = useSimVar('L:A32NX_COND_PACK_1_FLOW_VALVE_1_IS_OPEN', 'bool', 500);
-  const [pack1FlowValve2Open] = useSimVar('L:A32NX_COND_PACK_1_FLOW_VALVE_2_IS_OPEN', 'bool', 500);
-  const [pack2FlowValve1Open] = useSimVar('L:A32NX_COND_PACK_2_FLOW_VALVE_1_IS_OPEN', 'bool', 500);
-  const [pack2FlowValve2Open] = useSimVar('L:A32NX_COND_PACK_2_FLOW_VALVE_2_IS_OPEN', 'bool', 500);
+  const [apuBleedValveOpen] = useSimVar('L:A32NX_APU_BLEED_AIR_VALVE_OPEN', 'bool', 500);
+  const allApuValvesOpen = apuBleedValveOpen;
 
   const sdacDatum = true;
   const x = 0;
-  const y = 325;
+  const y = 330;
 
   return (
     <g id="CrossBleed" style={{ transform: `translate3d(${x}px, ${y}px, 0px)` }}>
       <Valve
-        x={283}
+        x={292}
         y={0}
-        radius={19}
-        css="Green SW2"
+        radius={19.5}
+        css="Green SW2 NoFill"
         position={lhCrossBleedValveOpen ? 'H' : 'V'}
         sdacDatum={sdacDatum}
       />
       <Valve
-        x={385}
+        x={395}
         y={0}
-        radius={19}
-        css="Green SW2"
+        radius={19.5}
+        css="Green SW2 NoFill"
         position={centreCrossBleedValveOpen ? 'H' : 'V'}
         sdacDatum={sdacDatum}
       />
       <Valve
-        x={470}
+        x={478}
         y={0}
-        radius={19}
-        css="Green SW2"
+        radius={19.5}
+        css="Green SW2 NoFill"
         position={rhCrossBleedValveOpen ? 'H' : 'V'}
         sdacDatum={sdacDatum}
       />
+      {/* Left Crossbleed valve to engine 2 */}
+      <path className={`${!lhCrossBleedValveOpen ? 'Hide' : 'Show'} Line Green NoFill`} d="M248,0 l 24,0" />
+      {/* Left Crossbleed valve to engine 1 junction */}
+      <path className={`${!lhCrossBleedValveOpen ? 'Hide' : 'Show'} Line Green NoFill`} d="M312,0 l 14,0" />
+      {/* Engine 1 Junction to APU Junction */}
       <path
-        className={`${allCrossBleedValveOpen && pack1FlowValve1Open && pack1FlowValve2Open ? 'Show' : 'Hide'} Line Green NoFill`}
-        d={`M${240},${0} l 112,0`}
+        className={`${!allApuValvesOpen && !lhCrossBleedValveOpen && !centreCrossBleedValveOpen ? 'Hide' : 'Show'} Line Green NoFill`}
+        d="M326,0 l 34,0"
       />
+      {/* Engine 1 Junction to Engine 1 */}
       <path
-        className={`${allCrossBleedValveOpen && pack2FlowValve1Open && pack2FlowValve2Open ? 'Show' : 'Hide'} Line Green NoFill`}
-        d={`M${352},${0} l 162,0`}
+        className={`${!allApuValvesOpen && !lhCrossBleedValveOpen && !centreCrossBleedValveOpen ? 'Hide' : 'Show'} Line Green NoFill`}
+        d="M326,0 v 40 h -60,0 m-10,10 l 20,-20 m-10,10 m -35,0 m-10,10 l20,-20 m-10,10 h -119"
       />
+      {/* APU Junction to Center Crossbleed valve */}
       <path
-        className={`${allCrossBleedValveOpen && pack1FlowValve1Open && pack1FlowValve2Open ? 'Show' : 'Hide'} Line Green NoFill`}
-        d={`M${315},${0} l 0,40 l -60,0 M${105},${40} l 115,0 M${217},${47.5} l 8,-15 M${250},${47.5} l 8,-15`}
+        className={`${!allApuValvesOpen && !lhCrossBleedValveOpen && !centreCrossBleedValveOpen ? 'Hide' : 'Show'} Line Green NoFill`}
+        d="M360,0 l 15,0"
       />
+      {/* Center Crossbleed valve to engine 4 junction */}
+      <path className={`${!centreCrossBleedValveOpen ? 'Hide' : 'Show'} Line Green NoFill`} d={`M415,0 l 24,0`} />
+      {/* Engine 4 junction to Right Crossbleed valve */}
+      <path className={`${!rhCrossBleedValveOpen ? 'Hide' : 'Show'} Line Green NoFill`} d={`M439,0 l 19,0`} />
+      {/* Engine 4 junction to Engine 4 */}
       <path
-        className={`${allCrossBleedValveOpen && pack2FlowValve1Open && pack2FlowValve2Open ? 'Show' : 'Hide'} Line Green NoFill`}
-        d={`M${435},${0} l 0,40 l 60,0 M${533},${40} l 115,0 M${492},${47.5} l 8,-15 M${530},${47.5} l 8,-15`}
+        className={`${!rhCrossBleedValveOpen && !centreCrossBleedValveOpen ? 'Hide' : 'Show'} Line Green NoFill`}
+        d="M439,0 v 40 h 67,0 m-10,10 l 20,-20 m-10,10 m 35,0 m-10,10 l20,-20 m-10,10 h 118"
       />
+      {/* Right Crossbleed valve to engine 3 */}
+      <path className={`${!rhCrossBleedValveOpen ? 'Hide' : 'Show'} Line Green NoFill`} d="M498,0 l 24,0" />
     </g>
   );
 };

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedEngine.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedEngine.tsx
@@ -146,7 +146,6 @@ const BleedEngine: React.FC<BleedPageProps> = ({ x, y, engine, sdacDatum }) => {
         </text>
       </g>
 
-      {/* Why does this use the pack flow valve status? */}
       <path className={`${bleedDuctHidden ? 'Hide' : 'SW2 Green'}`} d="M 33,-237 v 95" />
 
       {/* Pack valve */}

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedEngine.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedEngine.tsx
@@ -97,6 +97,7 @@ const BleedEngine: React.FC<BleedPageProps> = ({ x, y, engine, sdacDatum }) => {
         className={`SW2 ${shouldHpValveBeOpen === engineHpValveOpen && (engineHpValveOpen || isEngineRunning) ? 'Green' : 'Amber'}`}
         d="M 64,65 l 0,20"
       />
+      <path className={engineHpValveOpen ? 'SW2 Green NoFill' : 'Hide'} d="M 64,25 v -12 h -31" />
 
       {/* Engine Bleed units */}
       <g className={engine % 2 === 0 ? 'Hide' : 'Show'}>

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedEngine.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedEngine.tsx
@@ -35,6 +35,23 @@ const BleedEngine: React.FC<BleedPageProps> = ({ x, y, engine, sdacDatum }) => {
     'number',
     100,
   );
+  const [lhCrossBleedValveOpen] = useSimVar('L:A32NX_PNEU_XBLEED_VALVE_L_OPEN', 'bool', 500);
+  const [centreCrossBleedValveOpen] = useSimVar('L:A32NX_PNEU_XBLEED_VALVE_C_OPEN', 'bool', 500);
+  const [rhCrossBleedValveOpen] = useSimVar('L:A32NX_PNEU_XBLEED_VALVE_R_OPEN', 'bool', 500);
+  const [apuBleedValveOpen] = useSimVar('L:A32NX_APU_BLEED_AIR_VALVE_OPEN', 'bool', 500);
+  const allApuValvesOpen = apuBleedValveOpen;
+
+  let bleedDuctHidden = false;
+  if (engine == 1) {
+    bleedDuctHidden =
+      !engineBleedValveOpen && !allApuValvesOpen && !(lhCrossBleedValveOpen || centreCrossBleedValveOpen);
+  } else if (engine == 2) {
+    bleedDuctHidden = !engineBleedValveOpen && !lhCrossBleedValveOpen;
+  } else if (engine == 3) {
+    bleedDuctHidden = !engineBleedValveOpen && !centreCrossBleedValveOpen;
+  } else {
+    bleedDuctHidden = !engineBleedValveOpen && !(centreCrossBleedValveOpen && rhCrossBleedValveOpen);
+  }
 
   // TODO: Connect these up properly, so the valves can be shown in amber once we have failure conditions.
   // For now, we pretend the valves are always in the commanded state.
@@ -130,7 +147,7 @@ const BleedEngine: React.FC<BleedPageProps> = ({ x, y, engine, sdacDatum }) => {
       </g>
 
       {/* Why does this use the pack flow valve status? */}
-      <path className={`${packFlowValveOpen ? 'SW2 Green' : 'Hide'}`} d="M 33,-237 v 95" />
+      <path className={`${bleedDuctHidden ? 'Hide' : 'SW2 Green'}`} d="M 33,-237 v 95" />
 
       {/* Pack valve */}
       <BleedGauge

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedEngine.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedEngine.tsx
@@ -44,13 +44,13 @@ const BleedEngine: React.FC<BleedPageProps> = ({ x, y, engine, sdacDatum }) => {
   // TODO Degraded accuracy indication for fuel flow and used
 
   return (
-    <>
-      <text x={x - 22} y={y + 28} className="White F29">
+    <g style={{ transform: `translate3d(${x}px, ${y}px, 0px)` }}>
+      <text x={-18} y={32} className="White F29">
         {engine}
       </text>
       <image
-        x={x}
-        y={y}
+        x={0}
+        y={0}
         width={80}
         height={124}
         xlinkHref="/Images/fbw-a380x/Engine-Hyd-Bleed-Dithered.png"
@@ -59,84 +59,88 @@ const BleedEngine: React.FC<BleedPageProps> = ({ x, y, engine, sdacDatum }) => {
 
       <g className={engine === 1 ? 'Show' : 'Hide'}>
         {/* x=75   y=525 */}
-        <rect className="BackgroundFill" height={19} width={28} x={x + 35} y={y + 82} />
-        <rect className="BackgroundFill" height={19} width={28} x={x + 5} y={y + 40} />
-        <text className="White F22" x={x + 6} y={y + 58}>
+        <rect className="BackgroundFill" height={20} width={28} x={39} y={85} />
+        <rect className="BackgroundFill" height={19} width={28} x={7} y={44} />
+        <text className="White F23" x={8} y={63}>
           IP
         </text>
-        <text className="White F22" x={x + 37} y={y + 100}>
+        <text className="White F23" x={40} y={105}>
           HP
         </text>
       </g>
 
       {/* Engine Bleed valve */}
       <Valve
-        x={x + 29}
-        y={y - 29}
-        radius={19}
-        css={`Line ${shouldBleedValveBeOpen === engineBleedValveOpen && (engineHpValveOpen || isEngineRunning) ? 'Green' : 'Amber'}`}
+        x={32}
+        y={-24}
+        radius={19.5}
+        css={`Line NoFill ${shouldBleedValveBeOpen === engineBleedValveOpen && (engineHpValveOpen || isEngineRunning) ? 'Green' : 'Amber'}`}
         position={engineBleedValveOpen ? 'V' : 'H'}
         sdacDatum={sdacDatum}
       />
       <path
         className={`SW2 ${shouldBleedValveBeOpen === engineBleedValveOpen && (engineHpValveOpen || isEngineRunning) ? 'Green' : 'Amber'}`}
-        d={`M ${x + 29},${y - 10} l 0,46`}
+        d="M 32,-4 l 0,46"
       />
-      <path className={`${engineBleedValveOpen ? 'SW2 Green' : 'Hide'}`} d={`M ${x + 29},${y - 69} l 0,20`} />
+      <path className={`${engineBleedValveOpen ? 'SW2 Green' : 'Hide'}`} d="M 32,-67 l 0,23" />
 
       {/* HP valve */}
       <Valve
-        x={x + 61}
-        y={y + 40}
-        radius={19}
-        css={`Line ${shouldHpValveBeOpen === engineHpValveOpen && (engineHpValveOpen || isEngineRunning) ? 'Green' : 'Amber'}`}
+        x={64}
+        y={45}
+        radius={19.5}
+        css={`Line NoFill ${shouldHpValveBeOpen === engineHpValveOpen && (engineHpValveOpen || isEngineRunning) ? 'Green' : 'Amber'}`}
         position={engineHpValveOpen ? 'V' : 'H'}
         sdacDatum={sdacDatum}
       />
       <path
         className={`SW2 ${shouldHpValveBeOpen === engineHpValveOpen && (engineHpValveOpen || isEngineRunning) ? 'Green' : 'Amber'}`}
-        d={`M ${x + 61},${y + 59} l 0,20`}
+        d="M 64,65 l 0,20"
       />
 
-      {/* Engine Bleed temp */}
-      <path className="Grey SW2" d={`M ${x + 30},${y - 145} l -40,0 l 0,75 l 80,0 l 0,-75 l -40,0`} />
+      {/* Engine Bleed units */}
       <g className={engine % 2 === 0 ? 'Hide' : 'Show'}>
-        <text x={x + 78} y={y - 117} className="Cyan F23">
+        <text x={83} y={-113} className="Cyan F22">
           PSI
         </text>
-        <text x={x + 80} y={y - 75} className="Cyan F23">
+        <text x={85} y={-71} className="Cyan F22">
           °C
         </text>
       </g>
-      {/* Precooler inlet pressure */}
-      <text
-        x={x + 28}
-        y={y - 125}
-        className={`F29 MiddleAlign ${!sdacDatum || precoolerInletPressTwo <= 4 || precoolerInletPressTwo > 60 ? 'Amber' : 'Green'}`}
-      >
-        {!sdacDatum || precoolerInletPressTwo < 0 ? 'XX' : precoolerInletPressTwo}
-      </text>
-      {/* Precooler outlet temperature */}
-      <text
-        x={sdacDatum ? x + 28 : x}
-        y={y - 86}
-        className={`F29 MiddleAlign ${!sdacDatum || precoolerOutletTempFive < 150 || precoolerOutletTempFive > 257 ? 'Amber' : 'Green'}`}
-      >
-        {!sdacDatum ? 'XX' : precoolerOutletTempFive}
-      </text>
 
-      <path className={`${packFlowValveOpen ? 'SW2 Green' : 'Hide'}`} d={`M ${x + 29},${y - 240} l 0,94`} />
+      <g>
+        <path className="Grey NoFill SW2" d="M -9,-141 h 83 v 73 h -83 v -7 z" />
+        {/* Precooler inlet pressure */}
+        <text
+          x={34}
+          y={-122}
+          className={`F27 MiddleAlign ${!sdacDatum || precoolerInletPressTwo <= 4 || precoolerInletPressTwo > 60 ? 'Amber' : 'Green'}`}
+        >
+          {!sdacDatum || precoolerInletPressTwo < 0 ? 'XX' : precoolerInletPressTwo}
+        </text>
+        {/* Precooler outlet temperature */}
+        <text
+          x={34}
+          y={-82}
+          className={`F27 MiddleAlign ${!sdacDatum || precoolerOutletTempFive < 150 || precoolerOutletTempFive > 257 ? 'Amber' : 'Green'}`}
+        >
+          {!sdacDatum ? 'XX' : precoolerOutletTempFive}
+        </text>
+      </g>
+
+      {/* Why does this use the pack flow valve status? */}
+      <path className={`${packFlowValveOpen ? 'SW2 Green' : 'Hide'}`} d="M 33,-237 v 95" />
 
       {/* Pack valve */}
       <BleedGauge
-        x={x + 29}
-        y={y - 260}
+        x={33}
+        y={-257}
         engine={engine}
         sdacDatum={sdacDatum}
         packValveOpen={packFlowValveOpen}
         packFlowRate={packFlowValveRate}
       />
-    </>
+    </g>
   );
 };
 

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedGauge.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedGauge.tsx
@@ -12,28 +12,45 @@ interface BleedGaugeProps {
 }
 
 const BleedGauge: FC<BleedGaugeProps> = ({ x, y, engine, sdacDatum, packValveOpen, packFlowRate }) => {
-  const radius = 39;
+  const radius = 41;
   const startAngle = -90;
   const endAngle = 90;
   const min = 0;
   const max = 1;
 
   return (
-    <g id={`BleedGauge-${engine}`}>
+    <g id={`BleedGauge-${engine}`} style={{ transform: `translate3d(${x}px, ${y}px, 0px)` }}>
+      {/* Flow control valve */}
+      <Valve
+        x={0}
+        y={0}
+        radius={19.5}
+        css={`
+          ${packValveOpen ? 'Green' : 'Amber'} Line NoFill
+        `}
+        position={packValveOpen ? 'V' : 'H'}
+        sdacDatum={sdacDatum}
+      />
+
+      <path
+        className={`${packValveOpen ? 'Green' : 'Amber'} Line NoFill`}
+        d={`M-1,-51 l 0,-13 l ${engine % 2 === 0 ? '-' : ''}69, 0`}
+      />
+
       {/* Pack inlet flow */}
       <GaugeComponent
-        x={x}
-        y={y}
+        x={0}
+        y={0}
         radius={radius}
         startAngle={startAngle}
         endAngle={endAngle}
         visible
-        className="GaugeComponent Gauge"
+        className="White SW2 NoFill"
       >
         <GaugeMarkerComponent
           value={0}
-          x={x}
-          y={y}
+          x={0}
+          y={0}
           min={min}
           max={max}
           radius={radius}
@@ -44,8 +61,8 @@ const BleedGauge: FC<BleedGaugeProps> = ({ x, y, engine, sdacDatum, packValveOpe
         />
         <GaugeMarkerComponent
           value={0.5}
-          x={x}
-          y={y}
+          x={0}
+          y={0}
           min={min}
           max={max}
           radius={radius}
@@ -56,8 +73,8 @@ const BleedGauge: FC<BleedGaugeProps> = ({ x, y, engine, sdacDatum, packValveOpe
         />
         <GaugeMarkerComponent
           value={1}
-          x={x}
-          y={y}
+          x={0}
+          y={0}
           min={min}
           max={max}
           radius={radius}
@@ -70,8 +87,8 @@ const BleedGauge: FC<BleedGaugeProps> = ({ x, y, engine, sdacDatum, packValveOpe
           <GaugeMarkerComponent
             // value={packInletFlowPercentage < 80 ? 80 : packInletFlowPercentage}
             value={packFlowRate}
-            x={x}
-            y={y}
+            x={0}
+            y={0}
             min={min}
             max={max}
             radius={radius}
@@ -79,28 +96,12 @@ const BleedGauge: FC<BleedGaugeProps> = ({ x, y, engine, sdacDatum, packValveOpe
             endAngle={endAngle}
             className="GaugeIndicator Gauge LineRound"
             indicator
-            multiplierOuter={1.1}
+            halfIndicator
+            multiplierInner={0.47}
+            multiplierOuter={1.15}
           />
         )}
       </GaugeComponent>
-
-      {/* Flow control valve */}
-      <Valve x={x} y={y} radius={19} css="BackgroundFill Background" position="H" sdacDatum={sdacDatum} />
-      <Valve
-        x={x}
-        y={y}
-        radius={19}
-        css={`
-          ${packValveOpen ? 'Green' : 'Amber'} Line
-        `}
-        position={packValveOpen ? 'V' : 'H'}
-        sdacDatum={sdacDatum}
-      />
-
-      <path
-        className={`${packValveOpen ? 'Green' : 'Amber'} Line`}
-        d={`M${x},${y - 49} l 0,-12 l ${engine % 2 === 0 ? '-' : ''}67, 0`}
-      />
     </g>
   );
 };

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedGnd.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedGnd.tsx
@@ -9,10 +9,17 @@ const BleedGnd: FC = () => {
 
   const showGndIndication = onGround && !airspeed.isFailureWarning() && airspeed.value < 50;
 
+  const x = 343;
+  const y = 327;
+
   return (
-    <g id={`Gnd`} className={showGndIndication ? 'Show' : 'Hide'}>
-      <Triangle x={334} y={323} colour={'White'} fill={0} orientation={180} scale={1.2} />
-      <text x={334} y={295} className="White F23 MiddleAlign">
+    <g
+      id={`Gnd`}
+      className={showGndIndication ? 'Show' : 'Hide'}
+      style={{ transform: `translate3d(${x}px, ${y}px, 0px)` }}
+    >
+      <Triangle x={0} y={0} colour={'White'} fill={0} orientation={180} scale={1.3} />
+      <text x={1} y={-30} className="White F22 MiddleAlign">
         GND
       </text>
     </g>

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedHotAir.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedHotAir.tsx
@@ -30,35 +30,35 @@ const BleedHotAir: FC<BleedHotAirProps> = ({ x, y, hotAir, _sdacDatum }) => {
     ),
   );
 
-  const xoffset = 66;
+  const xoffset = 68;
 
   return (
-    <g id={`HotAir-${hotAir}`}>
+    <g id={`HotAir-${hotAir}`} style={{ transform: `translate3d(${x}px, ${y}px, 0px)` }}>
       <path
-        className={`${anyPackValveOpen ? 'Green' : 'Amber'} Line`}
-        d={`M${x},${y} l ${hotAir === 2 ? '-' : ''}${xoffset},0 l 0,-30`}
+        className={`${anyPackValveOpen ? 'Green' : 'Amber'} Line NoFill`}
+        d={`M0,0 l ${hotAir === 2 ? '-' : ''}${xoffset},0 l 0,-26`}
       />
       <path
         className={`${hotAirValveOpen && anyPackValveOpen ? 'Green' : 'Amber'} Line`}
-        d={`M${hotAir === 1 ? x + xoffset : x - xoffset},${y - 68} l 0,-24`}
+        d={`M${hotAir === 1 ? xoffset : -xoffset},${-66} l 0,-22`}
       />
       <Triangle
-        x={hotAir === 1 ? x + xoffset : x - xoffset}
-        y={y - 108}
+        x={hotAir === 1 ? xoffset : -xoffset}
+        y={-108}
         colour={hotAirValveOpen && anyPackValveOpen ? 'Green' : 'Amber'}
         fill={0}
         orientation={0}
-        scale={1.2}
+        scale={1.3}
       />
       <Valve
-        x={hotAir === 1 ? x + xoffset : x - xoffset}
-        y={y - 49}
-        radius={19}
-        css={`SW2 ${hotAirValveOpen && anyPackValveOpen ? 'Green' : 'Amber'}`}
+        x={hotAir === 1 ? xoffset : -xoffset}
+        y={-46}
+        radius={19.5}
+        css={`SW2 ${hotAirValveOpen && anyPackValveOpen ? 'Green' : 'Amber'} NoFill`}
         position={hotAirValveOpen ? 'V' : 'H'}
         sdacDatum
       />
-      <text x={hotAir === 1 ? x + xoffset + 37 : x - xoffset - 37} y={y - 43} className="White F23 MiddleAlign">
+      <text x={hotAir === 1 ? xoffset + 37 : -xoffset - 33} y={-43} className="White F22 MiddleAlign">
         {hotAir}
       </text>
     </g>

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedMixerUnit.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedMixerUnit.tsx
@@ -10,7 +10,6 @@ interface BleedMixerUnitProps {
 }
 
 const BleedMixerUnit: FC<BleedMixerUnitProps> = ({ x, y, _sdacDatum }) => {
-  // TODO Add Air supplied to cabin and cockpit simvar
   const [pack1FlowValve1Open] = useSimVar('L:A32NX_COND_PACK_1_FLOW_VALVE_1_IS_OPEN', 'bool', 500);
   const [pack1FlowValve2Open] = useSimVar('L:A32NX_COND_PACK_1_FLOW_VALVE_2_IS_OPEN', 'bool', 500);
   const [pack2FlowValve1Open] = useSimVar('L:A32NX_COND_PACK_2_FLOW_VALVE_1_IS_OPEN', 'bool', 500);

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedMixerUnit.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedMixerUnit.tsx
@@ -11,11 +11,16 @@ interface BleedMixerUnitProps {
 
 const BleedMixerUnit: FC<BleedMixerUnitProps> = ({ x, y, _sdacDatum }) => {
   // TODO Add Air supplied to cabin and cockpit simvar
-  const [hpValve1] = useSimVar('L:A32NX_PNEU_ENG_1_HP_VALVE_OPEN', 'bool', 500);
-  const [hpValve2] = useSimVar('L:A32NX_PNEU_ENG_2_HP_VALVE_OPEN', 'bool', 500);
-  const airSuppliedToCabinAndCockpit = hpValve1 || hpValve2;
+  const [pack1FlowValve1Open] = useSimVar('L:A32NX_COND_PACK_1_FLOW_VALVE_1_IS_OPEN', 'bool', 500);
+  const [pack1FlowValve2Open] = useSimVar('L:A32NX_COND_PACK_1_FLOW_VALVE_2_IS_OPEN', 'bool', 500);
+  const [pack2FlowValve1Open] = useSimVar('L:A32NX_COND_PACK_2_FLOW_VALVE_1_IS_OPEN', 'bool', 500);
+  const [pack2FlowValve2Open] = useSimVar('L:A32NX_COND_PACK_2_FLOW_VALVE_2_IS_OPEN', 'bool', 500);
+
   // TODO: Replace with signal from systems once implemented
   const [ramInletOpen] = useSimVar('L:A32NX_OVHD_COND_RAM_AIR_PB_IS_ON', 'bool', 100);
+
+  const airSuppliedToCabinAndCockpit =
+    pack1FlowValve1Open || pack1FlowValve2Open || pack2FlowValve1Open || pack2FlowValve2Open || ramInletOpen;
 
   return (
     <g id="MixerUnit" style={{ transform: `translate3d(${x}px, ${y}px, 0px)` }}>

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedMixerUnit.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedMixerUnit.tsx
@@ -18,56 +18,58 @@ const BleedMixerUnit: FC<BleedMixerUnitProps> = ({ x, y, _sdacDatum }) => {
   const [ramInletOpen] = useSimVar('L:A32NX_OVHD_COND_RAM_AIR_PB_IS_ON', 'bool', 100);
 
   return (
-    <g id="MixerUnit">
-      <path className="Grey SW2" d={`M ${x},${y} l -228,0 l 0,16 l 102,0`} />
-      <path className="Grey SW2" d={`M ${x},${y} l 210,0 l 0,16 l -100,0`} />
-      <path className="Grey SW2" d={`M ${x - 74},${y + 16} l 133,0`} />
+    <g id="MixerUnit" style={{ transform: `translate3d(${x}px, ${y}px, 0px)` }}>
+      <path className="Grey SW2 NoFill" d="M 105,14 h -105 v -14 h 441 v 14 h -98 m -54,0 h -130" />
 
       <GaugeMarkerComponent
         value={ramInletOpen ? 1 : 2}
-        x={x - 80}
-        y={y + 16}
+        x={152}
+        y={14}
         min={0}
         max={2}
         radius={44}
         startAngle={180}
         endAngle={270}
-        className="Green Line"
+        className="Green SW3 LineRound"
         indicator
+        halfIndicator
         multiplierOuter={1}
+        multiplierInner={0.07}
       />
-      <circle className="Green SW2 BackgroundFill" cx={x - 80} cy={y + 16} r={3} />
+      <circle className="Green SW2 NoFill" cx={152} cy={14} r={4} />
 
       <GaugeMarkerComponent
         value={ramInletOpen ? 1 : 2}
-        x={x + 105}
-        y={y + 16}
+        x={337}
+        y={15}
         min={0}
         max={2}
         radius={44}
         startAngle={180}
         endAngle={270}
-        className="Green Line"
+        className="Green SW3 LineRound"
         indicator
+        halfIndicator
         multiplierOuter={1}
+        multiplierInner={0.07}
       />
-      <circle className="Green SW2 BackgroundFill" cx={x + 104} cy={y + 16} r={3} />
+      <circle className="Green SW2 NoFill" cx={337} cy={15} r={4} />
 
       <Triangle
-        x={x - 116}
-        y={y - 22}
+        x={114}
+        y={-23}
         colour={airSuppliedToCabinAndCockpit ? 'Green' : 'Amber'}
         fill={0}
         orientation={0}
-        scale={1.2}
+        scale={1.3}
       />
       <Triangle
-        x={x + 98}
-        y={y - 22}
+        x={328}
+        y={-23}
         colour={airSuppliedToCabinAndCockpit ? 'Green' : 'Amber'}
         fill={0}
         orientation={0}
-        scale={1.2}
+        scale={1.3}
       />
     </g>
   );

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedPack.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedPack.tsx
@@ -15,6 +15,9 @@ const BleedPack: FC<BleedPackProps> = ({ x, y, pack, isPackOperative }) => {
   return (
     <g id={`BleedPack${pack}`} style={{ transform: `translate3d(${x}px, ${y}px, 0px)` }}>
       <path className={`${isPackOperative ? 'Green' : 'Amber'} Line`} d="M79,-21 l 0,-23" />
+      {/* Should this really be isPackOperative? Pack flow control valve status might make more sense */}
+      <path className={`${isPackOperative ? 'Green' : 'Amber'} Line`} d="M78,115 l 0,-21" />
+
       <path className="Grey SW2 NoFill" d="M 21,0 h -21 v 93 h 158 v -93 h -21" />
       <text x={42} y={0} className={`F22 ${isPackOperative ? 'White' : 'Amber'}`}>
         PACK

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedPack.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/BleedPack.tsx
@@ -10,28 +10,26 @@ interface BleedPackProps {
 
 const BleedPack: FC<BleedPackProps> = ({ x, y, pack, isPackOperative }) => {
   const [packOutletTemperature] = useSimVar(`L:A32NX_COND_PACK_${pack}_OUTLET_TEMPERATURE`, 'celsius', 500);
-  const packCtlOffset = pack == 1 ? -65 : 180;
+  const packCtlOffset = pack == 1 ? -50 : 210;
 
   return (
-    <g id={`BleedPack${pack}`}>
-      <path className={`${isPackOperative ? 'Green' : 'Amber'} Line`} d={`M${x + 56},${y - 21} l 0,-22`} />
-      <path className={`${isPackOperative ? 'Green' : 'Amber'} Line`} d={`M${x + 56},${y + 90} l 0,22`} />
-
-      <path className="Grey SW2" d={`M ${x},${y} l -20,0 l 0,90 l 153,0 l 0,-90 l -20,0`} />
-      <text x={x + 20} y={y} className={`F22 ${isPackOperative ? 'White' : 'Amber'}`}>
+    <g id={`BleedPack${pack}`} style={{ transform: `translate3d(${x}px, ${y}px, 0px)` }}>
+      <path className={`${isPackOperative ? 'Green' : 'Amber'} Line`} d="M79,-21 l 0,-23" />
+      <path className="Grey SW2 NoFill" d="M 21,0 h -21 v 93 h 158 v -93 h -21" />
+      <text x={42} y={0} className={`F22 ${isPackOperative ? 'White' : 'Amber'}`}>
         PACK
       </text>
-      <text x={x + 85} y={y} className={`F29 ${isPackOperative ? 'Green' : 'Amber'}`}>
+      <text x={108} y={0} className={`F24 ${isPackOperative ? 'Green' : 'Amber'}`}>
         {pack}
       </text>
 
-      <text x={x + 61} y={y + 57} className={`F29 EndAlign Green ${isPackOperative ? 'Show' : 'Hide'}`}>
+      <text x={83} y={57} className={`F28 EndAlign Green ${isPackOperative ? 'Show' : 'Hide'}`}>
         {Math.round(packOutletTemperature)}
       </text>
-      <text x={x + 62} y={y + 57} className={`Cyan F23 ${isPackOperative ? 'Show' : 'Hide'}`}>
+      <text x={84} y={57} className={`Cyan F22 ${isPackOperative ? 'Show' : 'Hide'}`}>
         °C
       </text>
-      <PackController x={x + packCtlOffset} y={y + 25} pack={pack} isPackOperative={isPackOperative} />
+      <PackController x={packCtlOffset} y={25} pack={pack} isPackOperative={isPackOperative} />
     </g>
   );
 };
@@ -43,19 +41,23 @@ const PackController: React.FC<BleedPackProps> = ({ x, y, pack }) => {
   const noFailure = !fdacChannel1Failure && !fdacChannel2Failure;
 
   return (
-    <g id="PackControl" className={noFailure ? 'Hide' : 'Show'}>
-      <text x={x} y={y} className="White F23 MiddleAlign">
+    <g
+      id="PackControl"
+      className={noFailure ? 'Hide' : 'Show'}
+      style={{ transform: `translate3d(${x}px, ${y}px, 0px)` }}
+    >
+      <text x={0} y={0} className="White F23 MiddleAlign">
         CTL
       </text>
-      <text x={x - 20} y={y + 25} className={`${fdacChannel1Failure ? 'Amber' : 'Green'} F23 MiddleAlign`}>
+      <text x={-20} y={25} className={`${fdacChannel1Failure ? 'Amber' : 'Green'} F22 MiddleAlign`}>
         1
       </text>
-      <text x={x + 20} y={y + 25} className={`${fdacChannel2Failure ? 'Amber' : 'Green'} F23 MiddleAlign`}>
+      <text x={20} y={25} className={`${fdacChannel2Failure ? 'Amber' : 'Green'} F22 MiddleAlign`}>
         2
       </text>
 
-      <path className={'White Line'} d={`M${x - 10},${y + 15} l 0,22 l -25,0`} fill={'none'} />
-      <path className={'White Line'} d={`M${x + 30},${y + 15} l 0,22 l -25,0`} fill={'none'} />
+      <path className="Grey SW2 NoFill" d="M-31,35 h 18 v -21" />
+      <path className="Grey SW2 NoFill" d="M10,35 h 18 v -21" />
     </g>
   );
 };

--- a/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/Valve.tsx
+++ b/fbw-a380x/src/systems/instruments/src/SD/Pages/Bleed/elements/Valve.tsx
@@ -10,15 +10,15 @@ interface ValveProps {
 }
 
 const Valve: FC<ValveProps> = ({ x, y, radius, position, css, sdacDatum }) => (
-  <g>
-    <circle cx={x} cy={y} r={radius} className={css} />
+  <g style={{ transform: `translate3d(${x}px, ${y}px, 0px)` }}>
+    <circle cx={0} cy={0} r={radius} className={css} />
     {!sdacDatum ? (
-      <text x={x + 1} y={y + 5} className="Small Amber Center">
+      <text x={1} y={5} className="Small Amber Center NoFill">
         XX
       </text>
     ) : null}
-    {sdacDatum && position === 'V' ? <path className={css} d={`M ${x},${y - radius} l 0,${2 * radius}`} /> : null}
-    {sdacDatum && position === 'H' ? <path className={css} d={`M ${x - radius},${y} l ${2 * radius},0`} /> : null}
+    {sdacDatum && position === 'V' ? <path className={css} d={`M ${0},${-radius} l 0,${2 * radius}`} /> : null}
+    {sdacDatum && position === 'H' ? <path className={css} d={`M ${-radius},${0} l ${2 * radius},0`} /> : null}
   </g>
 );
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR improves the visuals of the BLEED SD page, and adds/changes the following indications and logics:
* APU duct and valve indications no longer depend on pack status, but only on APU valve position
* Improved and more granular crossbleed indications, now only depending on crossbled and APU valve position and no longer pack status
* Engine bleed duct indication now depends on engine bleed valve, and crossbleed and APU valves depending on engine position. No longer depends on pack flow control valve
* Mixer unit bleed air user indication color now uses pack flow control valve and ram air inlet, no longer engine 1 and 2 HP valve position.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Make sure the bleed indication changes mentioned above make sense in various bleed system conditions. Otherwise, no testing required, as the changes are purely visual

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
