### PR TITLE
fix(a380x): fix c-chord when baro alti changes in std

### DIFF
--- a/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsFlightPhases.ts
+++ b/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsFlightPhases.ts
@@ -473,12 +473,9 @@ export class FwsFlightPhases {
       return;
     }
 
-    // FIXME better altitude selection
-    this.adrAltitude.setFromSimVar(`L:A32NX_ADIRS_ADR_1_BARO_CORRECTED_ALTITUDE_${this.fws.fwsNumber}`);
-    if (!this.adrAltitude.isNormalOperation()) {
-      return;
-    }
-    const delta = Math.abs(this.adrAltitude.value - targetAltitude);
+    // FIXME Needs ADR and FCU words + proper alt selection.. might as well just go proper logic at that point
+    const altitude = Simplane.getAltitude();
+    const delta = Math.abs(altitude - targetAltitude);
 
     if (delta < 200) {
       this._wasBelowThreshold = true;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Change the A380X to use Simplane like the A32NX for now to work around the logic being inadequate.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Capture an FCU altitude in STD mode. Adjust the baro pre-select so it's more than 200 feet different to pressure alt and make sure there's no c-chord.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
