### PR TITLE
fix(a380x/mfd): fix mfd tab navigator outer edge color styling

### DIFF
--- a/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/UiWidgets/TopTabNavigator.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/UiWidgets/TopTabNavigator.tsx
@@ -57,7 +57,7 @@ class TopTabElement extends DisplayComponent<TopTabElementProps> {
         <svg height={this.props.height} width={this.triangleWidth}>
           <polygon
             points={`0,${this.props.height} ${this.triangleWidth},0 ${this.triangleWidth},${this.props.height}`}
-            style={`fill:${this.props.isSelected ? '#000000' : '#3c3c3c'};`}
+            style={`fill:${this.props.isSelected ? '#000000' : '#272525'};`}
           />
           <line
             x1="0"
@@ -87,7 +87,7 @@ class TopTabElement extends DisplayComponent<TopTabElementProps> {
         <svg height={this.props.height} width={this.triangleWidth}>
           <polygon
             points={`0,0 ${this.triangleWidth},${this.props.height} 0,${this.props.height}`}
-            style={`fill:${this.props.isSelected ? '#000000' : '#3c3c3c'};`}
+            style={`fill:${this.props.isSelected ? '#000000' : '#272525'};`}
           />
           <line
             x1="0"


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Fix color of the outside edge of the MFD tabs not matching the label. The colour of the tab should be uniform.

BEFORE
![image](https://github.com/user-attachments/assets/9a5cef52-9e97-41da-953e-8693040b1866)

AFTER
![image](https://github.com/user-attachments/assets/c01c3d5b-74ae-4db8-8807-d238111a9778)


## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

![image](https://github.com/user-attachments/assets/e9dc0d81-66fc-46b8-846f-3ecda04ccd36)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Check tabs color are uniform.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
