### PR TITLE
fix(efb): Instant Fuel allowed always

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_Core/A32NX_Refuel.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_Core/A32NX_Refuel.ts
@@ -6,10 +6,10 @@ import { NXUnits } from '@flybywiresim/fbw-sdk';
 
 const WING_FUELRATE_GAL_SEC = 4.01;
 const CENTER_MODIFIER = 0.4528;
-enum RefuelRate {
-  REAL = '0',
-  FAST = '1',
-  INSTANT = '2',
+enum RefuelRateNumeric {
+  REAL = 0,
+  FAST = 1,
+  INSTANT = 2,
 }
 
 // FIXME move to systems host
@@ -58,7 +58,7 @@ export class A32NX_Refuel {
     const eng1Running = SimVar.GetSimVarValue('ENG COMBUSTION:1', 'Bool');
     const eng2Running = SimVar.GetSimVarValue('ENG COMBUSTION:2', 'Bool');
     const refuelRate = SimVar.GetSimVarValue('L:A32NX_EFB_REFUEL_RATE_SETTING', 'number');
-    if (refuelRate !== RefuelRate.INSTANT) {
+    if (refuelRate !== RefuelRateNumeric.INSTANT) {
       if (!onGround || eng1Running || eng2Running || gs > 0.1 || (!busDC2 && !busDCHot1)) {
         return;
       }
@@ -83,7 +83,7 @@ export class A32NX_Refuel {
     const LOutTarget = LOutTargetSimVar;
     const RInnTarget = RInnTargetSimVar;
     const ROutTarget = ROutTargetSimVar;
-    if (refuelRate == RefuelRate.INSTANT) {
+    if (refuelRate === RefuelRateNumeric.INSTANT) {
       SimVar.SetSimVarValue('FUEL TANK CENTER QUANTITY', 'Gallons', centerTarget);
       SimVar.SetSimVarValue('FUEL TANK LEFT MAIN QUANTITY', 'Gallons', LInnTarget);
       SimVar.SetSimVarValue('FUEL TANK LEFT AUX QUANTITY', 'Gallons', LOutTarget);
@@ -91,7 +91,7 @@ export class A32NX_Refuel {
       SimVar.SetSimVarValue('FUEL TANK RIGHT AUX QUANTITY', 'Gallons', ROutTarget);
     } else {
       let multiplier = 1;
-      if (refuelRate == RefuelRate.FAST) {
+      if (refuelRate === RefuelRateNumeric.FAST) {
         multiplier = 5;
       }
       multiplier *= _deltaTime / 1000;
@@ -174,11 +174,11 @@ export class A32NX_Refuel {
     }
 
     if (
-      centerCurrent == centerTarget &&
-      LInnCurrent == LInnTarget &&
-      LOutCurrent == LOutTarget &&
-      RInnCurrent == RInnTarget &&
-      ROutCurrent == ROutTarget
+      parseInt(centerCurrent) == parseInt(centerTarget) &&
+      parseInt(LInnCurrent) == parseInt(LInnTarget) &&
+      parseInt(LOutCurrent) == parseInt(LOutTarget) &&
+      parseInt(RInnCurrent) == parseInt(RInnTarget) &&
+      parseInt(ROutCurrent) == parseInt(ROutTarget)
     ) {
       // DONE FUELING
       SimVar.SetSimVarValue('L:A32NX_REFUEL_STARTED_BY_USR', 'Bool', false);

--- a/fbw-common/src/systems/instruments/src/EFB/Ground/Pages/Fuel/A380_842/A380Fuel.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Ground/Pages/Fuel/A380_842/A380Fuel.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 FlyByWire Simulations
+// Copyright (c) 2023-2025 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
 /* eslint-disable max-len */
@@ -113,7 +113,7 @@ const ValueUnitDisplay: React.FC<NumberUnitDisplayProps> = ({ value, padTo, unit
   );
 };
 
-enum RefuelRate {
+enum RefuelRateSetting {
   REAL = '0',
   FAST = '1',
   INSTANT = '2',
@@ -195,19 +195,21 @@ export const A380Fuel: React.FC<FuelProps> = ({
 
   const gsxRefuelCallable = () => gsxRefuelState === GsxServiceStates.CALLABLE;
 
-  const canRefuel = useCallback(
-    () => !(eng1Running || eng2Running || eng3Running || eng4Running || !isOnGround),
+  const onlyInstantRefuelAllowed = useCallback(
+    () => eng1Running || eng2Running || eng3Running || eng4Running || !isOnGround,
     [eng1Running, eng2Running, eng3Running, eng4Running, isOnGround],
   );
 
-  const isRefuelStartable = useCallback(() => {
-    if (canRefuel()) {
-      if (gsxFuelSyncEnabled === 1) {
-        return gsxFuelHoseConnected === 1 || refuelRate === RefuelRate.INSTANT;
-      }
-      return true;
+  const isRefuelAllowed = useCallback(() => {
+    if (gsxFuelSyncEnabled === 1) {
+      return refuelStartedByUser || gsxFuelHoseConnected === 1 || refuelRate === RefuelRateSetting.INSTANT;
+    } else {
+      return (
+        refuelStartedByUser ||
+        !onlyInstantRefuelAllowed() ||
+        (onlyInstantRefuelAllowed() && refuelRate === RefuelRateSetting.INSTANT)
+      );
     }
-    return !canRefuel() && refuelRate === RefuelRate.INSTANT;
   }, [
     eng1Running,
     eng2Running,
@@ -246,12 +248,12 @@ export const A380Fuel: React.FC<FuelProps> = ({
   const convertToGallon = (curr: number) => curr * (1 / convertUnit) * (1 / FUEL_GALLONS_TO_KG);
 
   const calculateEta = () => {
-    if (isDesiredEqualTo(totalFuelWeightKg) || refuelRate === RefuelRate.INSTANT) {
+    if (isDesiredEqualTo(totalFuelWeightKg) || refuelRate === RefuelRateSetting.INSTANT) {
       return ' 0';
     }
 
     const differentialFuel = Math.abs(convertToGallon(totalFuelWeightKg) - convertToGallon(fuelDesiredKg));
-    const factor = refuelRate === RefuelRate.FAST ? FAST_SPEED_FACTOR : 1.0;
+    const factor = refuelRate === RefuelRateSetting.FAST ? FAST_SPEED_FACTOR : 1.0;
     const estimatedTimeSeconds = differentialFuel / (FUELRATE_TOTAL_GAL_SEC * factor);
 
     if (estimatedTimeSeconds < 35) {
@@ -275,13 +277,13 @@ export const A380Fuel: React.FC<FuelProps> = ({
   const roundUpNearest100 = (plannedFuel: number) => Math.ceil(plannedFuel / 100) * 100;
 
   const switchRefuelState = () => {
-    if (refuelStartedByUser || isRefuelStartable()) {
+    if (refuelStartedByUser || isRefuelAllowed()) {
       setRefuelStartedByUser(!refuelStartedByUser);
     }
   };
 
   const formatRefuelStatusLabel = useCallback(() => {
-    if (canRefuel()) {
+    if (isRefuelAllowed()) {
       if (refuelStartedByUser) {
         return fuelDesiredKg > totalFuelWeightKg
           ? `(${t('Ground.Fuel.Refueling')}...)`
@@ -296,7 +298,7 @@ export const A380Fuel: React.FC<FuelProps> = ({
         if (gsxRefuelActive()) {
           return `(${t('Ground.Fuel.GSXFuelRequested')})`;
         }
-        if (gsxRefuelCallable() && refuelRate !== RefuelRate.INSTANT) {
+        if (gsxRefuelCallable() && refuelRate !== RefuelRateSetting.INSTANT) {
           return `(${t('Ground.Fuel.GSXFuelSyncEnabled')})`;
         }
       }
@@ -312,7 +314,7 @@ export const A380Fuel: React.FC<FuelProps> = ({
       return fuelDesiredKg > totalFuelWeightKg ? 'text-green-500' : 'text-yellow-500';
     }
 
-    if (canRefuel()) {
+    if (isRefuelAllowed()) {
       if (isDesiredEqualTo(totalFuelWeightKg) || !refuelStartedByUser) {
         return 'text-theme-highlight';
       }
@@ -660,12 +662,12 @@ export const A380Fuel: React.FC<FuelProps> = ({
               </div>
             </div>
           </div>
-          {(!gsxFuelSyncEnabled || (refuelRate === RefuelRate.INSTANT && !gsxRefuelActive())) && (
+          {(!gsxFuelSyncEnabled || (refuelRate === RefuelRateSetting.INSTANT && !gsxRefuelActive())) && (
             <div
               className={`flex w-48 items-center justify-center ${formatRefuelStatusClass()} bg-current`}
               onClick={() => switchRefuelState()}
             >
-              <div className={`${canRefuel() ? 'text-white' : 'text-theme-unselected'}`}>
+              <div className={`${isRefuelAllowed() ? 'text-white' : 'text-theme-unselected'}`}>
                 <PlayFill size={50} className={refuelStartedByUser ? 'hidden' : ''} />
                 <StopCircleFill size={50} className={refuelStartedByUser ? '' : 'hidden'} />
               </div>
@@ -678,35 +680,35 @@ export const A380Fuel: React.FC<FuelProps> = ({
         <h2 className="flex font-medium">{t('Ground.Fuel.RefuelTime')}</h2>
         <SelectGroup>
           <SelectItem
-            selected={canRefuel() ? refuelRate === RefuelRate.INSTANT : !canRefuel()}
-            onSelect={() => setRefuelRate(RefuelRate.INSTANT)}
+            selected={refuelRate === RefuelRateSetting.INSTANT}
+            onSelect={() => setRefuelRate(RefuelRateSetting.INSTANT)}
           >
             {t('Settings.Instant')}
           </SelectItem>
 
           <TooltipWrapper
-            text={!canRefuel() ? `${t('Ground.Fuel.TT.AircraftMustBeColdAndDarkToChangeRefuelTimes')}` : ''}
+            text={!isRefuelAllowed() ? `${t('Ground.Fuel.TT.AircraftMustBeColdAndDarkToChangeRefuelTimes')}` : ''}
           >
             <div>
               <SelectItem
-                className={`${!canRefuel() && 'opacity-20'}`}
-                disabled={!canRefuel()}
-                selected={refuelRate === RefuelRate.FAST}
-                onSelect={() => setRefuelRate(RefuelRate.FAST)}
+                className={`${!isRefuelAllowed() && 'opacity-20'}`}
+                disabled={!isRefuelAllowed()}
+                selected={refuelRate === RefuelRateSetting.FAST}
+                onSelect={() => setRefuelRate(RefuelRateSetting.FAST)}
               >
                 {t('Settings.Fast')}
               </SelectItem>
             </div>
           </TooltipWrapper>
           <TooltipWrapper
-            text={!canRefuel() ? `${t('Ground.Fuel.TT.AircraftMustBeColdAndDarkToChangeRefuelTimes')}` : ''}
+            text={!isRefuelAllowed() ? `${t('Ground.Fuel.TT.AircraftMustBeColdAndDarkToChangeRefuelTimes')}` : ''}
           >
             <div>
               <SelectItem
-                className={`${!canRefuel() && 'opacity-20'}`}
-                disabled={!canRefuel()}
-                selected={refuelRate === RefuelRate.REAL}
-                onSelect={() => setRefuelRate(RefuelRate.REAL)}
+                className={`${!isRefuelAllowed() && 'opacity-20'}`}
+                disabled={!isRefuelAllowed()}
+                selected={refuelRate === RefuelRateSetting.REAL}
+                onSelect={() => setRefuelRate(RefuelRateSetting.REAL)}
               >
                 {t('Settings.Real')}
               </SelectItem>

--- a/fbw-common/src/systems/shared/src/GsxSync.ts
+++ b/fbw-common/src/systems/shared/src/GsxSync.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 FlyByWire Simulations
+// Copyright (c) 2024-2025 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
 import {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes Issues introduced with PR #9528 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- `canRefuel` renamed after its Purpose: `onlyInstantRefuelAllowed` (and is not not using easier Logic 😅 )
- `isRefuelStartable` renamed to `isRefuelAllowed` since there is no Difference between startable and allowed
- Fixed potential conflict of `RefuelRate` Enums (using String in EFB and Numeric in A32NX_Refuel.ts)
- Changed/Fixed Stop-Condition in A32NX_Refuel.ts

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
- [PR 9528](https://github.com/flybywiresim/aircraft/pull/9528)
- https://discord.com/channels/738864299392630914/754130199804772372/1395744124065550389
- https://discord.com/channels/738864299392630914/758149448399847424/1395736199477334056

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Fragtality

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

**A380X**
- Test if (only!) Instant Refuel is allowed on the Runways (Engines Running)
- Since it is only UI Changes here, quick Sanity-Checks if the UI reflects the correct State

**A320**
- Test if (only!) Instant Refuel is allowed on the Runways (Engines Running)
- Since light Changes to Refuel Code: Test different Refuel-Scenarios delivering the desired Amount of Fuel (different Speeds, with and without GSX)

Both: For Orientation use the Testing Instructions in [PR 9528](https://github.com/flybywiresim/aircraft/pull/9528)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
