### PR TITLE
fix(efb): failure listener registration

### DIFF
--- a/fbw-common/src/systems/shared/src/ViewListenerUtils.ts
+++ b/fbw-common/src/systems/shared/src/ViewListenerUtils.ts
@@ -1,0 +1,9 @@
+export class ViewListenerUtils {
+  public static getListener(listenerName: string, singleton = true): Promise<ViewListener.ViewListener> {
+    return new Promise((resolve, reject) => {
+      let listener: ViewListener.ViewListener | undefined;
+      // eslint-disable-next-line prefer-const
+      listener = RegisterViewListener(listenerName, () => (listener ? resolve(listener) : reject()), singleton);
+    });
+  }
+}

--- a/fbw-common/src/systems/shared/src/failures/failures-orchestrator.ts
+++ b/fbw-common/src/systems/shared/src/failures/failures-orchestrator.ts
@@ -4,6 +4,7 @@
 
 import { AtaChapterNumber } from '../ata';
 import { GenericDataListenerSync } from '../GenericDataListenerSync';
+import { ViewListenerUtils } from '../ViewListenerUtils';
 
 export interface Failure {
   ata: AtaChapterNumber;
@@ -41,15 +42,11 @@ export class FailuresOrchestrator {
       });
     });
 
-    const commBusListener = RegisterViewListener(
-      'JS_LISTENER_COMM_BUS',
-      () => {
-        commBusListener.on('FBW_FAILURE_REQUEST', () => (this.needSendFailures = true));
-        // better send in case we missed a request from a wasm consumer
-        this.needSendFailures = true;
-      },
-      true,
-    );
+    ViewListenerUtils.getListener('JS_LISTENER_COMM_BUS').then((commBusListener) => {
+      commBusListener.on('FBW_FAILURE_REQUEST', () => (this.needSendFailures = true));
+      // better send in case we missed a request from a wasm consumer
+      this.needSendFailures = true;
+    });
   }
 
   private sendFailuresToWasm(activeFailures: number[]): void {

--- a/fbw-common/src/systems/shared/src/failures/failures-orchestrator.ts
+++ b/fbw-common/src/systems/shared/src/failures/failures-orchestrator.ts
@@ -41,10 +41,10 @@ export class FailuresOrchestrator {
       });
     });
 
-    RegisterViewListener(
+    const commBusListener = RegisterViewListener(
       'JS_LISTENER_COMM_BUS',
-      (listener) => {
-        listener.on('FBW_FAILURE_REQUEST', () => (this.needSendFailures = true));
+      () => {
+        commBusListener.on('FBW_FAILURE_REQUEST', () => (this.needSendFailures = true));
         // better send in case we missed a request from a wasm consumer
         this.needSendFailures = true;
       },

--- a/fbw-common/src/systems/shared/src/index.ts
+++ b/fbw-common/src/systems/shared/src/index.ts
@@ -48,3 +48,4 @@ export * from './GPUManagement';
 export * from './Troubleshooting';
 export * from './types';
 export * from './TelexCheck';
+export * from './ViewListenerUtils';

--- a/fbw-common/src/typings/fs-base-ui/html_ui/JS/common.d.ts
+++ b/fbw-common/src/typings/fs-base-ui/html_ui/JS/common.d.ts
@@ -639,10 +639,10 @@ declare global {
         let g_ViewListenersMgr: ViewListenerMgr;
     }
 
-    function RegisterViewListenerT<T>(name: string, callback: (() => void) | void, type: new() => T,
-                                      requiresSingleton?: boolean): T;
-    function RegisterViewListener(name: string, callback?: (listener: ViewListener.ViewListener) => void,
-                                  requiresSingleton?: boolean): ViewListener.ViewListener;
+    function RegisterViewListenerT<T extends ViewListener.ViewListener>(
+      name: string, callback: () => void, type: { new (name: string): T; }, requiresSingleton?: boolean
+    ): T;
+    function RegisterViewListener(name: string, callback?: () => void, requiresSingleton?: boolean): ViewListener.ViewListener;
 
     class Name_Z {
         static isValid(a: Name_Z | void): boolean;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fix the RegisterViewListener typing and fix this call. This didn't cause any user-visible issue as you would only need it to work when you reload a WASM gauge in-flight while some failures already exist on the orchestrator, so no changelog.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Not testable.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
