### PR TITLE
fix(A32X/MCDU): use NXUnits on arrival airport runway lengths

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -63,6 +63,7 @@
 1. [A32NX/FMS] Change GA PERF speeds to match APPR PERF speeds - @Jonny23787 (Jonathan)
 1. [EFB] Fixed overflow on settings pages when the page is too long - @heclak (Heclak)
 1. [EFB] Renamed "Weight Unit" pin program to "US Units" to reflect it's actual effect and real-world name - @tracernz (Mike)
+1. [A32NX/MCDU] Fix units on arrival airport runway lenghts - @Lucas-IQ21 (Lucas)
 
 ## 0.13.0
 

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AvailableArrivalsPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AvailableArrivalsPage.ts
@@ -23,6 +23,7 @@ import {
   ApproachType,
   ApproachUtils,
   Arrival,
+  NXUnits,
   Runway,
   RunwayUtils,
 } from '@flybywiresim/fbw-sdk';
@@ -221,7 +222,7 @@ export class CDUAvailableArrivalsPage {
             rows[2 * i] = [
               `{${color}}${!isSelected ? '{' : '{sp}'}${ApproachUtils.shortApproachName(approachOrRunway)}{end}`,
               '',
-              `{sp}{sp}{sp}${runwayLength}{small}M{end}[color]${color}`,
+              `{sp}{sp}{sp}${NXUnits.mToUser(runwayLength).toFixed(0).padStart(6, '\xa0')}{small}${NXUnits.userDistanceUnit().padEnd(2)}{end}{end}[color]${color}`,
             ];
             rows[2 * i + 1] = [`{${color}}{sp}{sp}{sp}${runwayCourse}${ilsText}{end}`];
           }
@@ -262,7 +263,7 @@ export class CDUAvailableArrivalsPage {
           rows[2 * i] = [
             `{${color}}${!isSelected ? '{' : '{sp}'}${RunwayUtils.runwayString(approachOrRunway.ident)}{end}`,
             '',
-            `{sp}{sp}{sp}${runwayLength}{small}M{end}[color]${color}`,
+            `{sp}{sp}{sp}${NXUnits.mToUser(runwayLength).toFixed(0).padStart(6, '\xa0')}{small}${NXUnits.userDistanceUnit().padEnd(2)}{end}{end}[color]${color}`,
           ];
           rows[2 * i + 1] = ['{sp}{sp}{sp}{sp}' + runwayCourse + '[color]cyan'];
 

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AvailableArrivalsPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AvailableArrivalsPage.ts
@@ -222,7 +222,7 @@ export class CDUAvailableArrivalsPage {
             rows[2 * i] = [
               `{${color}}${!isSelected ? '{' : '{sp}'}${ApproachUtils.shortApproachName(approachOrRunway)}{end}`,
               '',
-              `{sp}{sp}{sp}${NXUnits.mToUser(runwayLength).toFixed(0).padStart(6, '\xa0')}{small}${NXUnits.userDistanceUnit().padEnd(2)}{end}{end}[color]${color}`,
+              `{sp}{sp}${NXUnits.mToUser(runwayLength).toFixed(0).padStart(6, '\xa0')}{small}${NXUnits.userDistanceUnit().padEnd(2)}{end}[color]${color}`,
             ];
             rows[2 * i + 1] = [`{${color}}{sp}{sp}{sp}${runwayCourse}${ilsText}{end}`];
           }
@@ -263,9 +263,9 @@ export class CDUAvailableArrivalsPage {
           rows[2 * i] = [
             `{${color}}${!isSelected ? '{' : '{sp}'}${RunwayUtils.runwayString(approachOrRunway.ident)}{end}`,
             '',
-            `{sp}{sp}{sp}${NXUnits.mToUser(runwayLength).toFixed(0).padStart(6, '\xa0')}{small}${NXUnits.userDistanceUnit().padEnd(2)}{end}{end}[color]${color}`,
+            `{sp}{sp}${NXUnits.mToUser(runwayLength).toFixed(0).padStart(6, '\xa0')}{small}${NXUnits.userDistanceUnit().padEnd(2)}{end}[color]${color}`,
           ];
-          rows[2 * i + 1] = ['{sp}{sp}{sp}{sp}' + runwayCourse + '[color]cyan'];
+          rows[2 * i + 1] = ['{sp}{sp}{sp}' + runwayCourse + '[color]cyan'];
 
           mcdu.onLeftInput[i + 2] = async (_, scratchpadCallback) => {
             // Clicking the already selected runway is not allowed


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #10155 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Improved arrival runway length display: replaced fixed meter value with user selected unit using `NXUnits.mToUser(...)`, including proper formatting and alignment.

<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://github.com/user-attachments/assets/23269326-efa3-48e5-8196-65eedbe82548)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): lucasiq

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Enable US units on EFB
1. Load a flight plan
1. Check rwy lenght units in the arrival page

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
