### PR TITLE
feat(a380x/nd): show RNP label on RNP AR appr

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -28,6 +28,7 @@
 1. [FMS] Fix pseudo waypoint transmission for F/O side when EFIS range different from CAPT side - @flogross89 (floridude)
 1. [A380X/SURV] Enable SURV system switching via MFD SURV page; Add ECAM faults for TERR/GPWS - @flogross89 (floridude)
 1. [A380X/MFD] MFD F-PLN page data display improvements when no predictions or flightplan available - @BravoMike99 (bruno_pt99)
+1. [A380X/ND] Show RNP on approach identifier for RNP AR approaches
 
 ## 0.13.0
 

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/A320AircraftConfig.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/A320AircraftConfig.ts
@@ -141,6 +141,7 @@ const engineModelParams: EngineModelParameters = {
 
 const fmsSymbolConfig: FMSymbolsConfig = {
   publishDepartureIdent: false,
+  showRnpArLabel: false,
 };
 
 export const A320AircraftConfig: AircraftConfig = {

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/A380AircraftConfig.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/A380AircraftConfig.ts
@@ -168,6 +168,7 @@ const engineModelParams: EngineModelParameters = {
 
 const fmsSymbolConfig: FMSymbolsConfig = {
   publishDepartureIdent: true,
+  showRnpArLabel: true,
 };
 
 export const A380AircraftConfig: AircraftConfig = {

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/AircraftConfigTypes.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/AircraftConfigTypes.ts
@@ -187,4 +187,7 @@ export interface FlightModelParameters {
 
 export interface FMSymbolsConfig {
   publishDepartureIdent: boolean;
+
+  /** whether to show RNP label on ND for RNP AR approaches */
+  showRnpArLabel: boolean;
 }

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/GuidanceController.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/GuidanceController.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 FlyByWire Simulations
+// Copyright (c) 2021-2025 FlyByWire Simulations
 //
 // SPDX-License-Identifier: GPL-3.0
 
@@ -171,6 +171,8 @@ export class GuidanceController {
     FmgcFlightPhase.Preflight,
   );
 
+  private readonly approachIdentSize: number;
+
   private updateEfisState(side: EfisSide, state: EfisState<number>): void {
     const ndMode = SimVar.GetSimVarValue(`L:A32NX_EFIS_${side}_ND_MODE`, 'Enum') as EfisNdMode;
     const ndRange = this.efisNDRangeValues[SimVar.GetSimVarValue(`L:A32NX_EFIS_${side}_ND_RANGE`, 'Enum')];
@@ -225,7 +227,7 @@ export class GuidanceController {
 
     if (this.symbolConfig.publishDepartureIdent && phase < FmgcFlightPhase.Cruise) {
       if (this.flightPlanService.active.isDepartureProcedureActive) {
-        apprMsg = this.flightPlanService.active.originDeparture.ident;
+        apprMsg = this.flightPlanService.active.originDeparture.ident.padEnd(this.approachIdentSize);
       }
     } else {
       const runway = this.flightPlanService.active.destinationRunway;
@@ -235,14 +237,20 @@ export class GuidanceController {
         if (phase > FmgcFlightPhase.Cruise || (phase === FmgcFlightPhase.Cruise && distanceToDestination < 250)) {
           const appr = this.flightPlanService.active.approach;
           // Nothing is shown on the ND for runway-by-itself approaches
-          apprMsg = appr && appr.type !== ApproachType.Unknown ? ApproachUtils.longApproachName(appr).padEnd(9) : '';
+          apprMsg =
+            appr && appr.type !== ApproachType.Unknown
+              ? ApproachUtils.longApproachName(appr) +
+                (appr.authorisationRequired && this.symbolConfig.showRnpArLabel ? '(RNP)' : '').padEnd(
+                  this.approachIdentSize,
+                )
+              : '';
         }
       }
     }
 
     if (apprMsg !== this.approachMessage) {
       this.approachMessage = apprMsg;
-      const apprMsgVars = SimVarString.pack(apprMsg, 9);
+      const apprMsgVars = SimVarString.pack(apprMsg, this.approachIdentSize);
       // setting the simvar as a number greater than about 16 million causes precision error > 1... but this works..
       SimVar.SetSimVarValue('L:A32NX_EFIS_L_APPR_MSG_0', 'string', apprMsgVars[0].toString());
       SimVar.SetSimVarValue('L:A32NX_EFIS_L_APPR_MSG_1', 'string', apprMsgVars[1].toString());
@@ -318,6 +326,7 @@ export class GuidanceController {
     this.pseudoWaypoints = new PseudoWaypoints(flightPlanService, this, this.atmosphericConditions, this.acConfig);
     this.efisVectors = new EfisVectors(this.bus, this.flightPlanService, this, efisInterfaces);
     this.symbolConfig = acConfig.fmSymbolConfig;
+    this.approachIdentSize = this.symbolConfig.showRnpArLabel ? 14 : 9;
   }
 
   init() {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Adds RNP label on ND approach identifier for RNP AR approaches (batch 7). Consequently, SID/approach names are aligned to the left for 14 chars.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![SID](https://github.com/user-attachments/assets/5afe0426-1f93-414c-8bbb-83fffa260ae3)
![RNP](https://github.com/user-attachments/assets/2a4b95e1-139f-498a-93b1-ee5e2a158560)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![image](https://github.com/user-attachments/assets/32c7c659-975f-46c5-a7cd-9e302e20da82)
![image](https://github.com/user-attachments/assets/5fbd9e3e-8a1b-4ce1-9c8f-f14b647b62e5)
![SID REF](https://github.com/user-attachments/assets/fd06c1a5-af52-4201-898b-f06c53757ec5)
![SID2](https://github.com/user-attachments/assets/b7d82d94-3c75-45b0-ada2-ff1bbcf05b6a)

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): bruno_pt99

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Program a SID, verify sid identifier appears left aligned as the picture above.
Select an RNP AR approach. Verify (RNP) appears next to the approach identifier once it is appears. 
Select any other approach, verify approach identifier appears left aligned like the reference pictures.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
