### PR TITLE
fix(a380x/rmp): amu not reading rmp state

### DIFF
--- a/fbw-a380x/src/systems/systems-host/systems/Communications/AudioManagementUnit.ts
+++ b/fbw-a380x/src/systems/systems-host/systems/Communications/AudioManagementUnit.ts
@@ -11,7 +11,7 @@ import {
   Subscribable,
 } from '@microsoft/msfs-sdk';
 import { RadioNavSelectedNavaid, RmpAmuBusEvents } from './RmpAmuBusPublisher';
-import { FailuresConsumer, RmpState } from '@flybywiresim/fbw-sdk';
+import { FailuresConsumer, RegisteredSimVar, RmpState } from '@flybywiresim/fbw-sdk';
 import { A380Failure } from '@failures';
 
 export type AmuIndex = 1 | 2;
@@ -32,16 +32,11 @@ export class AudioManagementUnit implements Instrument {
   private readonly onsideRmpIndex = this.index;
   private readonly offsideRmpIndex = this.index === 2 ? 1 : 2;
 
-  private readonly onsideRmpStateLocalVar = SimVar.GetRegisteredId(
-    `A380X_RMP_${this.onsideRmpIndex}_STATE`,
+  private readonly onsideRmpStateLocalVar = RegisteredSimVar.create<number>(
+    `L:A380X_RMP_${this.onsideRmpIndex}_STATE`,
     SimVarValueType.Enum,
-    document.title,
   );
-  private readonly rmp3StateLocalVar = SimVar.GetRegisteredId(
-    `A380X_RMP_3_STATE`,
-    SimVarValueType.Enum,
-    document.title,
-  );
+  private readonly rmp3StateLocalVar = RegisteredSimVar.create<number>(`L:A380X_RMP_3_STATE`, SimVarValueType.Enum);
 
   private readonly mainPowerVar = 'L:A32NX_ELEC_DC_ESS_BUS_IS_POWERED';
 
@@ -111,10 +106,8 @@ export class AudioManagementUnit implements Instrument {
     const powered = SimVar.GetSimVarValue(this.mainPowerVar, SimVarValueType.Bool) > 0;
     this._isHealthy.set(!failed && powered);
 
-    this.onsideRmpSwitchedOn.set(
-      AudioManagementUnit.isRmpOn(SimVar.GetSimVarValueFastReg(this.onsideRmpStateLocalVar)),
-    );
-    this.rmp3SwitchedOn.set(AudioManagementUnit.isRmpOn(SimVar.GetSimVarValueFastReg(this.rmp3StateLocalVar)));
+    this.onsideRmpSwitchedOn.set(AudioManagementUnit.isRmpOn(this.onsideRmpStateLocalVar.get()));
+    this.rmp3SwitchedOn.set(AudioManagementUnit.isRmpOn(this.rmp3StateLocalVar.get()));
   }
 
   public getActiveNavAudio(): RadioNavSelectedNavaid {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes an issue where the AMU would not read the RMP states correctly, and end up falling back to the offside RMP.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Check that the COM RECEIVE EX1 and COM TRANSMIT vars line up with the selections on the pilot's RMP (either auto or manually selected in flypad sim settings).

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
