### PR TITLE
feat: improve hoppie logon process to support reconnections

### DIFF
--- a/fbw-common/src/systems/datalink/router/src/webinterfaces/HoppieConnector.ts
+++ b/fbw-common/src/systems/datalink/router/src/webinterfaces/HoppieConnector.ts
@@ -96,12 +96,14 @@ export class HoppieConnector {
     };
     const text = await Hoppie.sendRequest(body).then((resp) => resp.response);
 
-    if (text === 'error {callsign already in use}' || text.includes(station)) {
+    if (text === 'error {callsign already in use}') {
       return AtsuStatusCodes.CallsignInUse;
     }
+
     if (text.includes('error')) {
       return AtsuStatusCodes.ProxyError;
     }
+
     if (text.startsWith('ok') !== true) {
       return AtsuStatusCodes.ComFailed;
     }
@@ -127,12 +129,18 @@ export class HoppieConnector {
     };
     const text = await Hoppie.sendRequest(body).then((resp) => resp.response);
 
+    if (text === 'error {callsign already in use}') {
+      return AtsuStatusCodes.CallsignInUse;
+    }
+
     if (text.includes('error')) {
       return AtsuStatusCodes.ProxyError;
     }
+
     if (text.startsWith('ok') !== true) {
       return AtsuStatusCodes.ComFailed;
     }
+
     if (text !== `ok {${station}}`) {
       return AtsuStatusCodes.NoAtc;
     }
@@ -155,6 +163,10 @@ export class HoppieConnector {
     const text = await Hoppie.sendRequest(body)
       .then((resp) => resp.response)
       .catch(() => 'proxy');
+
+    if (text === 'error {callsign already in use}') {
+      return AtsuStatusCodes.CallsignInUse;
+    }
 
     if (text === 'proxy') {
       return AtsuStatusCodes.ProxyError;
@@ -321,6 +333,10 @@ export class HoppieConnector {
       const text = await Hoppie.sendRequest(body)
         .then((resp) => resp.response)
         .catch(() => 'proxy');
+
+      if (text === 'error {callsign already in use}') {
+        return [AtsuStatusCodes.CallsignInUse, retval];
+      }
 
       // proxy error during request
       if (text === 'proxy') {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

* removed internal callsign check to favour the usage of hoppie network's checks which is more accurate
* added more informative error messages to indicate callsign in use when sending messages

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

This PR fixes an issue where a reimport of a simbrief flightplan with a same flight number will result in locking yourself out of your hoppie acars connection.

In the existing system, an internal callsign check is performed through the public API each time the flight number is updated, either manually or through a simbrief import. Our internal checks cannot differentiate a callsign that is used by another hoppie user or the current user's previous connection.

Upon checking with the Hoppie ACARS author, the network does compare the logon code to prevent a different logon code from stealing a callsign based on a server-side timer, and returns a "callsign already in use" error when a different logon code is detected. The server-side check will be much more accurate than ours, while ours will only cause self-blocking. 

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Heclak

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

**Test 1**
_Note: Steps 2 to 4 need to be completed quickly (under 5 minutes) as the hoppie network will release a callsign after 300 seconds._ 
1. Ensure your Hoppie ID is setup correctly through the EFB
2. Enter a flight number (eg ABC123) on the INIT page. Check that your flight number appears on the online stations page. https://www.hoppie.nl/acars/system/online.html
3. Switch your flight number to another callsign on the INIT page (eg ABC234). Check that your flight number appears on the online stations page.
4. Switch your flight number back to the original flight number (eg ABC123). Confirm that MCDU MENU light on the right side of the MCDU does not light up and you do not receive a FLT NBR IN USE message in the ATSU section.

**Test 2** (requires two unique hoppie acars logon IDs)
1. User 1 needs to block a callsign on the network (eg ABC123). (does not need to be using the FBW A32NX, could be using another aircraft or another hoppie client if preferred). Use that account to send a telex message to another callsign, you can send a message to the "TEST" callsign.
2. User 2 (needs to be in the A32NX) will enter user 1's flight number (ABC123) on the MCDU INIT page. The MCDU MENU light should illuminate and a FLT NBR IN USE message should appear in the ATSU scratchpad. This step needs to be completed in under 300 seconds of step 1 to avoid the callsign being released back into the pool (best to do it in under 60 seconds as there might be some disrepencies on the server side timer)
![image](https://github.com/user-attachments/assets/3776a37d-bb4e-4685-a473-19c4e03c8396)
![image](https://github.com/user-attachments/assets/9b04bf37-bc91-448b-9a66-f5aeb29781fc)


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
