### PR TITLE
feat(a380x/fcu): reduce fcu texture size from 5120 to 2560

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -22,6 +22,7 @@
 1. [A380X/PFD] Inhibit rudder trim indication in the air - @Jonny23787 (Jonathan)
 1. [A380X/ECAM] Add FLAPS LEVER NOT ZERO ECAM message - @Jonny23787 (Jonathan)
 1. [A380X/ECAM] Improve ALL PRIMARY CABIN FANS FAULT - @Jonny23787 (Jonathan)
+1. [A380X/FCU] Reduce FCU texture size from 5120 to 2560 - @heclak (Heclak)
 
 ## 0.13.0
 

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/panel/panel.cfg
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/panel/panel.cfg
@@ -79,11 +79,11 @@ htmlgauge00=WasmInstrument/WasmInstrument.html?wasm_module=terronnd.wasm&wasm_ga
 htmlgauge01=A380X/ND/nd.html?Index=2?duID=4, 0,0,768,1024
 
 [VCockpit09]
-size_mm=5120,5120
-pixel_size=5120,5120
+size_mm=2560,2560
+pixel_size=2560,2560
 texture=$FCU
 
-htmlgauge00=A380X/FCU/FCU.html, 0,0,5120,5120
+htmlgauge00=A380X/FCU/FCU.html, 0,0,2560,2560
 
 [VCockpit10]
 size_mm=512,512

--- a/fbw-a380x/src/systems/instruments/src/FCU/Components/NdData.tsx
+++ b/fbw-a380x/src/systems/instruments/src/FCU/Components/NdData.tsx
@@ -54,62 +54,62 @@ export class NdData extends DisplayComponent<NdDataProps> {
         <div class="TopRow">
           <img
             style="position: absolute; top: 0; left: 0"
-            width="620px"
+            width="310px"
             class={{ hidden: this.isLightTestActive }}
             src="/Images/fbw-a380x/fcu/CSTR.png"
           />
           <img
-            style="position: absolute; top: 0; left: 890px"
-            width="620px"
+            style="position: absolute; top: 0; left: 445px"
+            width="310px"
             class={{ hidden: this.isLightTestActive }}
             src="/Images/fbw-a380x/fcu/WPT.png"
           />
           <img
-            style="position: absolute; top: 0; left: 1840px"
-            width="620px"
+            style="position: absolute; top: 0; left: 920px"
+            width="310px"
             class={{ hidden: this.isLightTestActive }}
             src="/Images/fbw-a380x/fcu/VORD.png"
           />
           <img
-            style="position: absolute; top: 0; left: 2790px"
-            width="620px"
+            style="position: absolute; top: 0; left: 1395px"
+            width="310px"
             class={{ hidden: this.isLightTestActive }}
             src="/Images/fbw-a380x/fcu/NDB.png"
           />
           <img
-            style="position: absolute; top: 0; left: 3740px"
-            width="620px"
+            style="position: absolute; top: 0; left: 1870px"
+            width="310px"
             class={{ hidden: this.isLightTestActive }}
             src="/Images/fbw-a380x/fcu/ARPT.png"
           />
           {/* LIGHT TESTS */}
           <img
             style="position: absolute; top: 0; left: 0"
-            width="620px"
+            width="310px"
             class={{ hidden: this.isLightTestActive.map(SubscribableMapFunctions.not()) }}
             src="/Images/fbw-a380x/fcu/TEST.png"
           />
           <img
-            style="position: absolute; top: 0; left: 890px"
-            width="620px"
+            style="position: absolute; top: 0; left: 445px"
+            width="310px"
             class={{ hidden: this.isLightTestActive.map(SubscribableMapFunctions.not()) }}
             src="/Images/fbw-a380x/fcu/TEST.png"
           />
           <img
-            style="position: absolute; top: 0; left: 1840px"
-            width="620px"
+            style="position: absolute; top: 0; left: 920px"
+            width="310px"
             class={{ hidden: this.isLightTestActive.map(SubscribableMapFunctions.not()) }}
             src="/Images/fbw-a380x/fcu/TEST.png"
           />
           <img
-            style="position: absolute; top: 0; left: 2790px"
-            width="620px"
+            style="position: absolute; top: 0; left: 1395px"
+            width="310px"
             class={{ hidden: this.isLightTestActive.map(SubscribableMapFunctions.not()) }}
             src="/Images/fbw-a380x/fcu/TEST.png"
           />
           <img
-            style="position: absolute; top: 0; left: 3740px"
-            width="620px"
+            style="position: absolute; top: 0; left: 1870px"
+            width="310px"
             class={{ hidden: this.isLightTestActive.map(SubscribableMapFunctions.not()) }}
             src="/Images/fbw-a380x/fcu/TEST.png"
           />
@@ -118,62 +118,62 @@ export class NdData extends DisplayComponent<NdDataProps> {
         <div class="BottomRow">
           <img
             style="position: absolute; top: 0; left: 0"
-            width="620px"
+            width="310px"
             class={{ hidden: this.isLightTestActive }}
             src={this.navaidMode1.map((v) => NdData.NAVAID_1_IMAGES[v])}
           />
           <img
-            style="position: absolute; top: 0; left: 890px"
-            width="620px"
+            style="position: absolute; top: 0; left: 445px"
+            width="310px"
             class={{ hidden: this.isLightTestActive }}
             src="/Images/fbw-a380x/fcu/WX.png"
           />
           <img
-            style="position: absolute; top: 0; left: 1840px"
-            width="620px"
+            style="position: absolute; top: 0; left: 920px"
+            width="310px"
             class={{ hidden: this.isLightTestActive }}
             src="/Images/fbw-a380x/fcu/TERR.png"
           />
           <img
-            style="position: absolute; top: 0; left: 2790px"
-            width="620px"
+            style="position: absolute; top: 0; left: 1395px"
+            width="310px"
             class={{ hidden: this.isLightTestActive }}
             src="/Images/fbw-a380x/fcu/TRAF.png"
           />
           <img
-            style="position: absolute; top: 0; left: 3740px"
-            width="620px"
+            style="position: absolute; top: 0; left: 1870px"
+            width="310px"
             class={{ hidden: this.isLightTestActive }}
             src={this.navaidMode2.map((v) => NdData.NAVAID_2_IMAGES[v])}
           />
           {/* LIGHT TESTS */}
           <img
             style="position: absolute; top: 0; left: 0"
-            width="620px"
+            width="310px"
             class={{ hidden: this.isLightTestActive.map(SubscribableMapFunctions.not()) }}
             src="/Images/fbw-a380x/fcu/TEST.png"
           />
           <img
-            style="position: absolute; top: 0; left: 890px"
-            width="620px"
+            style="position: absolute; top: 0; left: 445px"
+            width="310px"
             class={{ hidden: this.isLightTestActive.map(SubscribableMapFunctions.not()) }}
             src="/Images/fbw-a380x/fcu/TEST.png"
           />
           <img
-            style="position: absolute; top: 0; left: 1840px"
-            width="620px"
+            style="position: absolute; top: 0; left: 920px"
+            width="310px"
             class={{ hidden: this.isLightTestActive.map(SubscribableMapFunctions.not()) }}
             src="/Images/fbw-a380x/fcu/TEST.png"
           />
           <img
-            style="position: absolute; top: 0; left: 2790px"
-            width="620px"
+            style="position: absolute; top: 0; left: 1395px"
+            width="310px"
             class={{ hidden: this.isLightTestActive.map(SubscribableMapFunctions.not()) }}
             src="/Images/fbw-a380x/fcu/TEST.png"
           />
           <img
-            style="position: absolute; top: 0; left: 3740px"
-            width="620px"
+            style="position: absolute; top: 0; left: 1870px"
+            width="310px"
             class={{ hidden: this.isLightTestActive.map(SubscribableMapFunctions.not()) }}
             src="/Images/fbw-a380x/fcu/TEST.png"
           />

--- a/fbw-a380x/src/systems/instruments/src/FCU/style.scss
+++ b/fbw-a380x/src/systems/instruments/src/FCU/style.scss
@@ -49,12 +49,12 @@
 
 text.Label {
   font-family: "Poppins-SemiBold";
-  font-size: 230px;
+  font-size: 115px;
   fill: $display-colour-inactive;
 }
 
 .Baro text.Label {
-  font-size: 210px;
+  font-size: 105px;
 }
 
 text.Label.Visible {
@@ -64,40 +64,40 @@ text.Label.Visible {
 // deprecated
 :root text.Active {
   font-family: "Poppins-SemiBold";
-  font-size: 230px;
+  font-size: 115px;
   fill: $display-colour;
 }
 :root text.Active.BaroValue {
-  font-size: 210px;
+  font-size: 105px;
 }
 
 // deprecated
 :root text.Inactive {
   font-family: "Poppins-SemiBold";
-  font-size: 230px;
+  font-size: 115px;
   fill: $display-colour-inactive;
 }
 :root text.Inactive.BaroValue {
-  font-size: 210px;
+  font-size: 105px;
 }
 
 :root text.Value {
   font-family: Digital;
-  font-size:550px;
+  font-size:275px;
   text-anchor: start;
   fill: $display-colour;
   letter-spacing: 0px;
 }
 
 :root .Baro text.Value {
-  font-size: 512px;
+  font-size: 256px;
 }
 
 :root #PreSelBaroValue {
   font-family: Digital;
   text-anchor: end;
   letter-spacing: 0px;
-  font-size: 275px;
+  font-size: 137.5px;
 }
 
 :root line {
@@ -197,13 +197,13 @@ text.Label.Visible {
 }
 
 .NdData.LeftSide {
-  top: 1750px;
-  left: 240px;
+  top: 875px;
+  left: 120px;
 }
 
 .NdData.RightSide {
-  top: 2900px;
-  left: 300px;
+  top: 1450px;
+  left: 150px;
 }
 
 .NdData .TopRow {
@@ -214,6 +214,6 @@ text.Label.Visible {
 
 .NdData .BottomRow {
   position: absolute;
-  top: 550px;
+  top: 275px;
   left: 0;
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Partial of #9889

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Texture size reduced to 2560 in preparation of model update to change UV layout

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://github.com/user-attachments/assets/6e88928d-25a5-4958-ae41-a284c2f6f7ce)
![image](https://github.com/user-attachments/assets/caec0220-d8a5-4021-99e6-67e6a4f2f010)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
Tried reducing it to 1280x1280 but the gauges would be pixelated. 2560 is the lowest without pixelated. Could consider reducing it to 2048 but might result in diminishing returns.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Heclak

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Load aircraft and turn on annunciator test mode. Change that FCU labels are still in the correct place.
2. Interact with the FCU to change values and check for rendering errors. This might appear as large fonts. This PR doesn't fix any existing FCU bugs like in #9636 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
