### PR TITLE
fix(nd): GS, TAS & wind data not taking source switching into account

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -55,6 +55,7 @@
 1. [A380X/RMP] Added standby mode handling for VHF3 - @tracernz (Mike)
 1. [A380X/RMP] Keep the ATC frequency tuned when spawning on the runway in MSFS2024 - @tracernz (Mike)
 1. [A32NX/ND] Fixed ND range change & mode change font size - @Lucas-IQ21 (Lucas)
+1. [ND] Fixed TAS, GS & Wind data not taking source switching into account - @BravoMike99 (bruno_pt99)
 
 ## 0.13.0
 

--- a/fbw-a32nx/src/systems/instruments/src/MsfsAvionicsCommon/AdirsValueProvider.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/MsfsAvionicsCommon/AdirsValueProvider.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 FlyByWire Simulations
+// Copyright (c) 2021-2025 FlyByWire Simulations
 //
 // SPDX-License-Identifier: GPL-3.0
 
@@ -77,6 +77,19 @@ export class AdirsValueProvider<T extends AdirsSimVars> {
           name: `L:A32NX_ADIRS_IR_${inertialSource}_TRUE_TRACK`,
           type: SimVarValueType.Number,
         });
+        this.varProvider.updateSimVarSource('groundSpeed', {
+          name: `L:A32NX_ADIRS_IR_${inertialSource}_GROUND_SPEED`,
+          type: SimVarValueType.Number,
+        });
+        this.varProvider.updateSimVarSource('windSpeed', {
+          name: `L:A32NX_ADIRS_IR_${inertialSource}_WIND_SPEED_BNR`,
+          type: SimVarValueType.Number,
+        });
+
+        this.varProvider.updateSimVarSource('windDirection', {
+          name: `L:A32NX_ADIRS_IR_${inertialSource}_WIND_DIRECTION_BNR`,
+          type: SimVarValueType.Number,
+        });
       });
 
     sub
@@ -102,6 +115,10 @@ export class AdirsValueProvider<T extends AdirsSimVars> {
         });
         this.varProvider.updateSimVarSource('mach', {
           name: `L:A32NX_ADIRS_ADR_${airSource}_MACH`,
+          type: SimVarValueType.Number,
+        });
+        this.varProvider.updateSimVarSource('trueAirSpeed', {
+          name: `L:A32NX_ADIRS_ADR_${airSource}_TRUE_AIRSPEED`,
           type: SimVarValueType.Number,
         });
       });

--- a/fbw-a380x/src/systems/instruments/src/PFD/shared/AdirsValueProvider.tsx
+++ b/fbw-a380x/src/systems/instruments/src/PFD/shared/AdirsValueProvider.tsx
@@ -46,6 +46,10 @@ export class AdirsValueProvider implements Instrument {
           name: `L:A32NX_ADIRS_IR_${inertialSource}_DRIFT_ANGLE`,
           type: SimVarValueType.Number,
         });
+        this.pfdSimvar.updateSimVarSource('groundSpeed', {
+          name: `L:A32NX_ADIRS_IR_${inertialSource}_GROUND_SPEED`,
+          type: SimVarValueType.Number,
+        });
       });
 
     sub


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes ground speed, true airspeed & wind data not taking ADIRS source switching into account.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): bruno_pt99

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
A32NX or A380X, your choice:
In the air:
Verify TAS, GS & wind data is available with IR & ADR1 on.
Turn IR & ADR 1 off, verify TAS, GS & Wind data is lost on the left side ND.
Turn the ATT HDG switching knob to CAPT 3. Verify GS & wind data is recovered on the left side ND.
Turn the AIR DATA switching knob to CAPT3. Verify TAS data is recovered on the left side ND.
Turn IR & ADR3 off. Verify TAS, GS & Wind data are lost.
Repeat the previous process but for the right side (IR & ADR2 & FO3 instead of CAPT ON 3)


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
