### PR TITLE
fix(a32nx/fms): fix automatic cruise temperature calculation according to isa

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -64,6 +64,7 @@
 1. [EFB] Fixed overflow on settings pages when the page is too long - @heclak (Heclak)
 1. [EFB] Renamed "Weight Unit" pin program to "US Units" to reflect it's actual effect and real-world name - @tracernz (Mike)
 1. [A32NX/MCDU] Fix units on arrival airport runway lenghts - @Lucas-IQ21 (Lucas)
+1. [A32NX/FMS] Fix automatic cruise temperature calculation on INIT A page - @BlueberryKing (BlueberryKing)
 
 ## 0.13.0
 

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
@@ -314,7 +314,6 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
   public guidanceController?: GuidanceController;
   public navigation?: Navigation;
 
-  public tempCurve;
   public casToMachManualCrossoverCurve;
   public machToCasManualCrossoverCurve;
 
@@ -393,12 +392,6 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
     this.efisSymbolsLeft.init();
     this.efisSymbolsRight.init();
     this.navigation.init();
-
-    this.tempCurve = new Avionics.Curve();
-    this.tempCurve.interpolationFunction = Avionics.CurveTool.NumberInterpolation;
-    this.tempCurve.add(-6.1 * 3.28084, 19.0);
-    this.tempCurve.add(0, 15.0);
-    this.tempCurve.add(110 * 3.28084, -56.5);
 
     // This is used to determine the Mach number corresponding to a CAS at the manual crossover altitude
     // The curve was calculated numerically and approximated using a few interpolated values

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
@@ -396,27 +396,9 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
 
     this.tempCurve = new Avionics.Curve();
     this.tempCurve.interpolationFunction = Avionics.CurveTool.NumberInterpolation;
-    this.tempCurve.add(-10 * 3.28084, 21.5);
+    this.tempCurve.add(-6.1 * 3.28084, 19.0);
     this.tempCurve.add(0, 15.0);
-    this.tempCurve.add(10 * 3.28084, 8.5);
-    this.tempCurve.add(20 * 3.28084, 2.0);
-    this.tempCurve.add(30 * 3.28084, -4.49);
-    this.tempCurve.add(40 * 3.28084, -10.98);
-    this.tempCurve.add(50 * 3.28084, -17.47);
-    this.tempCurve.add(60 * 3.28084, -23.96);
-    this.tempCurve.add(70 * 3.28084, -30.45);
-    this.tempCurve.add(80 * 3.28084, -36.94);
-    this.tempCurve.add(90 * 3.28084, -43.42);
-    this.tempCurve.add(100 * 3.28084, -49.9);
-    this.tempCurve.add(150 * 3.28084, -56.5);
-    this.tempCurve.add(200 * 3.28084, -56.5);
-    this.tempCurve.add(250 * 3.28084, -51.6);
-    this.tempCurve.add(300 * 3.28084, -46.64);
-    this.tempCurve.add(400 * 3.28084, -22.8);
-    this.tempCurve.add(500 * 3.28084, -2.5);
-    this.tempCurve.add(600 * 3.28084, -26.13);
-    this.tempCurve.add(700 * 3.28084, -53.57);
-    this.tempCurve.add(800 * 3.28084, -74.51);
+    this.tempCurve.add(110 * 3.28084, -56.5);
 
     // This is used to determine the Mach number corresponding to a CAS at the manual crossover altitude
     // The curve was calculated numerically and approximated using a few interpolated values

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/LegacyFmsPageInterface.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/LegacyFmsPageInterface.ts
@@ -252,7 +252,6 @@ interface LegacyFmsPageFmsInterface extends FmsDataInterface, FmsDisplayInterfac
   costIndex: number | undefined;
   cruiseLevel: number | undefined;
   cruiseTemperature?: number;
-  tempCurve: any; // we don't have the MSFS SDK typings for these curves
   casToMachManualCrossoverCurve: any;
   machToCasManualCrossoverCurve: any;
   tropo: number | undefined;

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_InitPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_InitPage.ts
@@ -15,6 +15,7 @@ import { LegacyFmsPageInterface } from '../legacy/LegacyFmsPageInterface';
 import { FuelPlanningPhases } from '../legacy/A32NX_Core/A32NX_FuelPred';
 import { FmsFormatters } from '../legacy/FmsFormatters';
 import { SimBriefUplinkAdapter } from '@fmgc/flightplanning/uplink/SimBriefUplinkAdapter';
+import { AeroMath } from '@microsoft/msfs-sdk';
 
 export class CDUInitPage {
   static ShowPage1(mcdu: LegacyFmsPageInterface) {
@@ -143,7 +144,7 @@ export class CDUInitPage {
             cruiseFlTempSeparator.updateAttributes(Column.cyan);
           } else {
             cruiseTemp.update(
-              CDUInitPage.formatTemperature(Math.round(mcdu.tempCurve.evaluate(mcdu.cruiseLevel))),
+              CDUInitPage.formatTemperature(Math.round(AeroMath.isaTemperature(mcdu.cruiseLevel * 100 * 0.3048))),
               Column.cyan,
               Column.small,
             );


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #10171

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes the automatic cruise temperature calculation to follow the ISA profile

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before:
![Screenshot 2025-06-21 222855](https://github.com/user-attachments/assets/41a81322-b107-45fc-b788-4965325d19da)
After:
![image](https://github.com/user-attachments/assets/06299514-ffde-46e7-a2fd-4547fd499ed6)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![Screenshot 2025-06-21 222650](https://github.com/user-attachments/assets/0ce0913d-cec6-43f5-b044-198b4bd110c0)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Load in
- Enter a cruise level on INIT A
- Make sure it corresponds the the ISA temperature using some online tool for example.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
