### PR TITLE
build: allow USE_4K_TEXTURES to be defined by environment

### DIFF
--- a/.github/Contributing.md
+++ b/.github/Contributing.md
@@ -33,7 +33,7 @@ git submodule update --init
 
 Note that you should use `run.sh` instead of `run.cmd` if you are on Linux (including WSL).
 
-To build only the A32NX or the A380X, change `build.sh` to `build_a32nx.sh` or `build_a380x.sh`. To build the A380X with 4K textures instead of maximum quality (8K), add the `-4k` flag at the end of the command.
+To build only the A32NX or the A380X, change `build.sh` to `build_a32nx.sh` or `build_a380x.sh`. To build the A380X with 4K textures instead of maximum quality (8K), add the `-4k` flag at the end of the command. Alternatively you can define the `USE_4K_TEXTURES=true` environment variable in a `.env` file at the root of the repo.
 
 If you are using WSL, ensure that the `Vmmem` process is not memory limited. At least `10GB` of memory is the recommended setting. This can be configured in `C:\<user>\.wslconfig`.
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@ set -e
 ORIGINAL_USER_ID=$(stat -c '%u' /external)
 ORIGINAL_GROUP_ID=$(stat -c '%g' /external)
 
-USE_4K_TEXTURES="false"
+[[ -z "${USE_4K_TEXTURES}" ]] && USE_4K_TEXTURES='false'
 
 # set ownership to root to fix cargo/rust build (when run as github action)
 if [ "${GITHUB_ACTIONS}" == "true" ]; then

--- a/scripts/build_a380x.sh
+++ b/scripts/build_a380x.sh
@@ -7,7 +7,7 @@ ORIGINAL_USER_ID=$(stat -c '%u' /external)
 ORIGINAL_GROUP_ID=$(stat -c '%g' /external)
 
 AIRCRAFT_PROJECT_PREFIX="a380x"
-USE_4K_TEXTURES="false"
+[[ -z "${USE_4K_TEXTURES}" ]] && USE_4K_TEXTURES='false'
 
 # set ownership to root to fix cargo/rust build (when run as github action)
 if [ "${GITHUB_ACTIONS}" == "true" ]; then

--- a/scripts/dev-env/run-local.cmd
+++ b/scripts/dev-env/run-local.cmd
@@ -5,4 +5,4 @@ rem This is a script to use a locally built docker image to run the tests
 set image="sha256:1d5abe77849b0e6ff97a9d1698857cc0497f5982b28e7077cc3fffbed9e0069b"
 
 docker image inspect %image% 1> nul || docker system prune --filter label=flybywiresim=true -f
-docker run --rm -it -v "%cd%:/external" %image% %*
+docker run --rm -it -v "%cd%:/external" --env-file "%cd%/.env" %image% %*

--- a/scripts/dev-env/run.cmd
+++ b/scripts/dev-env/run.cmd
@@ -3,4 +3,4 @@
 set image="ghcr.io/flybywiresim/dev-env@sha256:1d5abe77849b0e6ff97a9d1698857cc0497f5982b28e7077cc3fffbed9e0069b"
 
 docker image inspect %image% 1> nul || docker system prune --filter label=flybywiresim=true -f
-docker run --rm -it -v "%cd%:/external" %image% %*
+docker run --rm -it -v "%cd%:/external" --env-file "%cd%/.env" %image% %*


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Allows the 4k texture variable to come from the environment, and loads the .env into the container for local builds. Now I don't need to try remember the -4k flag when I work on the 380.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
