### PR TITLE
feat(lgciu): added `DISCRETE_WORD_4` in LGCIU

### DIFF
--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -4018,6 +4018,19 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
       | 27  | LH Nose gear door fully open      |
       | 28  | RH Nose gear door fully open      |
 
+- A32NX_LGCIU_{number}_DISCRETE_WORD_4
+    - Discrete Data word 4 of the LGCIU bus output
+    - Arinc429<Discrete>
+    - {number}
+        - 1
+        - 2
+    - | Bit |             Description             |
+      |:---:|:-----------------------------------:|
+      | 21  | LH flap attachment failure detected |
+      | 22  | LH flap attachment sensor valid     |
+      | 25  | RH flap attachment failure detected |
+      | 26  | RH flap attachment sensor valid     |
+
 - A32NX_LGCIU_{number}_{gear}_GEAR_COMPRESSED
     - Indicates if the shock absorber is compressed (not fully extended)
     - Bool

--- a/fbw-common/src/wasm/systems/systems/src/landing_gear/mod.rs
+++ b/fbw-common/src/wasm/systems/systems/src/landing_gear/mod.rs
@@ -879,6 +879,7 @@ pub struct LandingGearControlInterfaceUnit {
     discrete_word_1_id: VariableIdentifier,
     discrete_word_2_id: VariableIdentifier,
     discrete_word_3_id: VariableIdentifier,
+    discrete_word_4_id: VariableIdentifier,
 
     is_powered: bool,
     is_powered_previous_state: bool,
@@ -944,6 +945,8 @@ impl LandingGearControlInterfaceUnit {
                 .get_identifier(format!("LGCIU_{}_DISCRETE_WORD_2", lgciu_number(lgciu_id))),
             discrete_word_3_id: context
                 .get_identifier(format!("LGCIU_{}_DISCRETE_WORD_3", lgciu_number(lgciu_id))),
+            discrete_word_4_id: context
+                .get_identifier(format!("LGCIU_{}_DISCRETE_WORD_4", lgciu_number(lgciu_id))),
 
             is_powered: false,
             is_powered_previous_state: false,
@@ -1221,6 +1224,32 @@ impl LandingGearControlInterfaceUnit {
             word
         }
     }
+
+    pub fn discrete_word_4(&self) -> Arinc429Word<u32> {
+        if !self.is_powered {
+            Arinc429Word::new(0, SignStatus::FailureWarning)
+        } else {
+            // Label 23
+            let mut word = Arinc429Word::new(0, SignStatus::NormalOperation);
+
+            // If the differential movement between the inboard and outboard flap is more than 15mm, sensors send failure signal.
+            // Failures not implemented.
+
+            // LH Flap attachment failure
+            word.set_bit(21, false);
+
+            // LH flat attachment sensor valid
+            word.set_bit(22, true);
+
+            // RH Flap attachment failure
+            word.set_bit(25, false);
+
+            // RH flat attachment sensor valid
+            word.set_bit(26, true);
+
+            word
+        }
+    }
 }
 impl SimulationElement for LandingGearControlInterfaceUnit {
     fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
@@ -1278,6 +1307,7 @@ impl SimulationElement for LandingGearControlInterfaceUnit {
         writer.write(&self.discrete_word_1_id, self.discrete_word_1());
         writer.write(&self.discrete_word_2_id, self.discrete_word_2());
         writer.write(&self.discrete_word_3_id, self.discrete_word_3());
+        writer.write(&self.discrete_word_4_id, self.discrete_word_4());
     }
 }
 
@@ -1742,6 +1772,45 @@ mod tests {
 
     fn test_bed_in_flight_with() -> LgciusTestBed {
         test_bed(StartState::Cruise)
+    }
+
+    #[test]
+    fn landing_gear_simvars() {
+        let test_bed = test_bed_on_ground_with().on_the_ground();
+
+        assert!(test_bed.contains_variable_with_name("LGCIU_1_NOSE_GEAR_COMPRESSED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_2_NOSE_GEAR_COMPRESSED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_1_LEFT_GEAR_COMPRESSED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_2_LEFT_GEAR_COMPRESSED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_1_RIGHT_GEAR_COMPRESSED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_2_RIGHT_GEAR_COMPRESSED"));
+
+        assert!(test_bed.contains_variable_with_name("GEAR_HANDLE_POSITION"));
+        assert!(test_bed.contains_variable_with_name("GEAR_LEVER_POSITION_REQUEST"));
+        assert!(test_bed.contains_variable_with_name("GEAR_HANDLE_HITS_LOCK_SOUND"));
+
+        assert!(test_bed.contains_variable_with_name("LGCIU_1_LEFT_GEAR_DOWNLOCKED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_2_LEFT_GEAR_DOWNLOCKED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_1_LEFT_GEAR_UNLOCKED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_2_LEFT_GEAR_UNLOCKED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_1_NOSE_GEAR_DOWNLOCKED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_2_NOSE_GEAR_DOWNLOCKED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_1_NOSE_GEAR_UNLOCKED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_2_NOSE_GEAR_UNLOCKED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_1_RIGHT_GEAR_DOWNLOCKED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_2_RIGHT_GEAR_DOWNLOCKED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_1_RIGHT_GEAR_UNLOCKED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_2_RIGHT_GEAR_UNLOCKED"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_1_FAULT"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_2_FAULT"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_1_DISCRETE_WORD_1"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_2_DISCRETE_WORD_1"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_1_DISCRETE_WORD_2"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_2_DISCRETE_WORD_2"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_1_DISCRETE_WORD_3"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_2_DISCRETE_WORD_3"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_1_DISCRETE_WORD_4"));
+        assert!(test_bed.contains_variable_with_name("LGCIU_2_DISCRETE_WORD_4"));
     }
 
     #[test]


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This change completes the ARINC interface of the LGCIU by adding `DISCRETE_WORD_4`.

This new ARINC label is currently unused, but it will become relevant for the rewrite of the SFCC (and potentially other components).

No failures are considered.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Not necessary

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->
LGCIU Interface

## Additional context
<!-- Add any other context about the pull request here. -->
I would like to continue the work started in the draft PR #7632 which aims to rewrite the SFCC. Instead of making a big PR, I would like to make incremental changes.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): pythonist

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
This change doesn't introduce any visual change. Perform a standard circuit and verify normal aircraft operation.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
