### PR TITLE
fix(pfd): metric alt dead

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/PFD/AltitudeIndicator.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/AltitudeIndicator.tsx
@@ -893,7 +893,6 @@ class AltimeterIndicator extends DisplayComponent<AltimeterIndicatorProps> {
 }
 
 interface MetricAltIndicatorState {
-  altitude: Arinc429WordData;
   targetAlt: Arinc429WordData;
   altitudeColor: TargetAltitudeColor;
   fcuDiscreteWord1: Arinc429Word;
@@ -924,7 +923,6 @@ class MetricAltIndicator extends DisplayComponent<MetricAltIndicatorProps> {
 
   // FIXME remove this weird pattern... the state of the component belongs directly to the component
   private state: MetricAltIndicatorState = {
-    altitude: new Arinc429Word(0),
     altitudeColor: TargetAltitudeColor.Cyan,
     targetAlt: new Arinc429Word(0),
     fcuDiscreteWord1: new Arinc429Word(0),
@@ -1003,7 +1001,7 @@ class MetricAltIndicator extends DisplayComponent<MetricAltIndicatorProps> {
         this.metricAlt.instance.style.display = 'none';
       } else {
         this.metricAlt.instance.style.display = 'inline';
-        const currentMetricAlt = Math.round((this.state.altitude.value * 0.3048) / 10) * 10;
+        const currentMetricAlt = Math.round((this.altitude.get().value * 0.3048) / 10) * 10;
         this.metricAltText.instance.textContent = currentMetricAlt.toString();
 
         const targetMetric = Math.round((this.state.targetAlt.value * 0.3048) / 10) * 10;
@@ -1014,7 +1012,7 @@ class MetricAltIndicator extends DisplayComponent<MetricAltIndicatorProps> {
         if (
           !this.mda.get().isNoComputedData() &&
           !this.mda.get().isFailureWarning() &&
-          this.state.altitude.value < this.mda.get().value
+          this.altitude.get().value < this.mda.get().value
         ) {
           this.metricAltText.instance.classList.replace('Green', 'Amber');
         } else {

--- a/fbw-a380x/src/systems/instruments/src/PFD/AltitudeIndicator.tsx
+++ b/fbw-a380x/src/systems/instruments/src/PFD/AltitudeIndicator.tsx
@@ -839,7 +839,6 @@ class AltimeterIndicator extends DisplayComponent<AltimeterIndicatorProps> {
 }
 
 interface MetricAltIndicatorState {
-  altitude: Arinc429Word;
   MDA: number;
   targetAltSelected: number;
   targetAltManaged: number;
@@ -860,8 +859,8 @@ class MetricAltIndicator extends DisplayComponent<{ bus: ArincEventBus }> {
 
   private metricAltTargetText = FSComponent.createRef<SVGTextElement>();
 
+  // FIXME remove this weird pattern... the state of the component belongs directly to the component
   private state: MetricAltIndicatorState = {
-    altitude: new Arinc429Word(0),
     MDA: 0,
     targetAltSelected: 0,
     targetAltManaged: 0,
@@ -915,7 +914,7 @@ class MetricAltIndicator extends DisplayComponent<{ bus: ArincEventBus }> {
         this.metricAlt.instance.style.display = 'none';
       } else {
         this.metricAlt.instance.style.display = 'inline';
-        const currentMetricAlt = Math.round((this.state.altitude.value * 0.3048) / 10) * 10;
+        const currentMetricAlt = Math.round((this.altitude.get().value * 0.3048) / 10) * 10;
         this.metricAltText.instance.textContent = currentMetricAlt.toString();
 
         const targetMetric =
@@ -930,7 +929,7 @@ class MetricAltIndicator extends DisplayComponent<{ bus: ArincEventBus }> {
           this.metricAltTargetText.instance.classList.replace('Magenta', 'Cyan');
         }
 
-        if (this.state.altitude.value < this.state.MDA) {
+        if (this.altitude.get().value < this.state.MDA) {
           this.metricAltText.instance.classList.replace('Green', 'Amber');
         } else {
           this.metricAltText.instance.classList.replace('Amber', 'Green');


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes the metric altitude not working since #9659. I missed the wonky pattern with the state object inside the component when bulk updating the altitude consumers. Copied the FIXME from the 320 to the 380 PFD as well. Didn't want to fix the whole thing here as I want a quick fix that can be merged straight away.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
