### PR TITLE
feat(a320/sfcc): added implementation of SFCC FAP discrete outputs

### DIFF
--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -3570,6 +3570,10 @@ In the variables below, {number} should be replaced with one item in the set: { 
     - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - The Flap FPPU angle ranges from 0° to 360°
 
+- A32NX_SFCC_FAP_{num}
+    - Flap actual position discrete output
+    - {num} is from 1 to 7
+
 ## Flight Controls (ATA 27)
 
 - A32NX_FLIGHT_CONTROLS_TRACKING_MODE

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_Core/A32NX_GPWS.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_Core/A32NX_GPWS.ts
@@ -213,12 +213,10 @@ export class A32NX_GPWS {
     const isFlapModeOff = SimVar.GetSimVarValue('L:A32NX_GPWS_FLAP_OFF', 'Bool') === 1;
     const isLdgFlap3On = SimVar.GetSimVarValue('L:A32NX_GPWS_FLAPS3', 'Bool') === 1;
 
-    const sfccPositionWord = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD');
-    const isFlapsFull = sfccPositionWord.bitValueOr(22, false);
-    const isFlaps3 = sfccPositionWord.bitValueOr(21, false) && !isFlapsFull;
+    const sfccFap5 = SimVar.GetSimVarValue('L:A32NX_SFCC_FAP_5', 'Bool') === 1; // Flaps > 19deg
+    const sfccFap1 = SimVar.GetSimVarValue('L:A32NX_SFCC_FAP_1', 'Bool') === 1; // Flaps > 39deg
 
-    const areFlapsInLandingConfig =
-      !sfccPositionWord.isNormalOperation() || isFlapModeOff || (isLdgFlap3On ? isFlaps3 : isFlapsFull);
+    const areFlapsInLandingConfig = isFlapModeOff || (isLdgFlap3On ? sfccFap5 : sfccFap1);
     const isGearDownLocked = SimVar.GetSimVarValue('L:A32NX_LGCIU_1_LEFT_GEAR_DOWNLOCKED', 'Bool') === 1;
 
     // TODO only use this in the air?


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR adds the implementation of the FAP discrete outputs from the SFCC

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Not necessary

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->
ATA 27-50

## Additional context
<!-- Add any other context about the pull request here. -->
N/A

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): python

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Perform normal landing with FLAPS 3 (and FLAPS 3 pushbutton): verify no alarms from EGPWS
Perform landing with FLAPS FULL: verify no alarms from EGPWS
Perform landing with FLAPS 2: verify EGPWS alarm goes off

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
