### PR TITLE
fix(a32nx/fms): FMS entry and element position fixes

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -31,6 +31,9 @@
 1. [FMS] Use proper DME location for AF, CD, FD legs on MSFS2024 and add MSFS2020 fallback to improve AF legs - @tracernz (Mike)
 1. [FMS] Improve CR and FC leg geometry - @tracernz (Mike)
 1. [GENERAL] Fixed inconsistency in the PED/NO SMOKING option when it hasn't been set - @tracernz (Mike)
+1. [A32NX/FMS] Removed required leading zeros for some entries - @Jonny23787 (Jonathan)
+1. [A32NX/FMS] Adjusted TRANS ALT allowed entries - @Jonny23787 (Jonathan)
+1. [A32NX/FMS] Adjusted position of flight phase and flight number on PROG page  - @Jonny23787 (Jonathan)
 
 ## 0.13.0
 

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
@@ -3082,7 +3082,7 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
       return false;
     }
 
-    const match = s.match(/^(([0-9]{4,5})\/?)?(\/([0-9]{4,5}))?$/);
+    const match = s.match(/^(([0-9]{3,5})\/?)?(\/([0-9]{3,5}))?$/);
     if (match === null || (match[2] === undefined && match[4] === undefined) || s.split('/').length > 2) {
       this.setScratchpadMessage(NXSystemMessages.formatError);
       return false;

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
@@ -3044,13 +3044,13 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
     }
 
     let value = parseInt(s);
-    if (!isFinite(value) || !/^\d{4,5}$/.test(s)) {
+    if (!isFinite(value) || !/^\d{1,5}$/.test(s)) {
       this.setScratchpadMessage(NXSystemMessages.formatError);
       return false;
     }
 
     value = Math.round(value / 10) * 10;
-    if (value < 1000 || value > 45000) {
+    if (value < 0 || value > 39800) {
       this.setScratchpadMessage(NXSystemMessages.entryOutOfRange);
       return false;
     }
@@ -4011,12 +4011,12 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
       return true;
     }
 
-    if (!/^\d{4,5}$/.test(s)) {
+    if (!/^\d{1,5}$/.test(s)) {
       this.setScratchpadMessage(NXSystemMessages.formatError);
       return false;
     }
     const value = Math.round(parseInt(s) / 10) * 10;
-    if (value < 1000 || value > 45000) {
+    if (value < 0 || value > 39800) {
       this.setScratchpadMessage(NXSystemMessages.entryOutOfRange);
       return false;
     }

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
@@ -3143,7 +3143,7 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
       return false;
     }
 
-    const match = s.match(/^([0-9]{4,5})$/);
+    const match = s.match(/^([0-9]{3,5})$/);
     if (match === null) {
       this.setScratchpadMessage(NXSystemMessages.formatError);
       return false;
@@ -3187,7 +3187,7 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
       return false;
     }
 
-    const match = s.match(/^(([0-9]{4,5})\/?)?(\/([0-9]{4,5}))?$/);
+    const match = s.match(/^(([0-9]{3,5})\/?)?(\/([0-9]{3,5}))?$/);
     if (match === null || (match[2] === undefined && match[4] === undefined) || s.split('/').length > 2) {
       this.setScratchpadMessage(NXSystemMessages.formatError);
       return false;
@@ -3243,7 +3243,7 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
       return false;
     }
 
-    const match = s.match(/^([0-9]{4,5})$/);
+    const match = s.match(/^([0-9]{3,5})$/);
     if (match === null) {
       this.setScratchpadMessage(NXSystemMessages.formatError);
       return false;

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_ProgressPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_ProgressPage.ts
@@ -181,7 +181,7 @@ export class CDUProgressPage {
     }
 
     mcdu.setTemplate([
-      ['{green}' + flightPhase.padStart(15, '\xa0') + '{end}\xa0' + flightNo.padEnd(11, '\xa0')],
+      ['{green}' + flightPhase.padStart(13, '\xa0') + '{end}\xa0' + flightNo.padEnd(17, '\xa0')],
       ['\xa0' + 'CRZ\xa0', 'OPT\xa0\xa0\xa0\xa0REC MAX'],
       [flCrz, flOpt + '\xa0\xa0\xa0\xa0' + '{magenta}FL' + flMax.toString() + '\xa0{end}'],
       [''],


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8674

## Summary of Changes

- Removed required leading zeros for THR RED/ACC and EO ACC.
- Adjusted TRANS ALT allowed entries to allow values 0 to 39800.
- Adjusted position of flight phase and flight number on PROG page. 

<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
![Screenshot 2025-06-01 115809](https://github.com/user-attachments/assets/f035cfe3-9841-416b-8c74-033d0e215b89)
![Screenshot 2025-06-01 115823](https://github.com/user-attachments/assets/2252cf07-14e0-486a-8319-8d9478d48c70)
![Screenshot 2025-06-01 115838](https://github.com/user-attachments/assets/707d551d-8c70-40b2-bdb9-9a5e41a0f158)
![Screenshot 2025-06-01 115852](https://github.com/user-attachments/assets/d77fca2c-cdc8-4a5b-8a12-c034f607f1e8)
![Screenshot 2025-06-01 121619](https://github.com/user-attachments/assets/491a1274-be0c-4b61-b9cd-738b887437b7)
![Screenshot 2025-06-01 123829](https://github.com/user-attachments/assets/777030cf-8271-44f7-bcff-a0b5da4676ad)
![Screenshot 2025-06-01 125821](https://github.com/user-attachments/assets/631942b4-39d3-4a56-8a36-b36de13f94cd)
![Screenshot 2025-06-01 125846](https://github.com/user-attachments/assets/bb17be83-7439-43bc-8cf4-abd545d57f9d)
![Screenshot 2025-06-01 125904](https://github.com/user-attachments/assets/fb92178a-15ef-482c-bfa2-819fe95c8675)
![Screenshot 2025-06-01 131517](https://github.com/user-attachments/assets/0830a186-3eb2-4744-b822-dbfb63e72a3f)


<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
Pilots
![image](https://github.com/user-attachments/assets/a70a3baa-3916-44ab-95c3-60efe43be9b7)
![image](https://github.com/user-attachments/assets/89c9d850-a9af-4542-b2c7-0a1d977d22ab)
![image](https://github.com/user-attachments/assets/335f45d6-b8db-4a83-a3cf-849ee8a20b50)
#8674 also has references
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
jonny_23

## Testing instructions

1. Enter a FROM/TO airport route and flight number FBW1234.
2. Test that values such as 800/800 and 500 can be entered in the THR RED/ACC and Eng Out ACC respectively. Check that 0800/0800 and 0500 also work.
3. Perform step 1 for the GA page as well, you may need to enter a value of 900 in the Eng Out ACC.
4. Test that 0 and 39800 can be entered in the TRANS ALT, confirm that values such as 39900 give an ENTRY OUT OF RANGE error. Test this on the APPR PEFR page as well.
5. Confirm the flight phase and flight number on the PROG page look like the references/screenshots.
6. Takeoff and check that the CLB or CRZ flight phase matches the position of the references/screenshots.

<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
