### PR TITLE
fix(efb): rename us units option to reflect reality

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -62,6 +62,7 @@
 1. [A32NX/SD] Add flashing for AUTO BRK element - @Jonny23787 (Jonathan) & @BlueberryKing (BlueberryKing)
 1. [A32NX/FMS] Change GA PERF speeds to match APPR PERF speeds - @Jonny23787 (Jonathan)
 1. [EFB] Fixed overflow on settings pages when the page is too long - @heclak (Heclak)
+1. [EFB] Renamed "Weight Unit" pin program to "US Units" to reflect it's actual effect and real-world name - @tracernz (Mike)
 
 ## 0.13.0
 

--- a/fbw-common/src/systems/instruments/src/EFB/Localization/data/en.json
+++ b/fbw-common/src/systems/instruments/src/EFB/Localization/data/en.json
@@ -585,7 +585,7 @@
       "Select": "Select",
       "ThrustReductionHeight": "Thrust Reduction Height (ft)",
       "Title": "Aircraft Options / Pin Programs",
-      "WeightUnit": "Weight Unit"
+      "WeightUnit": "US Units"
     },
     "AutomaticCallOuts": {
       "Title": "Automatic Call Outs",

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/AircraftOptionsPinProgramsPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/AircraftOptionsPinProgramsPage.tsx
@@ -72,11 +72,6 @@ export const AircraftOptionsPinProgramsPage = () => {
     { name: 'No Portable Device', setting: '1' },
   ];
 
-  const weightUnitButtons: ButtonType[] = [
-    { name: 'No', setting: '1' },
-    { name: 'Yes', setting: '0' },
-  ];
-
   const isisBaroButtons: ButtonType[] = [
     { name: 'hPa', setting: '0' },
     { name: 'hPa/inHg', setting: '1' },
@@ -193,17 +188,7 @@ export const AircraftOptionsPinProgramsPage = () => {
           )}
 
           <SettingItem name={t('Settings.AircraftOptionsPinPrograms.WeightUnit')}>
-            <SelectGroup>
-              {weightUnitButtons.map((button) => (
-                <SelectItem
-                  key={button.name}
-                  onSelect={() => setUsingMetric(button.setting)}
-                  selected={usingMetric === button.setting}
-                >
-                  {button.name}
-                </SelectItem>
-              ))}
-            </SelectGroup>
+            <Toggle value={usingMetric === '0'} onToggle={(value) => setUsingMetric(value ? '0' : '1')} />
           </SettingItem>
           {aircraftContext.settingsPages.pinProgram.satcom && (
             <SettingItem name={t('Settings.AircraftOptionsPinPrograms.Satcom')}>

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/AircraftOptionsPinProgramsPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/AircraftOptionsPinProgramsPage.tsx
@@ -73,8 +73,8 @@ export const AircraftOptionsPinProgramsPage = () => {
   ];
 
   const weightUnitButtons: ButtonType[] = [
-    { name: 'kg', setting: '1' },
-    { name: 'lbs', setting: '0' },
+    { name: 'No', setting: '1' },
+    { name: 'Yes', setting: '0' },
   ];
 
   const isisBaroButtons: ButtonType[] = [


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Rename the "Weight Unit" pin program to it's actual name "US Units", and turn it into a toggle. Many users were confused when it affects more than just weights.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

Before:
![image](https://github.com/user-attachments/assets/5380ec9a-bf4c-43e0-81bf-89ce70d971ab)

After:
![image](https://github.com/user-attachments/assets/255a619c-be7c-47b1-aa71-8e6fd6cfacc7)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Make sure the option still works on the weights, runway lengths, and cabin temperatures.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
