### PR TITLE
feat(a32nx/fws): implement BAT 1(2) off ECAM message

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -93,6 +93,7 @@
 1. [A380X/FMS] Add TL indication for tailwind on APPR PERF - @Jonny23787 (Jonathan)
 1. [A32NX/FMS] Consider pilot-entered tropopause for automatic cruise temperature calculation - @BlueberryKing (BlueberryKing)
 1. [FMS] Make sure radials of CR/VR legs use the station declination as magvar - @BlueberryKing (BlueberryKing)
+1. [A32NX/FWS] Implement BAT 1(2) OFF ECAM warning - @BlueberryKing (BlueberryKing)
 
 ## 0.13.0
 

--- a/fbw-a32nx/src/systems/instruments/src/Common/EWDMessages.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/Common/EWDMessages.tsx
@@ -210,6 +210,8 @@ const EWDMessages = {
   '221070002': '\x1b<5m -TOW AND T.O DATA.CHECK',
   '221071001': '\x1b<4m\x1b4mT.O\x1bm V1/VR/V2 DISAGREE',
   '221072001': '\x1b<4m\x1b4mT.O\x1bm SPEEDS NOT INSERTED',
+  '240060001': '\x1b<4m\x1b4mELEC\x1bm BAT 1 OFF',
+  '240061001': '\x1b<4m\x1b4mELEC\x1bm BAT 2 OFF',
   '260001001': '\x1b<2m\x1b4mENG 1 FIRE\x1bm',
   '260001002': '\x1b<5m -THR LEVER 1.......IDLE',
   '260001003': '\x1b<5m -THR LEVERS........IDLE',


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Just a small PR that implements the BAT 1 OFF and BAT 2 OFF ECAM messages.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
<img width="649" height="648" alt="image" src="https://github.com/user-attachments/assets/62c77ab0-46cf-4b56-90af-96373d3fd49b" />

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Ensure warning does not show up if battery is off and both engines are off.
- After having started an engine, turn batteries off one by one, ensure correct warning shows up. No master caution should come up with the warning.
- If the batteries are turned off in-flight or during takeoff, the warning should only show up after about 60 seconds in the air and not while in T.O INHIBIT.
- Make sure the ELEC system page shows up when the warning occurs.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
