### PR TITLE
fix(a32nx/fms): fix incorrect TOO STEEP PATH AHEAD message logic

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -78,6 +78,7 @@
 1. [A380X/MODEL] Removed unwanted mesh in front of main landing gear - @heclak (Heclak)
 1. [A380X] Sidestick pushbuttons on CPT and FO sidesticks are made clickable - @heclak (Heclak)
 1. [A380X/MODEL] Fixed black textures on side windshield windows - @heclak (Heclak)
+1. [A32NX/FMS] Fixed TOO STEEP PATH AHEAD message appearing greater than 150nm from destination - @Jonny23787 (Jonathan)
 
 ## 0.13.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -78,12 +78,9 @@
 1. [A380X/MODEL] Removed unwanted mesh in front of main landing gear - @heclak (Heclak)
 1. [A380X] Sidestick pushbuttons on CPT and FO sidesticks are made clickable - @heclak (Heclak)
 1. [A380X/MODEL] Fixed black textures on side windshield windows - @heclak (Heclak)
-<<<<<<< too_steep_path_improvements
-1. [A32NX/FMS] Fixed TOO STEEP PATH AHEAD message appearing greater than 150nm from destination - @Jonny23787 (Jonathan)
-=======
 1. [ATSU] Improved Hoppie ACARS connection protocol - @heclak (Heclak)
 1. [ATSU] Fixed a case where "no active atc" is returned but station is online - @heclak (Heclak)
->>>>>>> master
+1. [A32NX/FMS] Fixed TOO STEEP PATH AHEAD message appearing greater than 150nm from destination - @Jonny23787 (Jonathan)
 
 ## 0.13.0
 

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VerticalProfileManager.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VerticalProfileManager.ts
@@ -753,7 +753,7 @@ export class VerticalProfileManager {
     const isDesOrApprPhase = flightPhase === FmgcFlightPhase.Descent || flightPhase === FmgcFlightPhase.Approach;
     const isCruisePhase = flightPhase === FmgcFlightPhase.Cruise;
     const isCloseToDestination =
-      ((this.constraintReader.distanceToEnd ?? Infinity) > 150 && isCruisePhase) || isDesOrApprPhase;
+      ((this.constraintReader.distanceToEnd ?? Infinity) < 150 && isCruisePhase) || isDesOrApprPhase;
 
     if (!isManagedLateralMode || !isCloseToDestination) {
       return false;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #10148

## Summary of Changes
Changed the operator so the message can only be shown less than 150nm from destination airport.
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
![Screenshot 2025-06-25 194555](https://github.com/user-attachments/assets/3378fe0f-db12-4dfe-8693-b95c94081438)

<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
manual
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
jonny_23

## Testing instructions

1. Load into aircraft at an airport such as LPMA or LPPT.
2. Program MCDU with the destination LPLA, ILS 33 via CUDLY.
3. Takeoff and reach cruise phase, ensure TOO STEEP PATH AHEAD message isn't shown.
4. Once aircraft is less than 150nm from LPLA ensure the TOO STEEP PATH AHEAD message is show on the MCDU in amber.

<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
