### PR TITLE
feat(sfcc): implemented dual SFCC simulation

### DIFF
--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -3506,10 +3506,9 @@ In the variables below, {number} should be replaced with one item in the set: { 
 
 ## Flaps / Slats (ATA 27)
 
-- A32NX_SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD
+- A32NX_SFCC_{number}_SLAT_FLAP_SYSTEM_STATUS_WORD
     - Slat/Flap system status discrete word of the SFCC bus output
     - Arinc429<Discrete>
-    - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - | Bit |            Description            |
       |:---:|:---------------------------------:|
       | 11  | Slat Fault                        |
@@ -3532,10 +3531,9 @@ In the variables below, {number} should be replaced with one item in the set: { 
       | 28  | Slat Data Valid                   |
       | 29  | Flap Data Valid                   |
 
-- A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD
+- A32NX_SFCC_{number}_SLAT_FLAP_ACTUAL_POSITION_WORD
     - Slat/Flap actual position discrete word of the SFCC bus output
     - Arinc429<Discrete>
-    - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - | Bit |                Description               |
       |:---:|:----------------------------------------:|
       | 11  | Slat Data Valid                          |
@@ -3558,19 +3556,17 @@ In the variables below, {number} should be replaced with one item in the set: { 
       | 28  | Slat System Jam                          |
       | 29  | Flap System Jam                          |
 
-- A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD
+- A32NX_SFCC_{number}_SLAT_ACTUAL_POSITION_WORD
     - Slat actual position word of the SFCC bus output
     - Arinc429<Degrees>
-    - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - The Slat FPPU angle ranges from 0° to 360°
 
-- A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD
+- A32NX_SFCC_{number}_FLAP_ACTUAL_POSITION_WORD
     - Flap actual position word of the SFCC bus output
     - Arinc429<Degrees>
-    - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - The Flap FPPU angle ranges from 0° to 360°
 
-- A32NX_SFCC_FAP_{num}
+- A32NX_SFCC_{side}_FAP_{num}
     - Flap actual position discrete output
     - {num} is from 1 to 7
 

--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -3507,6 +3507,7 @@ In the variables below, {number} should be replaced with one item in the set: { 
 ## Flaps / Slats (ATA 27)
 
 - A32NX_SFCC_{number}_SLAT_FLAP_SYSTEM_STATUS_WORD
+    - {number} is 1 or 2
     - Slat/Flap system status discrete word of the SFCC bus output
     - Arinc429<Discrete>
     - | Bit |            Description            |
@@ -3532,6 +3533,7 @@ In the variables below, {number} should be replaced with one item in the set: { 
       | 29  | Flap Data Valid                   |
 
 - A32NX_SFCC_{number}_SLAT_FLAP_ACTUAL_POSITION_WORD
+    - {number} is 1 or 2
     - Slat/Flap actual position discrete word of the SFCC bus output
     - Arinc429<Discrete>
     - | Bit |                Description               |
@@ -3557,18 +3559,21 @@ In the variables below, {number} should be replaced with one item in the set: { 
       | 29  | Flap System Jam                          |
 
 - A32NX_SFCC_{number}_SLAT_ACTUAL_POSITION_WORD
+    - {number} is 1 or 2
     - Slat actual position word of the SFCC bus output
     - Arinc429<Degrees>
     - The Slat FPPU angle ranges from 0° to 360°
 
 - A32NX_SFCC_{number}_FLAP_ACTUAL_POSITION_WORD
+    - {number} is 1 or 2
     - Flap actual position word of the SFCC bus output
     - Arinc429<Degrees>
     - The Flap FPPU angle ranges from 0° to 360°
 
-- A32NX_SFCC_{side}_FAP_{num}
+- A32NX_SFCC_{number}_FAP_{id}
+    - {number} is 1 or 2
+    - {id} is from 1 to 7
     - Flap actual position discrete output
-    - {num} is from 1 to 7
 
 ## Flight Controls (ATA 27)
 

--- a/fbw-a32nx/src/systems/instruments/src/EWD/shared/EwdSimvarPublisher.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EWD/shared/EwdSimvarPublisher.tsx
@@ -109,9 +109,10 @@ export enum EwdVars {
   flexTemp = 'L:A32NX_AIRLINER_TO_FLEX_TEMP',
   satRaw = 'L:A32NX_ADIRS_ADR_1_STATIC_AIR_TEMPERATURE',
   totalFuel = 'FUEL TOTAL QUANTITY WEIGHT',
-  slatsFlapsStatusRaw = 'L:A32NX_SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD',
-  slatsPositionRaw = 'L:A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD',
-  flapsPositionRaw = 'L:A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD',
+  // TODO: add switching between SFCC_1 and SFCC_2
+  slatsFlapsStatusRaw = 'L:A32NX_SFCC_1_SLAT_FLAP_SYSTEM_STATUS_WORD',
+  slatsPositionRaw = 'L:A32NX_SFCC_1_SLAT_ACTUAL_POSITION_WORD',
+  flapsPositionRaw = 'L:A32NX_SFCC_1_FLAP_ACTUAL_POSITION_WORD',
   ewdLowerLeft1 = 'L:A32NX_Ewd_LOWER_LEFT_LINE_1',
   ewdLowerLeft2 = 'L:A32NX_Ewd_LOWER_LEFT_LINE_2',
   ewdLowerLeft3 = 'L:A32NX_Ewd_LOWER_LEFT_LINE_3',

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_Core/A32NX_GPWS.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_Core/A32NX_GPWS.ts
@@ -213,8 +213,8 @@ export class A32NX_GPWS {
     const isFlapModeOff = SimVar.GetSimVarValue('L:A32NX_GPWS_FLAP_OFF', 'Bool') === 1;
     const isLdgFlap3On = SimVar.GetSimVarValue('L:A32NX_GPWS_FLAPS3', 'Bool') === 1;
 
-    const sfccFap5 = SimVar.GetSimVarValue('L:A32NX_SFCC_FAP_5', 'Bool') === 1; // Flaps > 19deg
-    const sfccFap1 = SimVar.GetSimVarValue('L:A32NX_SFCC_FAP_1', 'Bool') === 1; // Flaps > 39deg
+    const sfccFap5 = SimVar.GetSimVarValue('L:A32NX_SFCC_1_FAP_5', 'Bool') === 1; // Flaps > 19deg
+    const sfccFap1 = SimVar.GetSimVarValue('L:A32NX_SFCC_1_FAP_1', 'Bool') === 1; // Flaps > 39deg
 
     const areFlapsInLandingConfig = isFlapModeOff || (isLdgFlap3On ? sfccFap5 : sfccFap1);
     const isGearDownLocked = SimVar.GetSimVarValue('L:A32NX_LGCIU_1_LEFT_GEAR_DOWNLOCKED', 'Bool') === 1;

--- a/fbw-a32nx/src/systems/systems-host/systems/FWC/PseudoFWC.ts
+++ b/fbw-a32nx/src/systems/systems-host/systems/FWC/PseudoFWC.ts
@@ -2493,9 +2493,9 @@ export class PseudoFWC {
     this.flapsHandle.set(SimVar.GetSimVarValue('L:A32NX_FLAPS_HANDLE_INDEX', 'enum'));
     this.slatsAngle.set(SimVar.GetSimVarValue('L:A32NX_SLATS_IPPU_ANGLE', 'degrees'));
 
-    // FIXME these should be split between the two systems and the two sides
-    const flapsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD');
-    const slatsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD');
+    // TODO: add switching between SFCC_1 and SFCC_2
+    const flapsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_1_FLAP_ACTUAL_POSITION_WORD');
+    const slatsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_1_SLAT_ACTUAL_POSITION_WORD');
 
     // WARNING these vary for other variants... A320 CFM LEAP values here
     // flap/slat internal signals

--- a/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
@@ -503,11 +503,14 @@ void FlyByWireInterface::setupLocalVariables() {
     idLgciuDiscreteWord4[i] = std::make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_DISCRETE_WORD_4");
   }
 
-  idSfccSlatFlapComponentStatusWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_COMPONENT_STATUS_WORD");
-  idSfccSlatFlapSystemStatusWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD");
-  idSfccSlatFlapActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD");
-  idSfccSlatActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD");
-  idSfccFlapActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD");
+  for (int i = 0; i < 2; i++) {
+    std::string idString = std::to_string(i + 1);
+    idSfccSlatFlapComponentStatusWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_FLAP_COMPONENT_STATUS_WORD");
+    idSfccSlatFlapSystemStatusWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_FLAP_SYSTEM_STATUS_WORD");
+    idSfccSlatFlapActualPositionWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_FLAP_ACTUAL_POSITION_WORD");
+    idSfccSlatActualPositionWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_ACTUAL_POSITION_WORD");
+    idSfccFlapActualPositionWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_FLAP_ACTUAL_POSITION_WORD");
+  }
 
   for (int i = 0; i < 3; i++) {
     std::string idString = std::to_string(i + 1);
@@ -1253,11 +1256,11 @@ bool FlyByWireInterface::updateLgciu(int lgciuIndex) {
 }
 
 bool FlyByWireInterface::updateSfcc(int sfccIndex) {
-  sfccBusOutputs[sfccIndex].slat_flap_component_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapComponentStatusWord->get());
-  sfccBusOutputs[sfccIndex].slat_flap_system_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapSystemStatusWord->get());
-  sfccBusOutputs[sfccIndex].slat_flap_actual_position_word = Arinc429Utils::fromSimVar(idSfccSlatFlapActualPositionWord->get());
-  sfccBusOutputs[sfccIndex].slat_actual_position_deg = Arinc429Utils::fromSimVar(idSfccSlatActualPositionWord->get());
-  sfccBusOutputs[sfccIndex].flap_actual_position_deg = Arinc429Utils::fromSimVar(idSfccFlapActualPositionWord->get());
+  sfccBusOutputs[sfccIndex].slat_flap_component_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapComponentStatusWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].slat_flap_system_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapSystemStatusWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].slat_flap_actual_position_word = Arinc429Utils::fromSimVar(idSfccSlatFlapActualPositionWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].slat_actual_position_deg = Arinc429Utils::fromSimVar(idSfccSlatActualPositionWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].flap_actual_position_deg = Arinc429Utils::fromSimVar(idSfccFlapActualPositionWord[sfccIndex]->get());
 
   if (clientDataEnabled) {
     simConnectInterface.setClientDataSfcc(sfccBusOutputs[sfccIndex], sfccIndex);

--- a/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.h
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.h
@@ -332,11 +332,11 @@ class FlyByWireInterface {
   std::unique_ptr<LocalVariable> idLgciuDiscreteWord4[2];
 
   // SFCC inputs
-  std::unique_ptr<LocalVariable> idSfccSlatFlapComponentStatusWord;
-  std::unique_ptr<LocalVariable> idSfccSlatFlapSystemStatusWord;
-  std::unique_ptr<LocalVariable> idSfccSlatFlapActualPositionWord;
-  std::unique_ptr<LocalVariable> idSfccSlatActualPositionWord;
-  std::unique_ptr<LocalVariable> idSfccFlapActualPositionWord;
+  std::unique_ptr<LocalVariable> idSfccSlatFlapComponentStatusWord[2];
+  std::unique_ptr<LocalVariable> idSfccSlatFlapSystemStatusWord[2];
+  std::unique_ptr<LocalVariable> idSfccSlatFlapActualPositionWord[2];
+  std::unique_ptr<LocalVariable> idSfccSlatActualPositionWord[2];
+  std::unique_ptr<LocalVariable> idSfccFlapActualPositionWord[2];
 
   // ADR bus inputs
   std::unique_ptr<LocalVariable> idAdrAltitudeStandard[3];

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/flaps_computer.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/flaps_computer.rs
@@ -1,4 +1,5 @@
 use crate::systems::shared::arinc429::{Arinc429Word, SignStatus};
+use systems::accept_iterable;
 use systems::hydraulic::command_sensor_unit::{CSUMonitor, CSU};
 use systems::shared::PositionPickoffUnit;
 
@@ -34,6 +35,7 @@ struct SlatFlapControlComputer {
     slats_feedback_angle: Angle,
     flaps_conf: FlapsConf,
     fap: [bool; 7],
+    csu_monitor: CSUMonitor,
 }
 
 impl SlatFlapControlComputer {
@@ -41,25 +43,25 @@ impl SlatFlapControlComputer {
     const HANDLE_ONE_CONF_AIRSPEED_THRESHOLD_KNOTS: f64 = 100.;
     const CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS: f64 = 210.;
 
-    fn new(context: &mut InitContext) -> Self {
+    fn new(context: &mut InitContext, num: u8) -> Self {
         Self {
             flaps_conf_index_id: context.get_identifier("FLAPS_CONF_INDEX".to_owned()),
             slat_flap_system_status_word_id: context
-                .get_identifier("SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_SLAT_FLAP_SYSTEM_STATUS_WORD")),
             slat_flap_actual_position_word_id: context
-                .get_identifier("SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_SLAT_FLAP_ACTUAL_POSITION_WORD")),
             slat_actual_position_word_id: context
-                .get_identifier("SFCC_SLAT_ACTUAL_POSITION_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_SLAT_ACTUAL_POSITION_WORD")),
             flap_actual_position_word_id: context
-                .get_identifier("SFCC_FLAP_ACTUAL_POSITION_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_FLAP_ACTUAL_POSITION_WORD")),
             fap_ids: [
-                context.get_identifier("SFCC_FAP_1".to_owned()),
-                context.get_identifier("SFCC_FAP_2".to_owned()),
-                context.get_identifier("SFCC_FAP_3".to_owned()),
-                context.get_identifier("SFCC_FAP_4".to_owned()),
-                context.get_identifier("SFCC_FAP_5".to_owned()),
-                context.get_identifier("SFCC_FAP_6".to_owned()),
-                context.get_identifier("SFCC_FAP_7".to_owned()),
+                context.get_identifier(format!("SFCC_{num}_FAP_1")),
+                context.get_identifier(format!("SFCC_{num}_FAP_2")),
+                context.get_identifier(format!("SFCC_{num}_FAP_3")),
+                context.get_identifier(format!("SFCC_{num}_FAP_4")),
+                context.get_identifier(format!("SFCC_{num}_FAP_5")),
+                context.get_identifier(format!("SFCC_{num}_FAP_6")),
+                context.get_identifier(format!("SFCC_{num}_FAP_7")),
             ],
 
             flaps_demanded_angle: Angle::new::<degree>(0.),
@@ -69,7 +71,8 @@ impl SlatFlapControlComputer {
             flaps_conf: FlapsConf::Conf0,
 
             // Set to false to match power-off state
-            fap: [true; 7],
+            fap: [false; 7],
+            csu_monitor: CSUMonitor::new(context),
         }
     }
 
@@ -143,27 +146,28 @@ impl SlatFlapControlComputer {
     pub fn update(
         &mut self,
         context: &UpdateContext,
-        csu_monitor: &CSUMonitor,
         flaps_feedback: &impl PositionPickoffUnit,
         slats_feedback: &impl PositionPickoffUnit,
     ) {
-        self.flaps_conf = self.generate_configuration(csu_monitor, context);
+        self.csu_monitor.update(context);
+
+        self.flaps_conf = self.generate_configuration(&self.csu_monitor, context);
 
         self.flaps_demanded_angle = Self::demanded_flaps_fppu_angle_from_conf(self.flaps_conf);
         self.slats_demanded_angle = Self::demanded_slats_fppu_angle_from_conf(self.flaps_conf);
         self.flaps_feedback_angle = flaps_feedback.angle();
         self.slats_feedback_angle = slats_feedback.angle();
 
-        self.fap_update(csu_monitor);
+        self.fap_update();
     }
 
-    fn fap_update(&mut self, csu_monitor: &CSUMonitor) {
+    fn fap_update(&mut self) {
         let fppu_angle = self.flaps_feedback_angle.get::<degree>();
 
         self.fap[0] = fppu_angle > 247.8 && fppu_angle < 254.0;
         self.fap[1] = fppu_angle > 114.6 && fppu_angle < 254.0;
         self.fap[2] = fppu_angle > 163.7 && fppu_angle < 254.0;
-        self.fap[3] = csu_monitor.get_current_detent() == CSU::Conf0;
+        self.fap[3] = self.csu_monitor.get_current_detent() == CSU::Conf0;
         self.fap[4] = fppu_angle > 163.7 && fppu_angle < 254.0;
         self.fap[5] = fppu_angle > 247.8 && fppu_angle < 254.0;
         self.fap[6] = fppu_angle > 114.6 && fppu_angle < 254.0;
@@ -305,6 +309,11 @@ impl SlatFlapLane for SlatFlapControlComputer {
 }
 
 impl SimulationElement for SlatFlapControlComputer {
+    fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
+        self.csu_monitor.accept(visitor);
+        visitor.visit(self);
+    }
+
     fn write(&self, writer: &mut SimulatorWriter) {
         for (id, fap) in self.fap_ids.iter().zip(self.fap) {
             writer.write(id, fap);
@@ -332,15 +341,16 @@ impl SimulationElement for SlatFlapControlComputer {
 }
 
 pub struct SlatFlapComplex {
-    sfcc: SlatFlapControlComputer,
-    csu_monitor: CSUMonitor,
+    sfcc: [SlatFlapControlComputer; 2],
 }
 
 impl SlatFlapComplex {
     pub fn new(context: &mut InitContext) -> Self {
         Self {
-            sfcc: SlatFlapControlComputer::new(context),
-            csu_monitor: CSUMonitor::new(context),
+            sfcc: [
+                SlatFlapControlComputer::new(context, 1),
+                SlatFlapControlComputer::new(context, 2),
+            ],
         }
     }
 
@@ -350,23 +360,25 @@ impl SlatFlapComplex {
         flaps_feedback: &impl PositionPickoffUnit,
         slats_feedback: &impl PositionPickoffUnit,
     ) {
-        self.csu_monitor.update(context);
-        self.sfcc
-            .update(context, &self.csu_monitor, flaps_feedback, slats_feedback);
+        self.sfcc[0].update(context, flaps_feedback, slats_feedback);
+        self.sfcc[1].update(context, flaps_feedback, slats_feedback);
     }
 
-    pub fn flap_demand(&self) -> Option<Angle> {
-        self.sfcc.signal_demanded_angle("FLAPS")
+    // `idx` 0 is for SFCC1
+    // `idx` 1 is for SFCC2
+    pub fn flap_demand(&self, idx: usize) -> Option<Angle> {
+        self.sfcc[idx].signal_demanded_angle("FLAPS")
     }
 
-    pub fn slat_demand(&self) -> Option<Angle> {
-        self.sfcc.signal_demanded_angle("SLATS")
+    // `idx` 0 is for SFCC1
+    // `idx` 1 is for SFCC2
+    pub fn slat_demand(&self, idx: usize) -> Option<Angle> {
+        self.sfcc[idx].signal_demanded_angle("SLATS")
     }
 }
 impl SimulationElement for SlatFlapComplex {
     fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
-        self.csu_monitor.accept(visitor);
-        self.sfcc.accept(visitor);
+        accept_iterable!(self.sfcc, visitor);
         visitor.visit(self);
     }
 }
@@ -527,13 +539,13 @@ mod tests {
                 .update(context, &self.flap_gear, &self.slat_gear);
             self.flap_gear.update(
                 context,
-                &self.slat_flap_complex.sfcc,
+                &self.slat_flap_complex.sfcc[0],
                 self.green_pressure,
                 self.yellow_pressure,
             );
             self.slat_gear.update(
                 context,
-                &self.slat_flap_complex.sfcc,
+                &self.slat_flap_complex.sfcc[0],
                 self.blue_pressure,
                 self.green_pressure,
             );
@@ -588,40 +600,40 @@ mod tests {
             self.read_by_name("FLAPS_HANDLE_INDEX")
         }
 
-        fn read_slat_flap_system_status_word(&mut self) -> Arinc429Word<u32> {
-            self.read_by_name("SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD")
+        fn read_slat_flap_system_status_word(&mut self, num: u8) -> Arinc429Word<u32> {
+            self.read_by_name(&format!("SFCC_{num}_SLAT_FLAP_SYSTEM_STATUS_WORD"))
         }
 
-        fn read_slat_flap_actual_position_word(&mut self) -> Arinc429Word<u32> {
-            self.read_by_name("SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD")
+        fn read_slat_flap_actual_position_word(&mut self, num: u8) -> Arinc429Word<u32> {
+            self.read_by_name(&format!("SFCC_{num}_SLAT_FLAP_ACTUAL_POSITION_WORD"))
         }
 
-        fn read_sfcc_fap_1_word(&mut self) -> bool {
-            self.read_by_name("SFCC_FAP_1")
+        fn read_sfcc_fap_1_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_1"))
         }
 
-        fn read_sfcc_fap_2_word(&mut self) -> bool {
-            self.read_by_name("SFCC_FAP_2")
+        fn read_sfcc_fap_2_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_2"))
         }
 
-        fn read_sfcc_fap_3_word(&mut self) -> bool {
-            self.read_by_name("SFCC_FAP_3")
+        fn read_sfcc_fap_3_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_3"))
         }
 
-        fn read_sfcc_fap_4_word(&mut self) -> bool {
-            self.read_by_name("SFCC_FAP_4")
+        fn read_sfcc_fap_4_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_4"))
         }
 
-        fn read_sfcc_fap_5_word(&mut self) -> bool {
-            self.read_by_name("SFCC_FAP_5")
+        fn read_sfcc_fap_5_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_5"))
         }
 
-        fn read_sfcc_fap_6_word(&mut self) -> bool {
-            self.read_by_name("SFCC_FAP_6")
+        fn read_sfcc_fap_6_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_6"))
         }
 
-        fn read_sfcc_fap_7_word(&mut self) -> bool {
-            self.read_by_name("SFCC_FAP_7")
+        fn read_sfcc_fap_7_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_7"))
         }
 
         fn set_indicated_airspeed(mut self, indicated_airspeed: f64) -> Self {
@@ -644,26 +656,24 @@ mod tests {
             self
         }
 
-        fn get_flaps_demanded_angle(&self) -> f64 {
+        fn get_flaps_demanded_angle(&self, idx: usize) -> f64 {
             self.query(|a| {
-                a.slat_flap_complex
-                    .sfcc
+                a.slat_flap_complex.sfcc[idx]
                     .flaps_demanded_angle
                     .get::<degree>()
             })
         }
 
-        fn get_slats_demanded_angle(&self) -> f64 {
+        fn get_slats_demanded_angle(&self, idx: usize) -> f64 {
             self.query(|a| {
-                a.slat_flap_complex
-                    .sfcc
+                a.slat_flap_complex.sfcc[idx]
                     .slats_demanded_angle
                     .get::<degree>()
             })
         }
 
-        fn get_flaps_conf(&self) -> FlapsConf {
-            self.query(|a| a.slat_flap_complex.sfcc.flaps_conf)
+        fn get_flaps_conf(&self, num: usize) -> FlapsConf {
+            self.query(|a| a.slat_flap_complex.sfcc[num].flaps_conf)
         }
 
         fn get_flaps_fppu_feedback(&self) -> f64 {
@@ -674,32 +684,32 @@ mod tests {
             self.query(|a| a.slat_gear.angle().get::<degree>())
         }
 
-        fn get_fap_1(&self) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc.fap[0])
+        fn get_fap_1(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[0])
         }
 
-        fn get_fap_2(&self) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc.fap[1])
+        fn get_fap_2(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[1])
         }
 
-        fn get_fap_3(&self) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc.fap[2])
+        fn get_fap_3(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[2])
         }
 
-        fn get_fap_4(&self) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc.fap[3])
+        fn get_fap_4(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[3])
         }
 
-        fn get_fap_5(&self) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc.fap[4])
+        fn get_fap_5(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[4])
         }
 
-        fn get_fap_6(&self) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc.fap[5])
+        fn get_fap_6(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[5])
         }
 
-        fn get_fap_7(&self) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc.fap[6])
+        fn get_fap_7(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[6])
         }
 
         fn test_flap_conf(
@@ -711,9 +721,13 @@ mod tests {
             angle_delta: f64,
         ) {
             assert_eq!(self.read_flaps_handle_position(), handle_pos);
-            assert!((self.get_flaps_demanded_angle() - flaps_demanded_angle).abs() < angle_delta);
-            assert!((self.get_slats_demanded_angle() - slats_demanded_angle).abs() < angle_delta);
-            assert_eq!(self.get_flaps_conf(), conf);
+            assert!((self.get_flaps_demanded_angle(0) - flaps_demanded_angle).abs() < angle_delta);
+            assert!((self.get_slats_demanded_angle(0) - slats_demanded_angle).abs() < angle_delta);
+            assert_eq!(self.get_flaps_conf(0), conf);
+
+            assert!((self.get_flaps_demanded_angle(1) - flaps_demanded_angle).abs() < angle_delta);
+            assert!((self.get_slats_demanded_angle(1) - slats_demanded_angle).abs() < angle_delta);
+            assert_eq!(self.get_flaps_conf(1), conf);
         }
     }
     impl TestBed for A320FlapsTestBed {
@@ -752,13 +766,33 @@ mod tests {
 
         assert!(test_bed.contains_variable_with_name("FLAPS_CONF_INDEX"));
 
-        assert!(test_bed.contains_variable_with_name("SFCC_FAP_1"));
-        assert!(test_bed.contains_variable_with_name("SFCC_FAP_2"));
-        assert!(test_bed.contains_variable_with_name("SFCC_FAP_3"));
-        assert!(test_bed.contains_variable_with_name("SFCC_FAP_4"));
-        assert!(test_bed.contains_variable_with_name("SFCC_FAP_5"));
-        assert!(test_bed.contains_variable_with_name("SFCC_FAP_6"));
-        assert!(test_bed.contains_variable_with_name("SFCC_FAP_7"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_1"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_2"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_3"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_4"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_5"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_6"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_7"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_1"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_2"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_3"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_4"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_5"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_6"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_7"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FLAP_ACTUAL_POSITION_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FLAP_ACTUAL_POSITION_WORD"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SLAT_ACTUAL_POSITION_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SLAT_ACTUAL_POSITION_WORD"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SLAT_FLAP_ACTUAL_POSITION_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SLAT_FLAP_ACTUAL_POSITION_WORD"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SLAT_FLAP_SYSTEM_STATUS_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SLAT_FLAP_SYSTEM_STATUS_WORD"));
     }
 
     #[test]
@@ -771,101 +805,181 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert!(!test_bed.get_fap_1());
-        assert!(!test_bed.get_fap_2());
-        assert!(!test_bed.get_fap_3());
-        assert!(test_bed.get_fap_4());
-        assert!(!test_bed.get_fap_5());
-        assert!(!test_bed.get_fap_6());
-        assert!(!test_bed.get_fap_7());
+        assert!(!test_bed.get_fap_1(0));
+        assert!(!test_bed.get_fap_2(0));
+        assert!(!test_bed.get_fap_3(0));
+        assert!(test_bed.get_fap_4(0));
+        assert!(!test_bed.get_fap_5(0));
+        assert!(!test_bed.get_fap_6(0));
+        assert!(!test_bed.get_fap_7(0));
 
-        assert!(!test_bed.read_sfcc_fap_1_word());
-        assert!(!test_bed.read_sfcc_fap_2_word());
-        assert!(!test_bed.read_sfcc_fap_3_word());
-        assert!(test_bed.read_sfcc_fap_4_word());
-        assert!(!test_bed.read_sfcc_fap_5_word());
-        assert!(!test_bed.read_sfcc_fap_6_word());
-        assert!(!test_bed.read_sfcc_fap_7_word());
+        assert!(!test_bed.get_fap_1(1));
+        assert!(!test_bed.get_fap_2(1));
+        assert!(!test_bed.get_fap_3(1));
+        assert!(test_bed.get_fap_4(1));
+        assert!(!test_bed.get_fap_5(1));
+        assert!(!test_bed.get_fap_6(1));
+        assert!(!test_bed.get_fap_7(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(1));
+        assert!(!test_bed.read_sfcc_fap_2_word(1));
+        assert!(!test_bed.read_sfcc_fap_3_word(1));
+        assert!(test_bed.read_sfcc_fap_4_word(1));
+        assert!(!test_bed.read_sfcc_fap_5_word(1));
+        assert!(!test_bed.read_sfcc_fap_6_word(1));
+        assert!(!test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(2));
+        assert!(!test_bed.read_sfcc_fap_2_word(2));
+        assert!(!test_bed.read_sfcc_fap_3_word(2));
+        assert!(test_bed.read_sfcc_fap_4_word(2));
+        assert!(!test_bed.read_sfcc_fap_5_word(2));
+        assert!(!test_bed.read_sfcc_fap_6_word(2));
+        assert!(!test_bed.read_sfcc_fap_7_word(2));
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.get_fap_1());
-        assert!(test_bed.get_fap_2());
-        assert!(!test_bed.get_fap_3());
-        assert!(!test_bed.get_fap_4());
-        assert!(!test_bed.get_fap_5());
-        assert!(!test_bed.get_fap_6());
-        assert!(test_bed.get_fap_7());
+        assert!(!test_bed.get_fap_1(0));
+        assert!(test_bed.get_fap_2(0));
+        assert!(!test_bed.get_fap_3(0));
+        assert!(!test_bed.get_fap_4(0));
+        assert!(!test_bed.get_fap_5(0));
+        assert!(!test_bed.get_fap_6(0));
+        assert!(test_bed.get_fap_7(0));
 
-        assert!(!test_bed.read_sfcc_fap_1_word());
-        assert!(test_bed.read_sfcc_fap_2_word());
-        assert!(!test_bed.read_sfcc_fap_3_word());
-        assert!(!test_bed.read_sfcc_fap_4_word());
-        assert!(!test_bed.read_sfcc_fap_5_word());
-        assert!(!test_bed.read_sfcc_fap_6_word());
-        assert!(test_bed.read_sfcc_fap_7_word());
+        assert!(!test_bed.get_fap_1(1));
+        assert!(test_bed.get_fap_2(1));
+        assert!(!test_bed.get_fap_3(1));
+        assert!(!test_bed.get_fap_4(1));
+        assert!(!test_bed.get_fap_5(1));
+        assert!(!test_bed.get_fap_6(1));
+        assert!(test_bed.get_fap_7(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(1));
+        assert!(test_bed.read_sfcc_fap_2_word(1));
+        assert!(!test_bed.read_sfcc_fap_3_word(1));
+        assert!(!test_bed.read_sfcc_fap_4_word(1));
+        assert!(!test_bed.read_sfcc_fap_5_word(1));
+        assert!(!test_bed.read_sfcc_fap_6_word(1));
+        assert!(test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(2));
+        assert!(test_bed.read_sfcc_fap_2_word(2));
+        assert!(!test_bed.read_sfcc_fap_3_word(2));
+        assert!(!test_bed.read_sfcc_fap_4_word(2));
+        assert!(!test_bed.read_sfcc_fap_5_word(2));
+        assert!(!test_bed.read_sfcc_fap_6_word(2));
+        assert!(test_bed.read_sfcc_fap_7_word(2));
 
         test_bed = test_bed
             .set_flaps_handle_position(2)
             .run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.get_fap_1());
-        assert!(test_bed.get_fap_2());
-        assert!(!test_bed.get_fap_3());
-        assert!(!test_bed.get_fap_4());
-        assert!(!test_bed.get_fap_5());
-        assert!(!test_bed.get_fap_6());
-        assert!(test_bed.get_fap_7());
+        assert!(!test_bed.get_fap_1(0));
+        assert!(test_bed.get_fap_2(0));
+        assert!(!test_bed.get_fap_3(0));
+        assert!(!test_bed.get_fap_4(0));
+        assert!(!test_bed.get_fap_5(0));
+        assert!(!test_bed.get_fap_6(0));
+        assert!(test_bed.get_fap_7(0));
 
-        assert!(!test_bed.read_sfcc_fap_1_word());
-        assert!(test_bed.read_sfcc_fap_2_word());
-        assert!(!test_bed.read_sfcc_fap_3_word());
-        assert!(!test_bed.read_sfcc_fap_4_word());
-        assert!(!test_bed.read_sfcc_fap_5_word());
-        assert!(!test_bed.read_sfcc_fap_6_word());
-        assert!(test_bed.read_sfcc_fap_7_word());
+        assert!(!test_bed.get_fap_1(1));
+        assert!(test_bed.get_fap_2(1));
+        assert!(!test_bed.get_fap_3(1));
+        assert!(!test_bed.get_fap_4(1));
+        assert!(!test_bed.get_fap_5(1));
+        assert!(!test_bed.get_fap_6(1));
+        assert!(test_bed.get_fap_7(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(1));
+        assert!(test_bed.read_sfcc_fap_2_word(1));
+        assert!(!test_bed.read_sfcc_fap_3_word(1));
+        assert!(!test_bed.read_sfcc_fap_4_word(1));
+        assert!(!test_bed.read_sfcc_fap_5_word(1));
+        assert!(!test_bed.read_sfcc_fap_6_word(1));
+        assert!(test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(2));
+        assert!(test_bed.read_sfcc_fap_2_word(2));
+        assert!(!test_bed.read_sfcc_fap_3_word(2));
+        assert!(!test_bed.read_sfcc_fap_4_word(2));
+        assert!(!test_bed.read_sfcc_fap_5_word(2));
+        assert!(!test_bed.read_sfcc_fap_6_word(2));
+        assert!(test_bed.read_sfcc_fap_7_word(2));
 
         test_bed = test_bed
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.get_fap_1());
-        assert!(test_bed.get_fap_2());
-        assert!(test_bed.get_fap_3());
-        assert!(!test_bed.get_fap_4());
-        assert!(test_bed.get_fap_5());
-        assert!(!test_bed.get_fap_6());
-        assert!(test_bed.get_fap_7());
+        assert!(!test_bed.get_fap_1(0));
+        assert!(test_bed.get_fap_2(0));
+        assert!(test_bed.get_fap_3(0));
+        assert!(!test_bed.get_fap_4(0));
+        assert!(test_bed.get_fap_5(0));
+        assert!(!test_bed.get_fap_6(0));
+        assert!(test_bed.get_fap_7(0));
 
-        assert!(!test_bed.read_sfcc_fap_1_word());
-        assert!(test_bed.read_sfcc_fap_2_word());
-        assert!(test_bed.read_sfcc_fap_3_word());
-        assert!(!test_bed.read_sfcc_fap_4_word());
-        assert!(test_bed.read_sfcc_fap_5_word());
-        assert!(!test_bed.read_sfcc_fap_6_word());
-        assert!(test_bed.read_sfcc_fap_7_word());
+        assert!(!test_bed.get_fap_1(1));
+        assert!(test_bed.get_fap_2(1));
+        assert!(test_bed.get_fap_3(1));
+        assert!(!test_bed.get_fap_4(1));
+        assert!(test_bed.get_fap_5(1));
+        assert!(!test_bed.get_fap_6(1));
+        assert!(test_bed.get_fap_7(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(1));
+        assert!(test_bed.read_sfcc_fap_2_word(1));
+        assert!(test_bed.read_sfcc_fap_3_word(1));
+        assert!(!test_bed.read_sfcc_fap_4_word(1));
+        assert!(test_bed.read_sfcc_fap_5_word(1));
+        assert!(!test_bed.read_sfcc_fap_6_word(1));
+        assert!(test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(2));
+        assert!(test_bed.read_sfcc_fap_2_word(2));
+        assert!(test_bed.read_sfcc_fap_3_word(2));
+        assert!(!test_bed.read_sfcc_fap_4_word(2));
+        assert!(test_bed.read_sfcc_fap_5_word(2));
+        assert!(!test_bed.read_sfcc_fap_6_word(2));
+        assert!(test_bed.read_sfcc_fap_7_word(2));
 
         test_bed = test_bed
             .set_flaps_handle_position(4)
             .run_waiting_for(Duration::from_secs(60));
 
-        assert!(test_bed.get_fap_1());
-        assert!(test_bed.get_fap_2());
-        assert!(test_bed.get_fap_3());
-        assert!(!test_bed.get_fap_4());
-        assert!(test_bed.get_fap_5());
-        assert!(test_bed.get_fap_6());
-        assert!(test_bed.get_fap_7());
+        assert!(test_bed.get_fap_1(0));
+        assert!(test_bed.get_fap_2(0));
+        assert!(test_bed.get_fap_3(0));
+        assert!(!test_bed.get_fap_4(0));
+        assert!(test_bed.get_fap_5(0));
+        assert!(test_bed.get_fap_6(0));
+        assert!(test_bed.get_fap_7(0));
 
-        assert!(test_bed.read_sfcc_fap_1_word());
-        assert!(test_bed.read_sfcc_fap_2_word());
-        assert!(test_bed.read_sfcc_fap_3_word());
-        assert!(!test_bed.read_sfcc_fap_4_word());
-        assert!(test_bed.read_sfcc_fap_5_word());
-        assert!(test_bed.read_sfcc_fap_6_word());
-        assert!(test_bed.read_sfcc_fap_7_word());
+        assert!(test_bed.get_fap_1(1));
+        assert!(test_bed.get_fap_2(1));
+        assert!(test_bed.get_fap_3(1));
+        assert!(!test_bed.get_fap_4(1));
+        assert!(test_bed.get_fap_5(1));
+        assert!(test_bed.get_fap_6(1));
+        assert!(test_bed.get_fap_7(1));
+
+        assert!(test_bed.read_sfcc_fap_1_word(1));
+        assert!(test_bed.read_sfcc_fap_2_word(1));
+        assert!(test_bed.read_sfcc_fap_3_word(1));
+        assert!(!test_bed.read_sfcc_fap_4_word(1));
+        assert!(test_bed.read_sfcc_fap_5_word(1));
+        assert!(test_bed.read_sfcc_fap_6_word(1));
+        assert!(test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(test_bed.read_sfcc_fap_1_word(2));
+        assert!(test_bed.read_sfcc_fap_2_word(2));
+        assert!(test_bed.read_sfcc_fap_3_word(2));
+        assert!(!test_bed.read_sfcc_fap_4_word(2));
+        assert!(test_bed.read_sfcc_fap_5_word(2));
+        assert!(test_bed.read_sfcc_fap_6_word(2));
+        assert!(test_bed.read_sfcc_fap_7_word(2));
     }
 
     #[test]
@@ -878,24 +992,41 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(10));
 
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -908,24 +1039,41 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -938,24 +1086,41 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -968,24 +1133,41 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -998,24 +1180,41 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -1028,24 +1227,41 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(45));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     // Tests flaps configuration and angles for regular
@@ -1117,21 +1333,25 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed
             .set_indicated_airspeed(220.)
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
     }
 
     //Tests transition between Conf1F to Conf1 above 210 knots
@@ -1143,15 +1363,18 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_indicated_airspeed(150.).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_indicated_airspeed(220.).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
     }
 
     // Tests flaps configuration and angles for regular
@@ -1232,19 +1455,24 @@ mod tests {
             .run_one_tick();
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed
             .set_indicated_airspeed(110.)
@@ -1252,19 +1480,24 @@ mod tests {
             .run_one_tick();
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed
             .set_indicated_airspeed(220.)
@@ -1272,19 +1505,24 @@ mod tests {
             .run_one_tick();
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
     }
 
     #[test]
@@ -1295,16 +1533,20 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1312,13 +1554,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1326,12 +1571,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
+
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1339,13 +1588,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1353,13 +1605,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
     }
 
     #[test]
@@ -1370,13 +1625,16 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1384,13 +1642,16 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
     }
 
     #[test]
@@ -1401,13 +1662,16 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1415,13 +1679,16 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1429,13 +1696,16 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
     }
 
     #[test]
@@ -1446,13 +1716,16 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1460,13 +1733,16 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1474,19 +1750,24 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
     }
 
     #[test]
@@ -1498,14 +1779,19 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(20));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1519,14 +1805,19 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed
             .set_flaps_handle_position(2)
             .run_waiting_for(Duration::from_secs(20));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1540,14 +1831,19 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(30));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1561,14 +1857,19 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(20));
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed
             .set_flaps_handle_position(4)
             .run_waiting_for(Duration::from_secs(20));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1582,14 +1883,19 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(30));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1604,18 +1910,27 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(30));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
                 <= angle_delta
         );
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1629,14 +1944,19 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed
             .set_flaps_handle_position(2)
             .run_waiting_for(Duration::from_secs(40));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1650,14 +1970,19 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(40));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1671,14 +1996,19 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed
             .set_flaps_handle_position(4)
             .run_waiting_for(Duration::from_secs(50));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/flaps_computer.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/flaps_computer.rs
@@ -100,15 +100,11 @@ impl SlatFlapControlComputer {
         }
     }
 
-    fn generate_configuration(
-        &self,
-        csu_monitor: &CSUMonitor,
-        context: &UpdateContext,
-    ) -> FlapsConf {
+    fn generate_configuration(&self, context: &UpdateContext) -> FlapsConf {
         // Ignored `CSU::OutOfDetent` and `CSU::Fault` positions due to simplified SFCC.
         match (
-            csu_monitor.get_previous_detent(),
-            csu_monitor.get_current_detent(),
+            self.csu_monitor.get_previous_detent(),
+            self.csu_monitor.get_current_detent(),
         ) {
             (CSU::Conf0, CSU::Conf1)
                 if context.indicated_airspeed().get::<knot>()
@@ -151,7 +147,7 @@ impl SlatFlapControlComputer {
     ) {
         self.csu_monitor.update(context);
 
-        self.flaps_conf = self.generate_configuration(&self.csu_monitor, context);
+        self.flaps_conf = self.generate_configuration(context);
 
         self.flaps_demanded_angle = Self::demanded_flaps_fppu_angle_from_conf(self.flaps_conf);
         self.slats_demanded_angle = Self::demanded_slats_fppu_angle_from_conf(self.flaps_conf);

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/mod.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/mod.rs
@@ -2235,16 +2235,16 @@ impl A320Hydraulic {
 
         self.flap_system.update(
             context,
-            self.slats_flaps_complex.flap_demand(),
-            self.slats_flaps_complex.flap_demand(),
+            self.slats_flaps_complex.flap_demand(0),
+            self.slats_flaps_complex.flap_demand(1),
             self.green_circuit.system_section(),
             self.yellow_circuit.system_section(),
         );
 
         self.slat_system.update(
             context,
-            self.slats_flaps_complex.slat_demand(),
-            self.slats_flaps_complex.slat_demand(),
+            self.slats_flaps_complex.slat_demand(0),
+            self.slats_flaps_complex.slat_demand(1),
             self.blue_circuit.system_section(),
             self.green_circuit.system_section(),
         );

--- a/fbw-a380x/docs/a380-simvars.md
+++ b/fbw-a380x/docs/a380-simvars.md
@@ -895,6 +895,7 @@
       | 29  | SEC 3 Fault                              |
 
 - A32NX_SFCC_{number}_SLAT_FLAP_ACTUAL_POSITION_WORD
+    - {number} is 1 or 2
     - Slat/Flap actual position discrete word of the SFCC bus output
     - Arinc429<Discrete>
     - | Bit |      Description A380X, if different     |

--- a/fbw-a380x/docs/a380-simvars.md
+++ b/fbw-a380x/docs/a380-simvars.md
@@ -894,10 +894,9 @@
       | 28  | FCDC Opposite Fault                      |
       | 29  | SEC 3 Fault                              |
 
-- A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD
+- A32NX_SFCC_{number}_SLAT_FLAP_ACTUAL_POSITION_WORD
     - Slat/Flap actual position discrete word of the SFCC bus output
     - Arinc429<Discrete>
-    - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - | Bit |      Description A380X, if different     |
       |:---:|:----------------------------------------:|
       | 11  | Slat Data Valid                          |

--- a/fbw-a380x/src/systems/instruments/src/PFD/shared/PFDSimvarPublisher.tsx
+++ b/fbw-a380x/src/systems/instruments/src/PFD/shared/PFDSimvarPublisher.tsx
@@ -179,9 +179,10 @@ export interface PFDSimvars {
 }
 
 export enum PFDVars {
-  slatsFlapsStatusRaw = 'L:A32NX_SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD',
-  slatsPositionRaw = 'L:A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD',
-  flapsPositionRaw = 'L:A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD',
+  // TODO: add switching between SFCC_1 and SFCC_2
+  slatsFlapsStatusRaw = 'L:A32NX_SFCC_1_SLAT_FLAP_SYSTEM_STATUS_WORD',
+  slatsPositionRaw = 'L:A32NX_SFCC_1_SLAT_ACTUAL_POSITION_WORD',
+  flapsPositionRaw = 'L:A32NX_SFCC_1_FLAP_ACTUAL_POSITION_WORD',
   coldDark = 'L:A32NX_COLD_AND_DARK_SPAWN',
   elec = 'L:A32NX_ELEC_AC_ESS_BUS_IS_POWERED',
   elecFo = 'L:A32NX_ELEC_AC_2_BUS_IS_POWERED',

--- a/fbw-a380x/src/systems/systems-host/CpiomC/FlightWarningSystem/FwsCore.ts
+++ b/fbw-a380x/src/systems/systems-host/CpiomC/FlightWarningSystem/FwsCore.ts
@@ -2393,7 +2393,8 @@ export class FwsCore {
     this.flapsAngle.set(SimVar.GetSimVarValue('L:A32NX_FLAPS_IPPU_ANGLE', 'degrees'));
     this.flapsHandle.set(SimVar.GetSimVarValue('L:A32NX_FLAPS_HANDLE_INDEX', 'enum'));
     this.slatsAngle.set(SimVar.GetSimVarValue('L:A32NX_SLATS_IPPU_ANGLE', 'degrees'));
-    this.flapsBaulkActiveWord.setFromSimVar('L:A32NX_SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD');
+    // TODO: add switching between SFCC_1 and SFCC_2
+    this.flapsBaulkActiveWord.setFromSimVar('L:A32NX_SFCC_1_SLAT_FLAP_SYSTEM_STATUS_WORD');
 
     // FIXME move out of acquisition to logic below
     const oneEngineAboveMinPower = this.engine1AboveIdle.get() || this.engine2AboveIdle.get();
@@ -3756,9 +3757,9 @@ export class FwsCore {
     this.spoilersArmed.set(fcdc1DiscreteWord4.bitValueOr(27, false) || fcdc2DiscreteWord4.bitValueOr(27, false));
     this.speedBrakeCommand.set(fcdc1DiscreteWord4.bitValueOr(28, false) || fcdc2DiscreteWord4.bitValueOr(28, false));
 
-    // FIXME these should be split between the two systems and the two sides
-    const flapsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD');
-    const slatsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD');
+    // TODO: add switching between SFCC_1 and SFCC_2
+    const flapsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_1_FLAP_ACTUAL_POSITION_WORD');
+    const slatsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_1_SLAT_ACTUAL_POSITION_WORD');
 
     // WARNING these vary for other variants... A320 CFM LEAP values here
     // flap/slat internal signals

--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
@@ -509,11 +509,14 @@ void FlyByWireInterface::setupLocalVariables() {
     idLgciuDiscreteWord4[i] = std::make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_DISCRETE_WORD_4");
   }
 
-  idSfccSlatFlapComponentStatusWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_COMPONENT_STATUS_WORD");
-  idSfccSlatFlapSystemStatusWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD");
-  idSfccSlatFlapActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD");
-  idSfccSlatActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD");
-  idSfccFlapActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD");
+  for (int i = 0; i < 2; i++) {
+    std::string idString = std::to_string(i + 1);
+    idSfccSlatFlapComponentStatusWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_FLAP_COMPONENT_STATUS_WORD");
+    idSfccSlatFlapSystemStatusWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_FLAP_SYSTEM_STATUS_WORD");
+    idSfccSlatFlapActualPositionWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_FLAP_ACTUAL_POSITION_WORD");
+    idSfccSlatActualPositionWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_ACTUAL_POSITION_WORD");
+    idSfccFlapActualPositionWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_FLAP_ACTUAL_POSITION_WORD");
+  }
 
   for (int i = 0; i < 3; i++) {
     std::string idString = std::to_string(i + 1);
@@ -1197,11 +1200,11 @@ bool FlyByWireInterface::updateLgciu(int lgciuIndex) {
 }
 
 bool FlyByWireInterface::updateSfcc(int sfccIndex) {
-  sfccBusOutputs[sfccIndex].slat_flap_component_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapComponentStatusWord->get());
-  sfccBusOutputs[sfccIndex].slat_flap_system_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapSystemStatusWord->get());
-  sfccBusOutputs[sfccIndex].slat_flap_actual_position_word = Arinc429Utils::fromSimVar(idSfccSlatFlapActualPositionWord->get());
-  sfccBusOutputs[sfccIndex].slat_actual_position_deg = Arinc429Utils::fromSimVar(idSfccSlatActualPositionWord->get());
-  sfccBusOutputs[sfccIndex].flap_actual_position_deg = Arinc429Utils::fromSimVar(idSfccFlapActualPositionWord->get());
+  sfccBusOutputs[sfccIndex].slat_flap_component_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapComponentStatusWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].slat_flap_system_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapSystemStatusWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].slat_flap_actual_position_word = Arinc429Utils::fromSimVar(idSfccSlatFlapActualPositionWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].slat_actual_position_deg = Arinc429Utils::fromSimVar(idSfccSlatActualPositionWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].flap_actual_position_deg = Arinc429Utils::fromSimVar(idSfccFlapActualPositionWord[sfccIndex]->get());
 
   if (clientDataEnabled) {
     simConnectInterface.setClientDataSfcc(sfccBusOutputs[sfccIndex], sfccIndex);

--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.h
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.h
@@ -374,11 +374,11 @@ class FlyByWireInterface {
   std::unique_ptr<LocalVariable> idLgciuDiscreteWord4[2];
 
   // SFCC inputs
-  std::unique_ptr<LocalVariable> idSfccSlatFlapComponentStatusWord;
-  std::unique_ptr<LocalVariable> idSfccSlatFlapSystemStatusWord;
-  std::unique_ptr<LocalVariable> idSfccSlatFlapActualPositionWord;
-  std::unique_ptr<LocalVariable> idSfccSlatActualPositionWord;
-  std::unique_ptr<LocalVariable> idSfccFlapActualPositionWord;
+  std::unique_ptr<LocalVariable> idSfccSlatFlapComponentStatusWord[2];
+  std::unique_ptr<LocalVariable> idSfccSlatFlapSystemStatusWord[2];
+  std::unique_ptr<LocalVariable> idSfccSlatFlapActualPositionWord[2];
+  std::unique_ptr<LocalVariable> idSfccSlatActualPositionWord[2];
+  std::unique_ptr<LocalVariable> idSfccFlapActualPositionWord[2];
 
   // ADR bus inputs
   std::unique_ptr<LocalVariable> idAdrAltitudeCorrected[3];

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/flaps_computer.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/flaps_computer.rs
@@ -1,4 +1,5 @@
 use crate::systems::shared::arinc429::{Arinc429Word, SignStatus};
+use systems::accept_iterable;
 use systems::hydraulic::command_sensor_unit::{CSUMonitor, CSU};
 use systems::shared::{AdirsMeasurementOutputs, PositionPickoffUnit};
 
@@ -37,6 +38,8 @@ struct SlatFlapControlComputer {
     flap_load_relief_active: bool,
     cruise_baulk_active: bool,
     alpha_speed_lock_active: bool,
+
+    csu_monitor: CSUMonitor,
 }
 
 impl SlatFlapControlComputer {
@@ -57,17 +60,17 @@ impl SlatFlapControlComputer {
     const FLRS_CONF2S_TO_CONF3_AIRSPEED_THRESHOLD_KNOTS: f64 = 193.5;
     const FLRS_CONF3_TO_CONFFULL_AIRSPEED_THRESHOLD_KNOTS: f64 = 179.5;
 
-    fn new(context: &mut InitContext) -> Self {
+    fn new(context: &mut InitContext, num: u8) -> Self {
         Self {
             flaps_conf_index_id: context.get_identifier("FLAPS_CONF_INDEX".to_owned()),
             slat_flap_system_status_word_id: context
-                .get_identifier("SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_SLAT_FLAP_SYSTEM_STATUS_WORD")),
             slat_flap_actual_position_word_id: context
-                .get_identifier("SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_SLAT_FLAP_ACTUAL_POSITION_WORD")),
             slat_actual_position_word_id: context
-                .get_identifier("SFCC_SLAT_ACTUAL_POSITION_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_SLAT_ACTUAL_POSITION_WORD")),
             flap_actual_position_word_id: context
-                .get_identifier("SFCC_FLAP_ACTUAL_POSITION_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_FLAP_ACTUAL_POSITION_WORD")),
 
             flaps_demanded_angle: Angle::new::<degree>(0.),
             slats_demanded_angle: Angle::new::<degree>(0.),
@@ -78,6 +81,8 @@ impl SlatFlapControlComputer {
             flap_load_relief_active: false,
             cruise_baulk_active: false,
             alpha_speed_lock_active: false,
+
+            csu_monitor: CSUMonitor::new(context),
         }
     }
 
@@ -265,15 +270,16 @@ impl SlatFlapControlComputer {
         &mut self,
         context: &UpdateContext,
         adirs: &impl AdirsMeasurementOutputs,
-        flaps_handle: &CSUMonitor,
         flaps_feedback: &impl PositionPickoffUnit,
         slats_feedback: &impl PositionPickoffUnit,
     ) {
-        self.flaps_handle_position = flaps_handle.get_current_detent();
-        self.flaps_conf = self.generate_configuration(flaps_handle, context, adirs);
-        self.flap_load_relief_active = self.flap_load_relief_active(flaps_handle);
-        self.cruise_baulk_active = self.cruise_baulk_active(flaps_handle);
-        self.alpha_speed_lock_active = self.alpha_speed_lock_active(flaps_handle);
+        self.csu_monitor.update(context);
+
+        self.flaps_handle_position = self.csu_monitor.get_current_detent();
+        self.flaps_conf = self.generate_configuration(&self.csu_monitor, context, adirs);
+        self.flap_load_relief_active = self.flap_load_relief_active(&self.csu_monitor);
+        self.cruise_baulk_active = self.cruise_baulk_active(&self.csu_monitor);
+        self.alpha_speed_lock_active = self.alpha_speed_lock_active(&self.csu_monitor);
 
         self.flaps_demanded_angle = Self::demanded_flaps_fppu_angle_from_conf(self.flaps_conf);
         self.slats_demanded_angle = Self::demanded_slats_fppu_angle_from_conf(self.flaps_conf);
@@ -423,6 +429,11 @@ impl SlatFlapLane for SlatFlapControlComputer {
 }
 
 impl SimulationElement for SlatFlapControlComputer {
+    fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
+        self.csu_monitor.accept(visitor);
+        visitor.visit(self);
+    }
+
     fn write(&self, writer: &mut SimulatorWriter) {
         writer.write(&self.flaps_conf_index_id, self.flaps_conf as u8);
 
@@ -446,15 +457,16 @@ impl SimulationElement for SlatFlapControlComputer {
 }
 
 pub struct SlatFlapComplex {
-    sfcc: SlatFlapControlComputer,
-    csu_monitor: CSUMonitor,
+    sfcc: [SlatFlapControlComputer; 2],
 }
 
 impl SlatFlapComplex {
     pub fn new(context: &mut InitContext) -> Self {
         Self {
-            sfcc: SlatFlapControlComputer::new(context),
-            csu_monitor: CSUMonitor::new(context),
+            sfcc: [
+                SlatFlapControlComputer::new(context, 1),
+                SlatFlapControlComputer::new(context, 2),
+            ],
         }
     }
 
@@ -465,28 +477,25 @@ impl SlatFlapComplex {
         flaps_feedback: &impl PositionPickoffUnit,
         slats_feedback: &impl PositionPickoffUnit,
     ) {
-        self.csu_monitor.update(context);
-        self.sfcc.update(
-            context,
-            adirs,
-            &self.csu_monitor,
-            flaps_feedback,
-            slats_feedback,
-        );
+        self.sfcc[0].update(context, adirs, flaps_feedback, slats_feedback);
+        self.sfcc[1].update(context, adirs, flaps_feedback, slats_feedback);
     }
 
-    pub fn flap_demand(&self) -> Option<Angle> {
-        self.sfcc.signal_demanded_angle("FLAPS")
+    // `idx` 0 is for SFCC1
+    // `idx` 1 is for SFCC2
+    pub fn flap_demand(&self, idx: usize) -> Option<Angle> {
+        self.sfcc[idx].signal_demanded_angle("FLAPS")
     }
 
-    pub fn slat_demand(&self) -> Option<Angle> {
-        self.sfcc.signal_demanded_angle("SLATS")
+    // `idx` 0 is for SFCC1
+    // `idx` 1 is for SFCC2
+    pub fn slat_demand(&self, idx: usize) -> Option<Angle> {
+        self.sfcc[idx].signal_demanded_angle("SLATS")
     }
 }
 impl SimulationElement for SlatFlapComplex {
     fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
-        self.csu_monitor.accept(visitor);
-        self.sfcc.accept(visitor);
+        accept_iterable!(self.sfcc, visitor);
         visitor.visit(self);
     }
 }
@@ -655,13 +664,13 @@ mod tests {
                 .update(context, &self.adirs, &self.flap_gear, &self.slat_gear);
             self.flap_gear.update(
                 context,
-                &self.slat_flap_complex.sfcc,
+                &self.slat_flap_complex.sfcc[0],
                 self.green_pressure,
                 self.yellow_pressure,
             );
             self.slat_gear.update(
                 context,
-                &self.slat_flap_complex.sfcc,
+                &self.slat_flap_complex.sfcc[0],
                 self.blue_pressure,
                 self.green_pressure,
             );
@@ -775,12 +784,12 @@ mod tests {
             self.read_by_name("FLAPS_HANDLE_INDEX")
         }
 
-        fn read_slat_flap_system_status_word(&mut self) -> Arinc429Word<u32> {
-            self.read_by_name("SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD")
+        fn read_slat_flap_system_status_word(&mut self, num: u8) -> Arinc429Word<u32> {
+            self.read_by_name(&format!("SFCC_{num}_SLAT_FLAP_SYSTEM_STATUS_WORD"))
         }
 
-        fn read_slat_flap_actual_position_word(&mut self) -> Arinc429Word<u32> {
-            self.read_by_name("SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD")
+        fn read_slat_flap_actual_position_word(&mut self, num: u8) -> Arinc429Word<u32> {
+            self.read_by_name(&format!("SFCC_{num}_SLAT_FLAP_ACTUAL_POSITION_WORD"))
         }
 
         fn set_indicated_airspeed(mut self, indicated_airspeed: f64) -> Self {
@@ -813,26 +822,24 @@ mod tests {
             self
         }
 
-        fn get_flaps_demanded_angle(&self) -> f64 {
+        fn get_flaps_demanded_angle(&self, idx: usize) -> f64 {
             self.query(|a| {
-                a.slat_flap_complex
-                    .sfcc
+                a.slat_flap_complex.sfcc[idx]
                     .flaps_demanded_angle
                     .get::<degree>()
             })
         }
 
-        fn get_slats_demanded_angle(&self) -> f64 {
+        fn get_slats_demanded_angle(&self, idx: usize) -> f64 {
             self.query(|a| {
-                a.slat_flap_complex
-                    .sfcc
+                a.slat_flap_complex.sfcc[idx]
                     .slats_demanded_angle
                     .get::<degree>()
             })
         }
 
-        fn get_flaps_conf(&self) -> FlapsConf {
-            self.query(|a| a.slat_flap_complex.sfcc.flaps_conf)
+        fn get_flaps_conf(&self, num: usize) -> FlapsConf {
+            self.query(|a| a.slat_flap_complex.sfcc[num].flaps_conf)
         }
 
         fn get_flaps_fppu_feedback(&self) -> f64 {
@@ -852,9 +859,12 @@ mod tests {
             angle_delta: f64,
         ) {
             assert_eq!(self.read_flaps_handle_position(), handle_pos);
-            assert!((self.get_flaps_demanded_angle() - flaps_demanded_angle).abs() < angle_delta);
-            assert!((self.get_slats_demanded_angle() - slats_demanded_angle).abs() < angle_delta);
-            assert_eq!(self.get_flaps_conf(), conf);
+            assert!((self.get_flaps_demanded_angle(0) - flaps_demanded_angle).abs() < angle_delta);
+            assert!((self.get_flaps_demanded_angle(1) - flaps_demanded_angle).abs() < angle_delta);
+            assert!((self.get_slats_demanded_angle(0) - slats_demanded_angle).abs() < angle_delta);
+            assert!((self.get_slats_demanded_angle(1) - slats_demanded_angle).abs() < angle_delta);
+            assert_eq!(self.get_flaps_conf(0), conf);
+            assert_eq!(self.get_flaps_conf(1), conf);
         }
     }
     impl TestBed for A380FlapsTestBed {
@@ -892,6 +902,18 @@ mod tests {
         assert!(test_bed.contains_variable_with_name("RIGHT_SLATS_POSITION_PERCENT"));
 
         assert!(test_bed.contains_variable_with_name("FLAPS_CONF_INDEX"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FLAP_ACTUAL_POSITION_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FLAP_ACTUAL_POSITION_WORD"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SLAT_ACTUAL_POSITION_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SLAT_ACTUAL_POSITION_WORD"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SLAT_FLAP_ACTUAL_POSITION_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SLAT_FLAP_ACTUAL_POSITION_WORD"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SLAT_FLAP_SYSTEM_STATUS_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SLAT_FLAP_SYSTEM_STATUS_WORD"));
     }
 
     #[test]
@@ -904,24 +926,41 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(10));
 
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -934,24 +973,41 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -964,24 +1020,41 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -994,24 +1067,41 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -1024,24 +1114,41 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -1054,24 +1161,41 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     // Tests flaps configuration and angles for regular
@@ -1143,21 +1267,25 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed
             .set_indicated_airspeed(220.)
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
     }
 
     //Tests transition between Conf1F to Conf1 above 212 knots
@@ -1169,15 +1297,18 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_indicated_airspeed(150.).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_indicated_airspeed(220.).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
     }
 
     // Tests flaps configuration and angles for regular
@@ -1258,19 +1389,24 @@ mod tests {
             .run_one_tick();
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed
             .set_indicated_airspeed(160.)
@@ -1278,19 +1414,24 @@ mod tests {
             .run_one_tick();
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed
             .set_indicated_airspeed(220.)
@@ -1298,19 +1439,24 @@ mod tests {
             .run_one_tick();
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
     }
 
     #[test]
@@ -1321,16 +1467,20 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1338,13 +1488,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1352,12 +1505,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
+
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1365,13 +1522,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1379,13 +1539,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
     }
 
     #[test]
@@ -1396,13 +1559,16 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1410,13 +1576,16 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
     }
 
     #[test]
@@ -1427,13 +1596,16 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1441,13 +1613,16 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1455,13 +1630,16 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
     }
 
     #[test]
@@ -1472,13 +1650,16 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1486,13 +1667,16 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1500,19 +1684,24 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
     }
 
     #[test]
@@ -1525,14 +1714,19 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(20));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1547,14 +1741,19 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed
             .set_flaps_handle_position(2)
             .run_waiting_for(Duration::from_secs(35));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1569,14 +1768,19 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(30));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1591,14 +1795,19 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(20));
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed
             .set_flaps_handle_position(4)
             .run_waiting_for(Duration::from_secs(20));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1613,14 +1822,19 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(60));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1635,18 +1849,27 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(60));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
                 <= angle_delta
         );
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1661,14 +1884,19 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed
             .set_flaps_handle_position(2)
             .run_waiting_for(Duration::from_secs(60));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1683,14 +1911,19 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(60));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1705,14 +1938,19 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed
             .set_flaps_handle_position(4)
             .run_waiting_for(Duration::from_secs(50));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1729,7 +1967,8 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_waiting_for(Duration::from_secs(50));
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
     }
 
     #[test]
@@ -1744,7 +1983,8 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(50));
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2S);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2S);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2S);
     }
 
     #[test]
@@ -1759,7 +1999,8 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_waiting_for(Duration::from_secs(50));
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
     }
 
     #[test]
@@ -1775,8 +2016,10 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(20));
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(25));
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(25));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(25));
     }
 
     #[test]
@@ -1789,18 +2032,24 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(24));
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(24));
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(24));
 
         test_bed = test_bed.set_indicated_airspeed(200.).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(24));
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
     }
 
     #[test]
@@ -1813,19 +2062,25 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(24));
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(24));
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(24));
 
         test_bed = test_bed
             .set_angle_of_attack(Angle::new::<degree>(9.1))
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(24));
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
     }
 }

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
@@ -2535,16 +2535,16 @@ impl A380Hydraulic {
 
         self.flap_system.update(
             context,
-            self.slats_flaps_complex.flap_demand(),
-            self.slats_flaps_complex.flap_demand(),
+            self.slats_flaps_complex.flap_demand(0),
+            self.slats_flaps_complex.flap_demand(1),
             self.green_circuit.system_section(),
             self.yellow_circuit.system_section(),
         );
 
         self.slat_system.update(
             context,
-            self.slats_flaps_complex.slat_demand(),
-            self.slats_flaps_complex.slat_demand(),
+            self.slats_flaps_complex.slat_demand(0),
+            self.slats_flaps_complex.slat_demand(1),
             self.green_circuit.system_section(),
             self.green_circuit.system_section(),
         );


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR adds the simulation of a dual SFCC.

Failures and cross-talk aren't implemented. All readers of SFCC ARINC words are set to use `SFCC_1`.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Not necessary

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->
ATA27-50 system

## Additional context
<!-- Add any other context about the pull request here. -->
To be merged after #10151

I would like to continue the work started in the draft PR https://github.com/flybywiresim/aircraft/pull/7632 which aims to rewrite the SFCC. Instead of making a big PR, I would like to make incremental changes.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): pythonist

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Test on A320 and A380.
With plane ready for takeoff, move the flaps lever through all the positions and verify that the flaps/slats move accordingly on the external model and the EWD.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
