### PR TITLE
feat(sfcc): refactoring of SFCC

### DIFF
--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -3506,10 +3506,9 @@ In the variables below, {number} should be replaced with one item in the set: { 
 
 ## Flaps / Slats (ATA 27)
 
-- A32NX_SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD
+- A32NX_SFCC_{number}_SLAT_FLAP_SYSTEM_STATUS_WORD
     - Slat/Flap system status discrete word of the SFCC bus output
     - Arinc429<Discrete>
-    - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - | Bit |            Description            |
       |:---:|:---------------------------------:|
       | 11  | Slat Fault                        |
@@ -3532,10 +3531,9 @@ In the variables below, {number} should be replaced with one item in the set: { 
       | 28  | Slat Data Valid                   |
       | 29  | Flap Data Valid                   |
 
-- A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD
+- A32NX_SFCC_{number}_SLAT_FLAP_ACTUAL_POSITION_WORD
     - Slat/Flap actual position discrete word of the SFCC bus output
     - Arinc429<Discrete>
-    - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - | Bit |                Description               |
       |:---:|:----------------------------------------:|
       | 11  | Slat Data Valid                          |
@@ -3558,19 +3556,17 @@ In the variables below, {number} should be replaced with one item in the set: { 
       | 28  | Slat System Jam                          |
       | 29  | Flap System Jam                          |
 
-- A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD
+- A32NX_SFCC_{number}_SLAT_ACTUAL_POSITION_WORD
     - Slat actual position word of the SFCC bus output
     - Arinc429<Degrees>
-    - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - The Slat FPPU angle ranges from 0° to 360°
 
-- A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD
+- A32NX_SFCC_{number}_FLAP_ACTUAL_POSITION_WORD
     - Flap actual position word of the SFCC bus output
     - Arinc429<Degrees>
-    - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - The Flap FPPU angle ranges from 0° to 360°
 
-- A32NX_SFCC_FAP_{num}
+- A32NX_SFCC_{side}_FAP_{num}
     - Flap actual position discrete output
     - {num} is from 1 to 7
 

--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -3507,6 +3507,7 @@ In the variables below, {number} should be replaced with one item in the set: { 
 ## Flaps / Slats (ATA 27)
 
 - A32NX_SFCC_{number}_SLAT_FLAP_SYSTEM_STATUS_WORD
+    - {number} is 1 or 2
     - Slat/Flap system status discrete word of the SFCC bus output
     - Arinc429<Discrete>
     - | Bit |            Description            |
@@ -3532,6 +3533,7 @@ In the variables below, {number} should be replaced with one item in the set: { 
       | 29  | Flap Data Valid                   |
 
 - A32NX_SFCC_{number}_SLAT_FLAP_ACTUAL_POSITION_WORD
+    - {number} is 1 or 2
     - Slat/Flap actual position discrete word of the SFCC bus output
     - Arinc429<Discrete>
     - | Bit |                Description               |
@@ -3557,18 +3559,21 @@ In the variables below, {number} should be replaced with one item in the set: { 
       | 29  | Flap System Jam                          |
 
 - A32NX_SFCC_{number}_SLAT_ACTUAL_POSITION_WORD
+    - {number} is 1 or 2
     - Slat actual position word of the SFCC bus output
     - Arinc429<Degrees>
     - The Slat FPPU angle ranges from 0° to 360°
 
 - A32NX_SFCC_{number}_FLAP_ACTUAL_POSITION_WORD
+    - {number} is 1 or 2
     - Flap actual position word of the SFCC bus output
     - Arinc429<Degrees>
     - The Flap FPPU angle ranges from 0° to 360°
 
-- A32NX_SFCC_{side}_FAP_{num}
+- A32NX_SFCC_{number}_FAP_{id}
+    - {number} is 1 or 2
+    - {id} is from 1 to 7
     - Flap actual position discrete output
-    - {num} is from 1 to 7
 
 ## Flight Controls (ATA 27)
 

--- a/fbw-a32nx/src/systems/instruments/src/EWD/shared/EwdSimvarPublisher.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EWD/shared/EwdSimvarPublisher.tsx
@@ -109,9 +109,10 @@ export enum EwdVars {
   flexTemp = 'L:A32NX_AIRLINER_TO_FLEX_TEMP',
   satRaw = 'L:A32NX_ADIRS_ADR_1_STATIC_AIR_TEMPERATURE',
   totalFuel = 'FUEL TOTAL QUANTITY WEIGHT',
-  slatsFlapsStatusRaw = 'L:A32NX_SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD',
-  slatsPositionRaw = 'L:A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD',
-  flapsPositionRaw = 'L:A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD',
+  // TODO: add switching between SFCC_1 and SFCC_2
+  slatsFlapsStatusRaw = 'L:A32NX_SFCC_1_SLAT_FLAP_SYSTEM_STATUS_WORD',
+  slatsPositionRaw = 'L:A32NX_SFCC_1_SLAT_ACTUAL_POSITION_WORD',
+  flapsPositionRaw = 'L:A32NX_SFCC_1_FLAP_ACTUAL_POSITION_WORD',
   ewdLowerLeft1 = 'L:A32NX_Ewd_LOWER_LEFT_LINE_1',
   ewdLowerLeft2 = 'L:A32NX_Ewd_LOWER_LEFT_LINE_2',
   ewdLowerLeft3 = 'L:A32NX_Ewd_LOWER_LEFT_LINE_3',

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_Core/A32NX_GPWS.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_Core/A32NX_GPWS.ts
@@ -213,8 +213,8 @@ export class A32NX_GPWS {
     const isFlapModeOff = SimVar.GetSimVarValue('L:A32NX_GPWS_FLAP_OFF', 'Bool') === 1;
     const isLdgFlap3On = SimVar.GetSimVarValue('L:A32NX_GPWS_FLAPS3', 'Bool') === 1;
 
-    const sfccFap5 = SimVar.GetSimVarValue('L:A32NX_SFCC_FAP_5', 'Bool') === 1; // Flaps > 19deg
-    const sfccFap1 = SimVar.GetSimVarValue('L:A32NX_SFCC_FAP_1', 'Bool') === 1; // Flaps > 39deg
+    const sfccFap5 = SimVar.GetSimVarValue('L:A32NX_SFCC_1_FAP_5', 'Bool') === 1; // Flaps > 19deg
+    const sfccFap1 = SimVar.GetSimVarValue('L:A32NX_SFCC_1_FAP_1', 'Bool') === 1; // Flaps > 39deg
 
     const areFlapsInLandingConfig = isFlapModeOff || (isLdgFlap3On ? sfccFap5 : sfccFap1);
     const isGearDownLocked = SimVar.GetSimVarValue('L:A32NX_LGCIU_1_LEFT_GEAR_DOWNLOCKED', 'Bool') === 1;

--- a/fbw-a32nx/src/systems/systems-host/systems/FWC/PseudoFWC.ts
+++ b/fbw-a32nx/src/systems/systems-host/systems/FWC/PseudoFWC.ts
@@ -2493,9 +2493,9 @@ export class PseudoFWC {
     this.flapsHandle.set(SimVar.GetSimVarValue('L:A32NX_FLAPS_HANDLE_INDEX', 'enum'));
     this.slatsAngle.set(SimVar.GetSimVarValue('L:A32NX_SLATS_IPPU_ANGLE', 'degrees'));
 
-    // FIXME these should be split between the two systems and the two sides
-    const flapsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD');
-    const slatsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD');
+    // TODO: add switching between SFCC_1 and SFCC_2
+    const flapsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_1_FLAP_ACTUAL_POSITION_WORD');
+    const slatsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_1_SLAT_ACTUAL_POSITION_WORD');
 
     // WARNING these vary for other variants... A320 CFM LEAP values here
     // flap/slat internal signals

--- a/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
@@ -503,11 +503,14 @@ void FlyByWireInterface::setupLocalVariables() {
     idLgciuDiscreteWord4[i] = std::make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_DISCRETE_WORD_4");
   }
 
-  idSfccSlatFlapComponentStatusWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_COMPONENT_STATUS_WORD");
-  idSfccSlatFlapSystemStatusWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD");
-  idSfccSlatFlapActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD");
-  idSfccSlatActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD");
-  idSfccFlapActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD");
+  for (int i = 0; i < 2; i++) {
+    std::string idString = std::to_string(i + 1);
+    idSfccSlatFlapComponentStatusWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_FLAP_COMPONENT_STATUS_WORD");
+    idSfccSlatFlapSystemStatusWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_FLAP_SYSTEM_STATUS_WORD");
+    idSfccSlatFlapActualPositionWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_FLAP_ACTUAL_POSITION_WORD");
+    idSfccSlatActualPositionWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_ACTUAL_POSITION_WORD");
+    idSfccFlapActualPositionWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_FLAP_ACTUAL_POSITION_WORD");
+  }
 
   for (int i = 0; i < 3; i++) {
     std::string idString = std::to_string(i + 1);
@@ -1253,11 +1256,11 @@ bool FlyByWireInterface::updateLgciu(int lgciuIndex) {
 }
 
 bool FlyByWireInterface::updateSfcc(int sfccIndex) {
-  sfccBusOutputs[sfccIndex].slat_flap_component_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapComponentStatusWord->get());
-  sfccBusOutputs[sfccIndex].slat_flap_system_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapSystemStatusWord->get());
-  sfccBusOutputs[sfccIndex].slat_flap_actual_position_word = Arinc429Utils::fromSimVar(idSfccSlatFlapActualPositionWord->get());
-  sfccBusOutputs[sfccIndex].slat_actual_position_deg = Arinc429Utils::fromSimVar(idSfccSlatActualPositionWord->get());
-  sfccBusOutputs[sfccIndex].flap_actual_position_deg = Arinc429Utils::fromSimVar(idSfccFlapActualPositionWord->get());
+  sfccBusOutputs[sfccIndex].slat_flap_component_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapComponentStatusWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].slat_flap_system_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapSystemStatusWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].slat_flap_actual_position_word = Arinc429Utils::fromSimVar(idSfccSlatFlapActualPositionWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].slat_actual_position_deg = Arinc429Utils::fromSimVar(idSfccSlatActualPositionWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].flap_actual_position_deg = Arinc429Utils::fromSimVar(idSfccFlapActualPositionWord[sfccIndex]->get());
 
   if (clientDataEnabled) {
     simConnectInterface.setClientDataSfcc(sfccBusOutputs[sfccIndex], sfccIndex);

--- a/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.h
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.h
@@ -332,11 +332,11 @@ class FlyByWireInterface {
   std::unique_ptr<LocalVariable> idLgciuDiscreteWord4[2];
 
   // SFCC inputs
-  std::unique_ptr<LocalVariable> idSfccSlatFlapComponentStatusWord;
-  std::unique_ptr<LocalVariable> idSfccSlatFlapSystemStatusWord;
-  std::unique_ptr<LocalVariable> idSfccSlatFlapActualPositionWord;
-  std::unique_ptr<LocalVariable> idSfccSlatActualPositionWord;
-  std::unique_ptr<LocalVariable> idSfccFlapActualPositionWord;
+  std::unique_ptr<LocalVariable> idSfccSlatFlapComponentStatusWord[2];
+  std::unique_ptr<LocalVariable> idSfccSlatFlapSystemStatusWord[2];
+  std::unique_ptr<LocalVariable> idSfccSlatFlapActualPositionWord[2];
+  std::unique_ptr<LocalVariable> idSfccSlatActualPositionWord[2];
+  std::unique_ptr<LocalVariable> idSfccFlapActualPositionWord[2];
 
   // ADR bus inputs
   std::unique_ptr<LocalVariable> idAdrAltitudeStandard[3];

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/flaps_channel.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/flaps_channel.rs
@@ -1,0 +1,145 @@
+use crate::systems::shared::arinc429::{Arinc429Word, SignStatus};
+use systems::hydraulic::command_sensor_unit::{CSUMonitor, CSU};
+use systems::shared::PositionPickoffUnit;
+
+use systems::simulation::{
+    InitContext, SimulationElement, SimulationElementVisitor, SimulatorWriter, UpdateContext,
+    VariableIdentifier, Write,
+};
+
+use uom::si::{angle::degree, f64::*, velocity::knot};
+
+pub struct FlapsChannel {
+    flaps_fppu_angle_id: VariableIdentifier,
+    flap_actual_position_word_id: VariableIdentifier,
+    fap_ids: [VariableIdentifier; 7],
+
+    flaps_demanded_angle: Angle,
+    flaps_feedback_angle: Angle,
+
+    fap: [bool; 7],
+
+    csu_monitor: CSUMonitor,
+}
+
+impl FlapsChannel {
+    const HANDLE_ONE_CONF_AIRSPEED_THRESHOLD_KNOTS: f64 = 100.;
+    const CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS: f64 = 210.;
+
+    pub fn new(context: &mut InitContext, num: u8) -> Self {
+        Self {
+            flaps_fppu_angle_id: context.get_identifier("FLAPS_FPPU_ANGLE".to_owned()),
+            flap_actual_position_word_id: context
+                .get_identifier(format!("SFCC_{num}_FLAP_ACTUAL_POSITION_WORD")),
+            fap_ids: [
+                context.get_identifier(format!("SFCC_{num}_FAP_1")),
+                context.get_identifier(format!("SFCC_{num}_FAP_2")),
+                context.get_identifier(format!("SFCC_{num}_FAP_3")),
+                context.get_identifier(format!("SFCC_{num}_FAP_4")),
+                context.get_identifier(format!("SFCC_{num}_FAP_5")),
+                context.get_identifier(format!("SFCC_{num}_FAP_6")),
+                context.get_identifier(format!("SFCC_{num}_FAP_7")),
+            ],
+
+            flaps_demanded_angle: Angle::new::<degree>(0.),
+            flaps_feedback_angle: Angle::new::<degree>(0.),
+
+            // Set to false to match power-off state
+            fap: [false; 7],
+            csu_monitor: CSUMonitor::new(context),
+        }
+    }
+
+    fn fap_update(&mut self) {
+        let fppu_angle = self.flaps_feedback_angle.get::<degree>();
+
+        self.fap[0] = fppu_angle > 247.8 && fppu_angle < 254.0;
+        self.fap[1] = fppu_angle > 114.6 && fppu_angle < 254.0;
+        self.fap[2] = fppu_angle > 163.7 && fppu_angle < 254.0;
+        self.fap[3] = self.csu_monitor.get_current_detent() == CSU::Conf0;
+        self.fap[4] = fppu_angle > 163.7 && fppu_angle < 254.0;
+        self.fap[5] = fppu_angle > 247.8 && fppu_angle < 254.0;
+        self.fap[6] = fppu_angle > 114.6 && fppu_angle < 254.0;
+    }
+
+    fn generate_configuration(&self, context: &UpdateContext) -> Angle {
+        // Ignored `CSU::OutOfDetent` and `CSU::Fault` positions due to simplified SFCC.
+        match (
+            self.csu_monitor.get_previous_detent(),
+            self.csu_monitor.get_current_detent(),
+        ) {
+            (CSU::Conf0, CSU::Conf1)
+                if context.indicated_airspeed().get::<knot>()
+                    <= Self::HANDLE_ONE_CONF_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::new::<degree>(120.22)
+            }
+            (CSU::Conf0, CSU::Conf1) => Angle::default(),
+            (CSU::Conf1, CSU::Conf1)
+                if context.indicated_airspeed().get::<knot>()
+                    > Self::CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::default()
+            }
+            (CSU::Conf1, CSU::Conf1) => self.flaps_demanded_angle,
+            (_, CSU::Conf1)
+                if context.indicated_airspeed().get::<knot>()
+                    <= Self::CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::new::<degree>(120.22)
+            }
+            (_, CSU::Conf1) => Angle::default(),
+            (_, CSU::Conf0) => Angle::default(),
+            (from, CSU::Conf2) if from != CSU::Conf2 => Angle::new::<degree>(145.51),
+            (from, CSU::Conf3) if from != CSU::Conf3 => Angle::new::<degree>(168.35),
+            (from, CSU::ConfFull) if from != CSU::ConfFull => Angle::new::<degree>(251.97),
+            (_, _) => self.flaps_demanded_angle,
+        }
+    }
+
+    pub fn update(&mut self, context: &UpdateContext, flaps_feedback: &impl PositionPickoffUnit) {
+        self.csu_monitor.update(context);
+        self.flaps_demanded_angle = self.generate_configuration(context);
+        self.flaps_feedback_angle = flaps_feedback.angle();
+        self.fap_update();
+    }
+
+    pub fn get_demanded_angle(&self) -> Angle {
+        self.flaps_demanded_angle
+    }
+
+    pub fn get_feedback_angle(&self) -> Angle {
+        self.flaps_feedback_angle
+    }
+
+    #[cfg(test)]
+    pub fn get_fap(&self, idx: usize) -> bool {
+        self.fap[idx]
+    }
+
+    fn flap_actual_position_word(&self) -> Arinc429Word<f64> {
+        Arinc429Word::new(
+            self.flaps_feedback_angle.get::<degree>(),
+            SignStatus::NormalOperation,
+        )
+    }
+}
+impl SimulationElement for FlapsChannel {
+    fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
+        self.csu_monitor.accept(visitor);
+        visitor.visit(self);
+    }
+
+    fn write(&self, writer: &mut SimulatorWriter) {
+        for (id, fap) in self.fap_ids.iter().zip(self.fap) {
+            writer.write(id, fap);
+        }
+
+        writer.write(&self.flaps_fppu_angle_id, self.flaps_feedback_angle);
+
+        writer.write(
+            &self.flap_actual_position_word_id,
+            self.flap_actual_position_word(),
+        );
+    }
+}

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/flaps_computer.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/flaps_computer.rs
@@ -1,4 +1,5 @@
 use crate::systems::shared::arinc429::{Arinc429Word, SignStatus};
+use systems::accept_iterable;
 use systems::hydraulic::command_sensor_unit::{CSUMonitor, CSU};
 use systems::shared::PositionPickoffUnit;
 
@@ -34,6 +35,7 @@ struct SlatFlapControlComputer {
     slats_feedback_angle: Angle,
     flaps_conf: FlapsConf,
     fap: [bool; 7],
+    csu_monitor: CSUMonitor,
 }
 
 impl SlatFlapControlComputer {
@@ -41,25 +43,25 @@ impl SlatFlapControlComputer {
     const HANDLE_ONE_CONF_AIRSPEED_THRESHOLD_KNOTS: f64 = 100.;
     const CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS: f64 = 210.;
 
-    fn new(context: &mut InitContext) -> Self {
+    fn new(context: &mut InitContext, num: u8) -> Self {
         Self {
             flaps_conf_index_id: context.get_identifier("FLAPS_CONF_INDEX".to_owned()),
             slat_flap_system_status_word_id: context
-                .get_identifier("SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_SLAT_FLAP_SYSTEM_STATUS_WORD")),
             slat_flap_actual_position_word_id: context
-                .get_identifier("SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_SLAT_FLAP_ACTUAL_POSITION_WORD")),
             slat_actual_position_word_id: context
-                .get_identifier("SFCC_SLAT_ACTUAL_POSITION_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_SLAT_ACTUAL_POSITION_WORD")),
             flap_actual_position_word_id: context
-                .get_identifier("SFCC_FLAP_ACTUAL_POSITION_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_FLAP_ACTUAL_POSITION_WORD")),
             fap_ids: [
-                context.get_identifier("SFCC_FAP_1".to_owned()),
-                context.get_identifier("SFCC_FAP_2".to_owned()),
-                context.get_identifier("SFCC_FAP_3".to_owned()),
-                context.get_identifier("SFCC_FAP_4".to_owned()),
-                context.get_identifier("SFCC_FAP_5".to_owned()),
-                context.get_identifier("SFCC_FAP_6".to_owned()),
-                context.get_identifier("SFCC_FAP_7".to_owned()),
+                context.get_identifier(format!("SFCC_{num}_FAP_1")),
+                context.get_identifier(format!("SFCC_{num}_FAP_2")),
+                context.get_identifier(format!("SFCC_{num}_FAP_3")),
+                context.get_identifier(format!("SFCC_{num}_FAP_4")),
+                context.get_identifier(format!("SFCC_{num}_FAP_5")),
+                context.get_identifier(format!("SFCC_{num}_FAP_6")),
+                context.get_identifier(format!("SFCC_{num}_FAP_7")),
             ],
 
             flaps_demanded_angle: Angle::new::<degree>(0.),
@@ -69,7 +71,8 @@ impl SlatFlapControlComputer {
             flaps_conf: FlapsConf::Conf0,
 
             // Set to false to match power-off state
-            fap: [true; 7],
+            fap: [false; 7],
+            csu_monitor: CSUMonitor::new(context),
         }
     }
 
@@ -143,27 +146,28 @@ impl SlatFlapControlComputer {
     pub fn update(
         &mut self,
         context: &UpdateContext,
-        csu_monitor: &CSUMonitor,
         flaps_feedback: &impl PositionPickoffUnit,
         slats_feedback: &impl PositionPickoffUnit,
     ) {
-        self.flaps_conf = self.generate_configuration(csu_monitor, context);
+        self.csu_monitor.update(context);
+
+        self.flaps_conf = self.generate_configuration(&self.csu_monitor, context);
 
         self.flaps_demanded_angle = Self::demanded_flaps_fppu_angle_from_conf(self.flaps_conf);
         self.slats_demanded_angle = Self::demanded_slats_fppu_angle_from_conf(self.flaps_conf);
         self.flaps_feedback_angle = flaps_feedback.angle();
         self.slats_feedback_angle = slats_feedback.angle();
 
-        self.fap_update(csu_monitor);
+        self.fap_update();
     }
 
-    fn fap_update(&mut self, csu_monitor: &CSUMonitor) {
+    fn fap_update(&mut self) {
         let fppu_angle = self.flaps_feedback_angle.get::<degree>();
 
         self.fap[0] = fppu_angle > 247.8 && fppu_angle < 254.0;
         self.fap[1] = fppu_angle > 114.6 && fppu_angle < 254.0;
         self.fap[2] = fppu_angle > 163.7 && fppu_angle < 254.0;
-        self.fap[3] = csu_monitor.get_current_detent() == CSU::Conf0;
+        self.fap[3] = self.csu_monitor.get_current_detent() == CSU::Conf0;
         self.fap[4] = fppu_angle > 163.7 && fppu_angle < 254.0;
         self.fap[5] = fppu_angle > 247.8 && fppu_angle < 254.0;
         self.fap[6] = fppu_angle > 114.6 && fppu_angle < 254.0;
@@ -305,6 +309,11 @@ impl SlatFlapLane for SlatFlapControlComputer {
 }
 
 impl SimulationElement for SlatFlapControlComputer {
+    fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
+        self.csu_monitor.accept(visitor);
+        visitor.visit(self);
+    }
+
     fn write(&self, writer: &mut SimulatorWriter) {
         for (id, fap) in self.fap_ids.iter().zip(self.fap) {
             writer.write(id, fap);
@@ -332,15 +341,16 @@ impl SimulationElement for SlatFlapControlComputer {
 }
 
 pub struct SlatFlapComplex {
-    sfcc: SlatFlapControlComputer,
-    csu_monitor: CSUMonitor,
+    sfcc: [SlatFlapControlComputer; 2],
 }
 
 impl SlatFlapComplex {
     pub fn new(context: &mut InitContext) -> Self {
         Self {
-            sfcc: SlatFlapControlComputer::new(context),
-            csu_monitor: CSUMonitor::new(context),
+            sfcc: [
+                SlatFlapControlComputer::new(context, 1),
+                SlatFlapControlComputer::new(context, 2),
+            ],
         }
     }
 
@@ -350,23 +360,25 @@ impl SlatFlapComplex {
         flaps_feedback: &impl PositionPickoffUnit,
         slats_feedback: &impl PositionPickoffUnit,
     ) {
-        self.csu_monitor.update(context);
-        self.sfcc
-            .update(context, &self.csu_monitor, flaps_feedback, slats_feedback);
+        self.sfcc[0].update(context, flaps_feedback, slats_feedback);
+        self.sfcc[1].update(context, flaps_feedback, slats_feedback);
     }
 
-    pub fn flap_demand(&self) -> Option<Angle> {
-        self.sfcc.signal_demanded_angle("FLAPS")
+    // `idx` 0 is for SFCC1
+    // `idx` 1 is for SFCC2
+    pub fn flap_demand(&self, idx: usize) -> Option<Angle> {
+        self.sfcc[idx].signal_demanded_angle("FLAPS")
     }
 
-    pub fn slat_demand(&self) -> Option<Angle> {
-        self.sfcc.signal_demanded_angle("SLATS")
+    // `idx` 0 is for SFCC1
+    // `idx` 1 is for SFCC2
+    pub fn slat_demand(&self, idx: usize) -> Option<Angle> {
+        self.sfcc[idx].signal_demanded_angle("SLATS")
     }
 }
 impl SimulationElement for SlatFlapComplex {
     fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
-        self.csu_monitor.accept(visitor);
-        self.sfcc.accept(visitor);
+        accept_iterable!(self.sfcc, visitor);
         visitor.visit(self);
     }
 }
@@ -527,13 +539,13 @@ mod tests {
                 .update(context, &self.flap_gear, &self.slat_gear);
             self.flap_gear.update(
                 context,
-                &self.slat_flap_complex.sfcc,
+                &self.slat_flap_complex.sfcc[0],
                 self.green_pressure,
                 self.yellow_pressure,
             );
             self.slat_gear.update(
                 context,
-                &self.slat_flap_complex.sfcc,
+                &self.slat_flap_complex.sfcc[0],
                 self.blue_pressure,
                 self.green_pressure,
             );
@@ -588,40 +600,40 @@ mod tests {
             self.read_by_name("FLAPS_HANDLE_INDEX")
         }
 
-        fn read_slat_flap_system_status_word(&mut self) -> Arinc429Word<u32> {
-            self.read_by_name("SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD")
+        fn read_slat_flap_system_status_word(&mut self, num: u8) -> Arinc429Word<u32> {
+            self.read_by_name(&format!("SFCC_{num}_SLAT_FLAP_SYSTEM_STATUS_WORD"))
         }
 
-        fn read_slat_flap_actual_position_word(&mut self) -> Arinc429Word<u32> {
-            self.read_by_name("SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD")
+        fn read_slat_flap_actual_position_word(&mut self, num: u8) -> Arinc429Word<u32> {
+            self.read_by_name(&format!("SFCC_{num}_SLAT_FLAP_ACTUAL_POSITION_WORD"))
         }
 
-        fn read_sfcc_fap_1_word(&mut self) -> bool {
-            self.read_by_name("SFCC_FAP_1")
+        fn read_sfcc_fap_1_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_1"))
         }
 
-        fn read_sfcc_fap_2_word(&mut self) -> bool {
-            self.read_by_name("SFCC_FAP_2")
+        fn read_sfcc_fap_2_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_2"))
         }
 
-        fn read_sfcc_fap_3_word(&mut self) -> bool {
-            self.read_by_name("SFCC_FAP_3")
+        fn read_sfcc_fap_3_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_3"))
         }
 
-        fn read_sfcc_fap_4_word(&mut self) -> bool {
-            self.read_by_name("SFCC_FAP_4")
+        fn read_sfcc_fap_4_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_4"))
         }
 
-        fn read_sfcc_fap_5_word(&mut self) -> bool {
-            self.read_by_name("SFCC_FAP_5")
+        fn read_sfcc_fap_5_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_5"))
         }
 
-        fn read_sfcc_fap_6_word(&mut self) -> bool {
-            self.read_by_name("SFCC_FAP_6")
+        fn read_sfcc_fap_6_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_6"))
         }
 
-        fn read_sfcc_fap_7_word(&mut self) -> bool {
-            self.read_by_name("SFCC_FAP_7")
+        fn read_sfcc_fap_7_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_7"))
         }
 
         fn set_indicated_airspeed(mut self, indicated_airspeed: f64) -> Self {
@@ -644,26 +656,24 @@ mod tests {
             self
         }
 
-        fn get_flaps_demanded_angle(&self) -> f64 {
+        fn get_flaps_demanded_angle(&self, idx: usize) -> f64 {
             self.query(|a| {
-                a.slat_flap_complex
-                    .sfcc
+                a.slat_flap_complex.sfcc[idx]
                     .flaps_demanded_angle
                     .get::<degree>()
             })
         }
 
-        fn get_slats_demanded_angle(&self) -> f64 {
+        fn get_slats_demanded_angle(&self, idx: usize) -> f64 {
             self.query(|a| {
-                a.slat_flap_complex
-                    .sfcc
+                a.slat_flap_complex.sfcc[idx]
                     .slats_demanded_angle
                     .get::<degree>()
             })
         }
 
-        fn get_flaps_conf(&self) -> FlapsConf {
-            self.query(|a| a.slat_flap_complex.sfcc.flaps_conf)
+        fn get_flaps_conf(&self, num: usize) -> FlapsConf {
+            self.query(|a| a.slat_flap_complex.sfcc[num].flaps_conf)
         }
 
         fn get_flaps_fppu_feedback(&self) -> f64 {
@@ -674,32 +684,32 @@ mod tests {
             self.query(|a| a.slat_gear.angle().get::<degree>())
         }
 
-        fn get_fap_1(&self) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc.fap[0])
+        fn get_fap_1(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[0])
         }
 
-        fn get_fap_2(&self) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc.fap[1])
+        fn get_fap_2(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[1])
         }
 
-        fn get_fap_3(&self) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc.fap[2])
+        fn get_fap_3(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[2])
         }
 
-        fn get_fap_4(&self) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc.fap[3])
+        fn get_fap_4(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[3])
         }
 
-        fn get_fap_5(&self) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc.fap[4])
+        fn get_fap_5(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[4])
         }
 
-        fn get_fap_6(&self) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc.fap[5])
+        fn get_fap_6(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[5])
         }
 
-        fn get_fap_7(&self) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc.fap[6])
+        fn get_fap_7(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[6])
         }
 
         fn test_flap_conf(
@@ -711,9 +721,13 @@ mod tests {
             angle_delta: f64,
         ) {
             assert_eq!(self.read_flaps_handle_position(), handle_pos);
-            assert!((self.get_flaps_demanded_angle() - flaps_demanded_angle).abs() < angle_delta);
-            assert!((self.get_slats_demanded_angle() - slats_demanded_angle).abs() < angle_delta);
-            assert_eq!(self.get_flaps_conf(), conf);
+            assert!((self.get_flaps_demanded_angle(0) - flaps_demanded_angle).abs() < angle_delta);
+            assert!((self.get_slats_demanded_angle(0) - slats_demanded_angle).abs() < angle_delta);
+            assert_eq!(self.get_flaps_conf(0), conf);
+
+            assert!((self.get_flaps_demanded_angle(1) - flaps_demanded_angle).abs() < angle_delta);
+            assert!((self.get_slats_demanded_angle(1) - slats_demanded_angle).abs() < angle_delta);
+            assert_eq!(self.get_flaps_conf(1), conf);
         }
     }
     impl TestBed for A320FlapsTestBed {
@@ -752,13 +766,33 @@ mod tests {
 
         assert!(test_bed.contains_variable_with_name("FLAPS_CONF_INDEX"));
 
-        assert!(test_bed.contains_variable_with_name("SFCC_FAP_1"));
-        assert!(test_bed.contains_variable_with_name("SFCC_FAP_2"));
-        assert!(test_bed.contains_variable_with_name("SFCC_FAP_3"));
-        assert!(test_bed.contains_variable_with_name("SFCC_FAP_4"));
-        assert!(test_bed.contains_variable_with_name("SFCC_FAP_5"));
-        assert!(test_bed.contains_variable_with_name("SFCC_FAP_6"));
-        assert!(test_bed.contains_variable_with_name("SFCC_FAP_7"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_1"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_2"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_3"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_4"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_5"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_6"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_7"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_1"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_2"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_3"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_4"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_5"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_6"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_7"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FLAP_ACTUAL_POSITION_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FLAP_ACTUAL_POSITION_WORD"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SLAT_ACTUAL_POSITION_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SLAT_ACTUAL_POSITION_WORD"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SLAT_FLAP_ACTUAL_POSITION_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SLAT_FLAP_ACTUAL_POSITION_WORD"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SLAT_FLAP_SYSTEM_STATUS_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SLAT_FLAP_SYSTEM_STATUS_WORD"));
     }
 
     #[test]
@@ -771,101 +805,181 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert!(!test_bed.get_fap_1());
-        assert!(!test_bed.get_fap_2());
-        assert!(!test_bed.get_fap_3());
-        assert!(test_bed.get_fap_4());
-        assert!(!test_bed.get_fap_5());
-        assert!(!test_bed.get_fap_6());
-        assert!(!test_bed.get_fap_7());
+        assert!(!test_bed.get_fap_1(0));
+        assert!(!test_bed.get_fap_2(0));
+        assert!(!test_bed.get_fap_3(0));
+        assert!(test_bed.get_fap_4(0));
+        assert!(!test_bed.get_fap_5(0));
+        assert!(!test_bed.get_fap_6(0));
+        assert!(!test_bed.get_fap_7(0));
 
-        assert!(!test_bed.read_sfcc_fap_1_word());
-        assert!(!test_bed.read_sfcc_fap_2_word());
-        assert!(!test_bed.read_sfcc_fap_3_word());
-        assert!(test_bed.read_sfcc_fap_4_word());
-        assert!(!test_bed.read_sfcc_fap_5_word());
-        assert!(!test_bed.read_sfcc_fap_6_word());
-        assert!(!test_bed.read_sfcc_fap_7_word());
+        assert!(!test_bed.get_fap_1(1));
+        assert!(!test_bed.get_fap_2(1));
+        assert!(!test_bed.get_fap_3(1));
+        assert!(test_bed.get_fap_4(1));
+        assert!(!test_bed.get_fap_5(1));
+        assert!(!test_bed.get_fap_6(1));
+        assert!(!test_bed.get_fap_7(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(1));
+        assert!(!test_bed.read_sfcc_fap_2_word(1));
+        assert!(!test_bed.read_sfcc_fap_3_word(1));
+        assert!(test_bed.read_sfcc_fap_4_word(1));
+        assert!(!test_bed.read_sfcc_fap_5_word(1));
+        assert!(!test_bed.read_sfcc_fap_6_word(1));
+        assert!(!test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(2));
+        assert!(!test_bed.read_sfcc_fap_2_word(2));
+        assert!(!test_bed.read_sfcc_fap_3_word(2));
+        assert!(test_bed.read_sfcc_fap_4_word(2));
+        assert!(!test_bed.read_sfcc_fap_5_word(2));
+        assert!(!test_bed.read_sfcc_fap_6_word(2));
+        assert!(!test_bed.read_sfcc_fap_7_word(2));
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.get_fap_1());
-        assert!(test_bed.get_fap_2());
-        assert!(!test_bed.get_fap_3());
-        assert!(!test_bed.get_fap_4());
-        assert!(!test_bed.get_fap_5());
-        assert!(!test_bed.get_fap_6());
-        assert!(test_bed.get_fap_7());
+        assert!(!test_bed.get_fap_1(0));
+        assert!(test_bed.get_fap_2(0));
+        assert!(!test_bed.get_fap_3(0));
+        assert!(!test_bed.get_fap_4(0));
+        assert!(!test_bed.get_fap_5(0));
+        assert!(!test_bed.get_fap_6(0));
+        assert!(test_bed.get_fap_7(0));
 
-        assert!(!test_bed.read_sfcc_fap_1_word());
-        assert!(test_bed.read_sfcc_fap_2_word());
-        assert!(!test_bed.read_sfcc_fap_3_word());
-        assert!(!test_bed.read_sfcc_fap_4_word());
-        assert!(!test_bed.read_sfcc_fap_5_word());
-        assert!(!test_bed.read_sfcc_fap_6_word());
-        assert!(test_bed.read_sfcc_fap_7_word());
+        assert!(!test_bed.get_fap_1(1));
+        assert!(test_bed.get_fap_2(1));
+        assert!(!test_bed.get_fap_3(1));
+        assert!(!test_bed.get_fap_4(1));
+        assert!(!test_bed.get_fap_5(1));
+        assert!(!test_bed.get_fap_6(1));
+        assert!(test_bed.get_fap_7(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(1));
+        assert!(test_bed.read_sfcc_fap_2_word(1));
+        assert!(!test_bed.read_sfcc_fap_3_word(1));
+        assert!(!test_bed.read_sfcc_fap_4_word(1));
+        assert!(!test_bed.read_sfcc_fap_5_word(1));
+        assert!(!test_bed.read_sfcc_fap_6_word(1));
+        assert!(test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(2));
+        assert!(test_bed.read_sfcc_fap_2_word(2));
+        assert!(!test_bed.read_sfcc_fap_3_word(2));
+        assert!(!test_bed.read_sfcc_fap_4_word(2));
+        assert!(!test_bed.read_sfcc_fap_5_word(2));
+        assert!(!test_bed.read_sfcc_fap_6_word(2));
+        assert!(test_bed.read_sfcc_fap_7_word(2));
 
         test_bed = test_bed
             .set_flaps_handle_position(2)
             .run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.get_fap_1());
-        assert!(test_bed.get_fap_2());
-        assert!(!test_bed.get_fap_3());
-        assert!(!test_bed.get_fap_4());
-        assert!(!test_bed.get_fap_5());
-        assert!(!test_bed.get_fap_6());
-        assert!(test_bed.get_fap_7());
+        assert!(!test_bed.get_fap_1(0));
+        assert!(test_bed.get_fap_2(0));
+        assert!(!test_bed.get_fap_3(0));
+        assert!(!test_bed.get_fap_4(0));
+        assert!(!test_bed.get_fap_5(0));
+        assert!(!test_bed.get_fap_6(0));
+        assert!(test_bed.get_fap_7(0));
 
-        assert!(!test_bed.read_sfcc_fap_1_word());
-        assert!(test_bed.read_sfcc_fap_2_word());
-        assert!(!test_bed.read_sfcc_fap_3_word());
-        assert!(!test_bed.read_sfcc_fap_4_word());
-        assert!(!test_bed.read_sfcc_fap_5_word());
-        assert!(!test_bed.read_sfcc_fap_6_word());
-        assert!(test_bed.read_sfcc_fap_7_word());
+        assert!(!test_bed.get_fap_1(1));
+        assert!(test_bed.get_fap_2(1));
+        assert!(!test_bed.get_fap_3(1));
+        assert!(!test_bed.get_fap_4(1));
+        assert!(!test_bed.get_fap_5(1));
+        assert!(!test_bed.get_fap_6(1));
+        assert!(test_bed.get_fap_7(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(1));
+        assert!(test_bed.read_sfcc_fap_2_word(1));
+        assert!(!test_bed.read_sfcc_fap_3_word(1));
+        assert!(!test_bed.read_sfcc_fap_4_word(1));
+        assert!(!test_bed.read_sfcc_fap_5_word(1));
+        assert!(!test_bed.read_sfcc_fap_6_word(1));
+        assert!(test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(2));
+        assert!(test_bed.read_sfcc_fap_2_word(2));
+        assert!(!test_bed.read_sfcc_fap_3_word(2));
+        assert!(!test_bed.read_sfcc_fap_4_word(2));
+        assert!(!test_bed.read_sfcc_fap_5_word(2));
+        assert!(!test_bed.read_sfcc_fap_6_word(2));
+        assert!(test_bed.read_sfcc_fap_7_word(2));
 
         test_bed = test_bed
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.get_fap_1());
-        assert!(test_bed.get_fap_2());
-        assert!(test_bed.get_fap_3());
-        assert!(!test_bed.get_fap_4());
-        assert!(test_bed.get_fap_5());
-        assert!(!test_bed.get_fap_6());
-        assert!(test_bed.get_fap_7());
+        assert!(!test_bed.get_fap_1(0));
+        assert!(test_bed.get_fap_2(0));
+        assert!(test_bed.get_fap_3(0));
+        assert!(!test_bed.get_fap_4(0));
+        assert!(test_bed.get_fap_5(0));
+        assert!(!test_bed.get_fap_6(0));
+        assert!(test_bed.get_fap_7(0));
 
-        assert!(!test_bed.read_sfcc_fap_1_word());
-        assert!(test_bed.read_sfcc_fap_2_word());
-        assert!(test_bed.read_sfcc_fap_3_word());
-        assert!(!test_bed.read_sfcc_fap_4_word());
-        assert!(test_bed.read_sfcc_fap_5_word());
-        assert!(!test_bed.read_sfcc_fap_6_word());
-        assert!(test_bed.read_sfcc_fap_7_word());
+        assert!(!test_bed.get_fap_1(1));
+        assert!(test_bed.get_fap_2(1));
+        assert!(test_bed.get_fap_3(1));
+        assert!(!test_bed.get_fap_4(1));
+        assert!(test_bed.get_fap_5(1));
+        assert!(!test_bed.get_fap_6(1));
+        assert!(test_bed.get_fap_7(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(1));
+        assert!(test_bed.read_sfcc_fap_2_word(1));
+        assert!(test_bed.read_sfcc_fap_3_word(1));
+        assert!(!test_bed.read_sfcc_fap_4_word(1));
+        assert!(test_bed.read_sfcc_fap_5_word(1));
+        assert!(!test_bed.read_sfcc_fap_6_word(1));
+        assert!(test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(2));
+        assert!(test_bed.read_sfcc_fap_2_word(2));
+        assert!(test_bed.read_sfcc_fap_3_word(2));
+        assert!(!test_bed.read_sfcc_fap_4_word(2));
+        assert!(test_bed.read_sfcc_fap_5_word(2));
+        assert!(!test_bed.read_sfcc_fap_6_word(2));
+        assert!(test_bed.read_sfcc_fap_7_word(2));
 
         test_bed = test_bed
             .set_flaps_handle_position(4)
             .run_waiting_for(Duration::from_secs(60));
 
-        assert!(test_bed.get_fap_1());
-        assert!(test_bed.get_fap_2());
-        assert!(test_bed.get_fap_3());
-        assert!(!test_bed.get_fap_4());
-        assert!(test_bed.get_fap_5());
-        assert!(test_bed.get_fap_6());
-        assert!(test_bed.get_fap_7());
+        assert!(test_bed.get_fap_1(0));
+        assert!(test_bed.get_fap_2(0));
+        assert!(test_bed.get_fap_3(0));
+        assert!(!test_bed.get_fap_4(0));
+        assert!(test_bed.get_fap_5(0));
+        assert!(test_bed.get_fap_6(0));
+        assert!(test_bed.get_fap_7(0));
 
-        assert!(test_bed.read_sfcc_fap_1_word());
-        assert!(test_bed.read_sfcc_fap_2_word());
-        assert!(test_bed.read_sfcc_fap_3_word());
-        assert!(!test_bed.read_sfcc_fap_4_word());
-        assert!(test_bed.read_sfcc_fap_5_word());
-        assert!(test_bed.read_sfcc_fap_6_word());
-        assert!(test_bed.read_sfcc_fap_7_word());
+        assert!(test_bed.get_fap_1(1));
+        assert!(test_bed.get_fap_2(1));
+        assert!(test_bed.get_fap_3(1));
+        assert!(!test_bed.get_fap_4(1));
+        assert!(test_bed.get_fap_5(1));
+        assert!(test_bed.get_fap_6(1));
+        assert!(test_bed.get_fap_7(1));
+
+        assert!(test_bed.read_sfcc_fap_1_word(1));
+        assert!(test_bed.read_sfcc_fap_2_word(1));
+        assert!(test_bed.read_sfcc_fap_3_word(1));
+        assert!(!test_bed.read_sfcc_fap_4_word(1));
+        assert!(test_bed.read_sfcc_fap_5_word(1));
+        assert!(test_bed.read_sfcc_fap_6_word(1));
+        assert!(test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(test_bed.read_sfcc_fap_1_word(2));
+        assert!(test_bed.read_sfcc_fap_2_word(2));
+        assert!(test_bed.read_sfcc_fap_3_word(2));
+        assert!(!test_bed.read_sfcc_fap_4_word(2));
+        assert!(test_bed.read_sfcc_fap_5_word(2));
+        assert!(test_bed.read_sfcc_fap_6_word(2));
+        assert!(test_bed.read_sfcc_fap_7_word(2));
     }
 
     #[test]
@@ -878,24 +992,41 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(10));
 
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -908,24 +1039,41 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -938,24 +1086,41 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -968,24 +1133,41 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -998,24 +1180,41 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -1028,24 +1227,41 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(45));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     // Tests flaps configuration and angles for regular
@@ -1117,21 +1333,25 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed
             .set_indicated_airspeed(220.)
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
     }
 
     //Tests transition between Conf1F to Conf1 above 210 knots
@@ -1143,15 +1363,18 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_indicated_airspeed(150.).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_indicated_airspeed(220.).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
     }
 
     // Tests flaps configuration and angles for regular
@@ -1232,19 +1455,24 @@ mod tests {
             .run_one_tick();
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed
             .set_indicated_airspeed(110.)
@@ -1252,19 +1480,24 @@ mod tests {
             .run_one_tick();
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed
             .set_indicated_airspeed(220.)
@@ -1272,19 +1505,24 @@ mod tests {
             .run_one_tick();
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
     }
 
     #[test]
@@ -1295,16 +1533,20 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1312,13 +1554,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1326,12 +1571,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
+
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1339,13 +1588,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1353,13 +1605,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
     }
 
     #[test]
@@ -1370,13 +1625,16 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1384,13 +1642,16 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
     }
 
     #[test]
@@ -1401,13 +1662,16 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1415,13 +1679,16 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1429,13 +1696,16 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
     }
 
     #[test]
@@ -1446,13 +1716,16 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1460,13 +1733,16 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1474,19 +1750,24 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
     }
 
     #[test]
@@ -1498,14 +1779,19 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(20));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1519,14 +1805,19 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed
             .set_flaps_handle_position(2)
             .run_waiting_for(Duration::from_secs(20));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1540,14 +1831,19 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(30));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1561,14 +1857,19 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(20));
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed
             .set_flaps_handle_position(4)
             .run_waiting_for(Duration::from_secs(20));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1582,14 +1883,19 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(30));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1604,18 +1910,27 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(30));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
                 <= angle_delta
         );
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1629,14 +1944,19 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed
             .set_flaps_handle_position(2)
             .run_waiting_for(Duration::from_secs(40));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1650,14 +1970,19 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(40));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1671,14 +1996,19 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed
             .set_flaps_handle_position(4)
             .run_waiting_for(Duration::from_secs(50));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/flaps_computer.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/flaps_computer.rs
@@ -100,15 +100,11 @@ impl SlatFlapControlComputer {
         }
     }
 
-    fn generate_configuration(
-        &self,
-        csu_monitor: &CSUMonitor,
-        context: &UpdateContext,
-    ) -> FlapsConf {
+    fn generate_configuration(&self, context: &UpdateContext) -> FlapsConf {
         // Ignored `CSU::OutOfDetent` and `CSU::Fault` positions due to simplified SFCC.
         match (
-            csu_monitor.get_previous_detent(),
-            csu_monitor.get_current_detent(),
+            self.csu_monitor.get_previous_detent(),
+            self.csu_monitor.get_current_detent(),
         ) {
             (CSU::Conf0, CSU::Conf1)
                 if context.indicated_airspeed().get::<knot>()
@@ -151,7 +147,7 @@ impl SlatFlapControlComputer {
     ) {
         self.csu_monitor.update(context);
 
-        self.flaps_conf = self.generate_configuration(&self.csu_monitor, context);
+        self.flaps_conf = self.generate_configuration(context);
 
         self.flaps_demanded_angle = Self::demanded_flaps_fppu_angle_from_conf(self.flaps_conf);
         self.slats_demanded_angle = Self::demanded_slats_fppu_angle_from_conf(self.flaps_conf);

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/mod.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/mod.rs
@@ -2237,16 +2237,16 @@ impl A320Hydraulic {
 
         self.flap_system.update(
             context,
-            self.slats_flaps_complex.flap_demand(0),
-            self.slats_flaps_complex.flap_demand(1),
+            self.slats_flaps_complex.flap_command(0),
+            self.slats_flaps_complex.flap_command(1),
             self.green_circuit.system_section(),
             self.yellow_circuit.system_section(),
         );
 
         self.slat_system.update(
             context,
-            self.slats_flaps_complex.slat_demand(0),
-            self.slats_flaps_complex.slat_demand(1),
+            self.slats_flaps_complex.slat_command(0),
+            self.slats_flaps_complex.slat_command(1),
             self.blue_circuit.system_section(),
             self.green_circuit.system_section(),
         );

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/mod.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/mod.rs
@@ -78,8 +78,10 @@ use systems::{
     },
 };
 
-mod flaps_computer;
-use flaps_computer::SlatFlapComplex;
+mod flaps_channel;
+mod sfcc;
+mod slats_channel;
+use sfcc::SlatFlapComplex;
 
 #[cfg(test)]
 use systems::hydraulic::PressureSwitchState;

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/mod.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/mod.rs
@@ -2235,16 +2235,16 @@ impl A320Hydraulic {
 
         self.flap_system.update(
             context,
-            self.slats_flaps_complex.flap_demand(),
-            self.slats_flaps_complex.flap_demand(),
+            self.slats_flaps_complex.flap_demand(0),
+            self.slats_flaps_complex.flap_demand(1),
             self.green_circuit.system_section(),
             self.yellow_circuit.system_section(),
         );
 
         self.slat_system.update(
             context,
-            self.slats_flaps_complex.slat_demand(),
-            self.slats_flaps_complex.slat_demand(),
+            self.slats_flaps_complex.slat_demand(0),
+            self.slats_flaps_complex.slat_demand(1),
             self.blue_circuit.system_section(),
             self.green_circuit.system_section(),
         );

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/sfcc.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/sfcc.rs
@@ -8,7 +8,7 @@ use systems::simulation::{
     VariableIdentifier, Write,
 };
 
-use std::panic;
+// use std::panic;
 use uom::si::{angle::degree, f64::*};
 
 use super::flaps_channel::FlapsChannel;
@@ -36,8 +36,6 @@ struct SlatFlapControlComputer {
 }
 
 impl SlatFlapControlComputer {
-    const EQUAL_ANGLE_DELTA_DEGREE: f64 = 0.177;
-
     fn new(context: &mut InitContext, num: u8) -> Self {
         Self {
             config_index_id: context.get_identifier("FLAPS_CONF_INDEX".to_owned()),
@@ -50,10 +48,6 @@ impl SlatFlapControlComputer {
             slats_channel: SlatsChannel::new(context, num),
             config: FlapsConf::Conf0,
         }
-    }
-
-    fn surface_movement_required(demanded_angle: Angle, feedback_angle: Angle) -> bool {
-        (demanded_angle - feedback_angle).get::<degree>().abs() > Self::EQUAL_ANGLE_DELTA_DEGREE
     }
 
     pub fn calculate_config(&self) -> FlapsConf {
@@ -183,35 +177,6 @@ impl SlatFlapControlComputer {
     }
 }
 
-trait SlatFlapLane {
-    fn signal_demanded_angle(&self, surface_type: &str) -> Option<Angle>;
-}
-
-impl SlatFlapLane for SlatFlapControlComputer {
-    fn signal_demanded_angle(&self, surface_type: &str) -> Option<Angle> {
-        match surface_type {
-            "FLAPS"
-                if Self::surface_movement_required(
-                    self.flaps_channel.get_demanded_angle(),
-                    self.flaps_channel.get_feedback_angle(),
-                ) =>
-            {
-                Some(self.flaps_channel.get_demanded_angle())
-            }
-            "SLATS"
-                if Self::surface_movement_required(
-                    self.slats_channel.get_demanded_angle(),
-                    self.slats_channel.get_feedback_angle(),
-                ) =>
-            {
-                Some(self.slats_channel.get_demanded_angle())
-            }
-            "FLAPS" | "SLATS" => None,
-            _ => panic!("Not a valid slat/flap surface"),
-        }
-    }
-}
-
 impl SimulationElement for SlatFlapControlComputer {
     fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
         self.flaps_channel.accept(visitor);
@@ -257,18 +222,6 @@ impl SlatFlapComplex {
     ) {
         self.sfcc[0].update(context, flaps_feedback, slats_feedback);
         self.sfcc[1].update(context, flaps_feedback, slats_feedback);
-    }
-
-    // `idx` 0 is for SFCC1
-    // `idx` 1 is for SFCC2
-    pub fn flap_demand(&self, idx: usize) -> Option<Angle> {
-        self.sfcc[idx].signal_demanded_angle("FLAPS")
-    }
-
-    // `idx` 0 is for SFCC1
-    // `idx` 1 is for SFCC2
-    pub fn slat_demand(&self, idx: usize) -> Option<Angle> {
-        self.sfcc[idx].signal_demanded_angle("SLATS")
     }
 
     fn is_approaching_requested_position(
@@ -343,7 +296,6 @@ mod tests {
         right_position_percent_id: VariableIdentifier,
         left_position_angle_id: VariableIdentifier,
         right_position_angle_id: VariableIdentifier,
-        surface_type: String,
     }
     impl PositionPickoffUnit for SlatFlapGear {
         fn angle(&self) -> Angle {
@@ -374,22 +326,20 @@ mod tests {
                     .get_identifier(format!("LEFT_{}_ANGLE", surface_type)),
                 right_position_angle_id: context
                     .get_identifier(format!("RIGHT_{}_ANGLE", surface_type)),
-
-                surface_type: surface_type.to_string(),
             }
         }
 
         fn update(
             &mut self,
             context: &UpdateContext,
-            sfcc: &impl SlatFlapLane,
+            demanded_angle: Option<Angle>,
             hydraulic_pressure_left_side: Pressure,
             hydraulic_pressure_right_side: Pressure,
         ) {
             if hydraulic_pressure_left_side.get::<psi>() > 1500.
                 || hydraulic_pressure_right_side.get::<psi>() > 1500.
             {
-                if let Some(demanded_angle) = sfcc.signal_demanded_angle(&self.surface_type) {
+                if let Some(demanded_angle) = demanded_angle {
                     let actual_minus_target_ffpu = demanded_angle - self.angle();
 
                     let fppu_angle = self.angle();
@@ -444,6 +394,8 @@ mod tests {
     }
 
     impl A320FlapsTestAircraft {
+        const EQUAL_ANGLE_DELTA_DEGREE: f64 = 0.177;
+
         fn new(context: &mut InitContext) -> Self {
             Self {
                 green_hydraulic_pressure_id: context
@@ -472,21 +424,51 @@ mod tests {
                 yellow_pressure: Pressure::new::<psi>(0.),
             }
         }
+
+        fn surface_movement_required(demanded_angle: Angle, feedback_angle: Angle) -> bool {
+            (demanded_angle - feedback_angle).get::<degree>().abs() > Self::EQUAL_ANGLE_DELTA_DEGREE
+        }
+
+        fn signal_demanded_angle(&self, idx: usize, surface_type: &str) -> Option<Angle> {
+            let sfcc = &self.slat_flap_complex.sfcc[idx];
+            match surface_type {
+                "FLAPS"
+                    if Self::surface_movement_required(
+                        sfcc.flaps_channel.get_demanded_angle(),
+                        sfcc.flaps_channel.get_feedback_angle(),
+                    ) =>
+                {
+                    Some(sfcc.flaps_channel.get_demanded_angle())
+                }
+                "SLATS"
+                    if Self::surface_movement_required(
+                        sfcc.slats_channel.get_demanded_angle(),
+                        sfcc.slats_channel.get_feedback_angle(),
+                    ) =>
+                {
+                    Some(sfcc.slats_channel.get_demanded_angle())
+                }
+                "FLAPS" | "SLATS" => None,
+                _ => panic!("Not a valid slat/flap surface"),
+            }
+        }
     }
 
     impl Aircraft for A320FlapsTestAircraft {
         fn update_after_power_distribution(&mut self, context: &UpdateContext) {
             self.slat_flap_complex
                 .update(context, &self.flap_gear, &self.slat_gear);
+            let flaps_demanded_angle = self.signal_demanded_angle(0, "FLAPS");
             self.flap_gear.update(
                 context,
-                &self.slat_flap_complex.sfcc[0],
+                flaps_demanded_angle,
                 self.green_pressure,
                 self.yellow_pressure,
             );
+            let slats_demanded_angle = self.signal_demanded_angle(0, "SLATS");
             self.slat_gear.update(
                 context,
-                &self.slat_flap_complex.sfcc[0],
+                slats_demanded_angle,
                 self.blue_pressure,
                 self.green_pressure,
             );

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/sfcc.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/sfcc.rs
@@ -1,7 +1,6 @@
 use crate::systems::shared::arinc429::{Arinc429Word, SignStatus};
 use systems::accept_iterable;
-use systems::hydraulic::command_sensor_unit::{CSUMonitor, CSU};
-use systems::shared::{AdirsMeasurementOutputs, PositionPickoffUnit};
+use systems::shared::PositionPickoffUnit;
 
 use systems::simulation::{
     InitContext, SimulationElement, SimulationElementVisitor, SimulatorWriter, UpdateContext,
@@ -9,7 +8,10 @@ use systems::simulation::{
 };
 
 use std::panic;
-use uom::si::{angle::degree, f64::*, length::foot, velocity::knot};
+use uom::si::{angle::degree, f64::*};
+
+use super::flaps_channel::FlapsChannel;
+use super::slats_channel::SlatsChannel;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 enum FlapsConf {
@@ -17,274 +19,77 @@ enum FlapsConf {
     Conf1,
     Conf1F,
     Conf2,
-    Conf2S,
     Conf3,
     ConfFull,
 }
 
 struct SlatFlapControlComputer {
-    flaps_conf_index_id: VariableIdentifier,
+    config_index_id: VariableIdentifier,
     slat_flap_system_status_word_id: VariableIdentifier,
     slat_flap_actual_position_word_id: VariableIdentifier,
-    slat_actual_position_word_id: VariableIdentifier,
-    flap_actual_position_word_id: VariableIdentifier,
 
-    flaps_demanded_angle: Angle,
-    slats_demanded_angle: Angle,
-    flaps_feedback_angle: Angle,
-    slats_feedback_angle: Angle,
-    flaps_handle_position: CSU,
-    flaps_conf: FlapsConf,
-    flap_load_relief_active: bool,
-    cruise_baulk_active: bool,
-    alpha_speed_lock_active: bool,
+    flaps_channel: FlapsChannel,
+    slats_channel: SlatsChannel,
 
-    csu_monitor: CSUMonitor,
+    config: FlapsConf,
 }
 
 impl SlatFlapControlComputer {
     const EQUAL_ANGLE_DELTA_DEGREE: f64 = 0.177;
-    const HANDLE_ONE_CONF_AIRSPEED_THRESHOLD_KNOTS: f64 = 205.;
-    const CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS: f64 = 212.;
-    const CRUISE_BAULK_AIRSPEED_THRESHOLD_KNOTS: f64 = 265.5;
-    const CRUISE_BAULK_ALTITUDE_THRESHOLD_FEET: f64 = 22000.;
-    const ALPHA_SPEED_LOCK_IN_AIRSPEED_THRESHOLD_KNOTS: f64 = 155.;
-    const ALPHA_SPEED_LOCK_OUT_AIRSPEED_THRESHOLD_KNOTS: f64 = 161.;
-    const ALPHA_SPEED_LOCK_IN_AOA_THRESHOLD_DEGREES: f64 = 9.5;
-    const ALPHA_SPEED_LOCK_OUT_AOA_THRESHOLD_DEGREES: f64 = 9.2;
-
-    const FLRS_CONFFULL_TO_CONF3_AIRSPEED_THRESHOLD_KNOTS: f64 = 184.5;
-    const FLRS_CONF3_TO_CONF2S_AIRSPEED_THRESHOLD_KNOTS: f64 = 198.5;
-    const FLRS_CONF2_TO_CONF1F_AIRSPEED_THRESHOLD_KNOTS: f64 = 222.5;
-    const FLRS_CONF1F_TO_CONF2_AIRSPEED_THRESHOLD_KNOTS: f64 = 217.5;
-    const FLRS_CONF2S_TO_CONF3_AIRSPEED_THRESHOLD_KNOTS: f64 = 193.5;
-    const FLRS_CONF3_TO_CONFFULL_AIRSPEED_THRESHOLD_KNOTS: f64 = 179.5;
 
     fn new(context: &mut InitContext, num: u8) -> Self {
         Self {
-            flaps_conf_index_id: context.get_identifier("FLAPS_CONF_INDEX".to_owned()),
+            config_index_id: context.get_identifier("FLAPS_CONF_INDEX".to_owned()),
             slat_flap_system_status_word_id: context
                 .get_identifier(format!("SFCC_{num}_SLAT_FLAP_SYSTEM_STATUS_WORD")),
             slat_flap_actual_position_word_id: context
                 .get_identifier(format!("SFCC_{num}_SLAT_FLAP_ACTUAL_POSITION_WORD")),
-            slat_actual_position_word_id: context
-                .get_identifier(format!("SFCC_{num}_SLAT_ACTUAL_POSITION_WORD")),
-            flap_actual_position_word_id: context
-                .get_identifier(format!("SFCC_{num}_FLAP_ACTUAL_POSITION_WORD")),
 
-            flaps_demanded_angle: Angle::new::<degree>(0.),
-            slats_demanded_angle: Angle::new::<degree>(0.),
-            flaps_feedback_angle: Angle::new::<degree>(0.),
-            slats_feedback_angle: Angle::new::<degree>(0.),
-            flaps_handle_position: CSU::Conf0,
-            flaps_conf: FlapsConf::Conf0,
-            flap_load_relief_active: false,
-            cruise_baulk_active: false,
-            alpha_speed_lock_active: false,
-
-            csu_monitor: CSUMonitor::new(context),
+            flaps_channel: FlapsChannel::new(context, num),
+            slats_channel: SlatsChannel::new(context, num),
+            config: FlapsConf::Conf0,
         }
-    }
-
-    // Returns a flap demanded angle in FPPU reference degree (feedback sensor)
-    // Interpolated from A320 FPPU references, assuming we're using the A320 FPPU
-    fn demanded_flaps_fppu_angle_from_conf(flap_conf: FlapsConf) -> Angle {
-        match flap_conf {
-            FlapsConf::Conf0 => Angle::new::<degree>(0.),
-            FlapsConf::Conf1 => Angle::new::<degree>(0.),
-            FlapsConf::Conf1F => Angle::new::<degree>(108.28),
-            FlapsConf::Conf2 => Angle::new::<degree>(154.65),
-            FlapsConf::Conf2S => Angle::new::<degree>(154.65),
-            FlapsConf::Conf3 => Angle::new::<degree>(194.03),
-            FlapsConf::ConfFull => Angle::new::<degree>(218.91),
-        }
-    }
-
-    // Returns a slat demanded angle in FPPU reference degree (feedback sensor)
-    // Interpolated from A320 FPPU references, assuming we're using the A320 FPPU
-    fn demanded_slats_fppu_angle_from_conf(flap_conf: FlapsConf) -> Angle {
-        match flap_conf {
-            FlapsConf::Conf0 => Angle::new::<degree>(0.),
-            FlapsConf::Conf1 => Angle::new::<degree>(247.27),
-            FlapsConf::Conf1F => Angle::new::<degree>(247.27),
-            FlapsConf::Conf2 => Angle::new::<degree>(247.27),
-            FlapsConf::Conf2S => Angle::new::<degree>(284.65),
-            FlapsConf::Conf3 => Angle::new::<degree>(284.65),
-            FlapsConf::ConfFull => Angle::new::<degree>(284.65),
-        }
-    }
-
-    fn generate_configuration(
-        &self,
-        context: &UpdateContext,
-        adirs: &impl AdirsMeasurementOutputs,
-    ) -> FlapsConf {
-        // Ignored `CSU::OutOfDetent` and `CSU::Fault` positions due to simplified SFCC.
-        match (
-            self.csu_monitor.get_previous_detent(),
-            self.csu_monitor.get_current_detent(),
-        ) {
-            (CSU::Conf0 | CSU::Conf1, CSU::Conf1)
-                if context.indicated_airspeed().get::<knot>()
-                    < Self::HANDLE_ONE_CONF_AIRSPEED_THRESHOLD_KNOTS
-                    || context.is_on_ground() =>
-            {
-                FlapsConf::Conf1F
-            }
-            (CSU::Conf0 | CSU::Conf1, CSU::Conf1)
-                if context.indicated_airspeed().get::<knot>()
-                    > Self::CRUISE_BAULK_AIRSPEED_THRESHOLD_KNOTS
-                    // FIXME use ADRs
-                    || context.pressure_altitude().get::<foot>()
-                        > Self::CRUISE_BAULK_ALTITUDE_THRESHOLD_FEET =>
-            {
-                FlapsConf::Conf0
-            }
-            (CSU::Conf0, CSU::Conf1) => FlapsConf::Conf1,
-            (CSU::Conf1, CSU::Conf1)
-                if context.indicated_airspeed().get::<knot>()
-                    > Self::CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS =>
-            {
-                FlapsConf::Conf1
-            }
-            (CSU::Conf1, CSU::Conf1) => self.flaps_conf,
-            (_, CSU::Conf1)
-                if context.indicated_airspeed().get::<knot>()
-                    <= Self::CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS =>
-            {
-                FlapsConf::Conf1F
-            }
-            (_, CSU::Conf1) => FlapsConf::Conf1,
-            (_, CSU::Conf0) if context.is_in_flight() && self.alpha_speed_lock_active => {
-                if context.indicated_airspeed().get::<knot>()
-                    > Self::ALPHA_SPEED_LOCK_OUT_AIRSPEED_THRESHOLD_KNOTS
-                    || self
-                        .angle_of_attack(adirs)
-                        .unwrap_or_default()
-                        .get::<degree>()
-                        < Self::ALPHA_SPEED_LOCK_OUT_AOA_THRESHOLD_DEGREES
-                {
-                    FlapsConf::Conf0
-                } else {
-                    self.flaps_conf
-                }
-            }
-            (CSU::Conf1, CSU::Conf0)
-            | (CSU::Conf2, CSU::Conf0)
-            | (CSU::Conf3, CSU::Conf0)
-            | (CSU::ConfFull, CSU::Conf0)
-                if context.is_in_flight()
-                    && (context.indicated_airspeed().get::<knot>()
-                        < Self::ALPHA_SPEED_LOCK_IN_AIRSPEED_THRESHOLD_KNOTS
-                        || self
-                            .angle_of_attack(adirs)
-                            .unwrap_or_default()
-                            .get::<degree>()
-                            > Self::ALPHA_SPEED_LOCK_IN_AOA_THRESHOLD_DEGREES) =>
-            {
-                FlapsConf::Conf1F
-            }
-            (_, CSU::Conf0) => FlapsConf::Conf0,
-            (CSU::Conf1 | CSU::Conf2, CSU::Conf2)
-                if context.indicated_airspeed().get::<knot>()
-                    > Self::FLRS_CONF2_TO_CONF1F_AIRSPEED_THRESHOLD_KNOTS =>
-            {
-                FlapsConf::Conf1F
-            }
-            (CSU::Conf2, CSU::Conf2) if self.flaps_conf == FlapsConf::Conf1F => {
-                if context.indicated_airspeed().get::<knot>()
-                    < Self::FLRS_CONF1F_TO_CONF2_AIRSPEED_THRESHOLD_KNOTS
-                {
-                    FlapsConf::Conf2
-                } else {
-                    FlapsConf::Conf1F
-                }
-            }
-            (CSU::Conf2 | CSU::Conf3, CSU::Conf3)
-                if context.indicated_airspeed().get::<knot>()
-                    > Self::FLRS_CONF3_TO_CONF2S_AIRSPEED_THRESHOLD_KNOTS =>
-            {
-                FlapsConf::Conf2S
-            }
-            (CSU::Conf3, CSU::Conf3) if self.flaps_conf == FlapsConf::Conf2S => {
-                if context.indicated_airspeed().get::<knot>()
-                    < Self::FLRS_CONF2S_TO_CONF3_AIRSPEED_THRESHOLD_KNOTS
-                {
-                    FlapsConf::Conf3
-                } else {
-                    FlapsConf::Conf2S
-                }
-            }
-            (CSU::Conf3 | CSU::ConfFull, CSU::ConfFull)
-                if context.indicated_airspeed().get::<knot>()
-                    > Self::FLRS_CONFFULL_TO_CONF3_AIRSPEED_THRESHOLD_KNOTS =>
-            {
-                FlapsConf::Conf3
-            }
-            (CSU::ConfFull, CSU::ConfFull) if self.flaps_conf == FlapsConf::Conf3 => {
-                if context.indicated_airspeed().get::<knot>()
-                    < Self::FLRS_CONF3_TO_CONFFULL_AIRSPEED_THRESHOLD_KNOTS
-                {
-                    FlapsConf::ConfFull
-                } else {
-                    FlapsConf::Conf3
-                }
-            }
-            (from, CSU::Conf2) if from != CSU::Conf2 => FlapsConf::Conf2,
-            (from, CSU::Conf3) if from != CSU::Conf3 => FlapsConf::Conf3,
-            (from, CSU::ConfFull) if from != CSU::ConfFull => FlapsConf::ConfFull,
-            (_, _) => self.flaps_conf,
-        }
-    }
-
-    fn flap_load_relief_active(&self) -> bool {
-        let handle_position = self.csu_monitor.get_current_detent();
-        handle_position == CSU::Conf2 && self.flaps_conf != FlapsConf::Conf2
-            || handle_position == CSU::Conf3 && self.flaps_conf != FlapsConf::Conf3
-            || handle_position == CSU::ConfFull && self.flaps_conf != FlapsConf::ConfFull
-    }
-
-    fn cruise_baulk_active(&self) -> bool {
-        let handle_position = self.csu_monitor.get_current_detent();
-        handle_position == CSU::Conf1 && self.flaps_conf == FlapsConf::Conf0
-    }
-
-    fn alpha_speed_lock_active(&self) -> bool {
-        let handle_position = self.csu_monitor.get_current_detent();
-        handle_position == CSU::Conf0
-            && (self.flaps_conf == FlapsConf::Conf1 || self.flaps_conf == FlapsConf::Conf1F)
     }
 
     fn surface_movement_required(demanded_angle: Angle, feedback_angle: Angle) -> bool {
         (demanded_angle - feedback_angle).get::<degree>().abs() > Self::EQUAL_ANGLE_DELTA_DEGREE
     }
 
-    // FIXME This is not the correct ADR input selection yet, due to missing references
-    fn angle_of_attack(&self, adirs: &impl AdirsMeasurementOutputs) -> Option<Angle> {
-        [1, 2, 3]
-            .iter()
-            .find_map(|&adiru_number| adirs.angle_of_attack(adiru_number).normal_value())
+    pub fn calculate_config(&self) -> FlapsConf {
+        let s = self.slats_channel.get_demanded_angle();
+        let f = self.flaps_channel.get_demanded_angle();
+
+        if s == Angle::default() && f == Angle::default() {
+            return FlapsConf::Conf0;
+        } else if s == Angle::new::<degree>(222.27) && f == Angle::default() {
+            return FlapsConf::Conf1;
+        } else if s == Angle::new::<degree>(222.27) && f == Angle::new::<degree>(120.22) {
+            return FlapsConf::Conf1F;
+        } else if s == Angle::new::<degree>(272.27) && f == Angle::new::<degree>(145.51) {
+            return FlapsConf::Conf2;
+        } else if s == Angle::new::<degree>(272.27) && f == Angle::new::<degree>(168.35) {
+            return FlapsConf::Conf3;
+        } else if s == Angle::new::<degree>(334.16) && f == Angle::new::<degree>(251.97) {
+            return FlapsConf::ConfFull;
+        } else {
+            panic!(
+                "Invalid combination sfcc {} {}",
+                s.get::<degree>(),
+                f.get::<degree>()
+            );
+        }
     }
 
     pub fn update(
         &mut self,
         context: &UpdateContext,
-        adirs: &impl AdirsMeasurementOutputs,
         flaps_feedback: &impl PositionPickoffUnit,
         slats_feedback: &impl PositionPickoffUnit,
     ) {
-        self.csu_monitor.update(context);
+        self.flaps_channel.update(context, flaps_feedback);
+        self.slats_channel.update(context, slats_feedback);
 
-        self.flaps_handle_position = self.csu_monitor.get_current_detent();
-        self.flaps_conf = self.generate_configuration(context, adirs);
-        self.flap_load_relief_active = self.flap_load_relief_active();
-        self.cruise_baulk_active = self.cruise_baulk_active();
-        self.alpha_speed_lock_active = self.alpha_speed_lock_active();
-
-        self.flaps_demanded_angle = Self::demanded_flaps_fppu_angle_from_conf(self.flaps_conf);
-        self.slats_demanded_angle = Self::demanded_slats_fppu_angle_from_conf(self.flaps_conf);
-        self.flaps_feedback_angle = flaps_feedback.angle();
-        self.slats_feedback_angle = slats_feedback.angle();
+        self.config = self.calculate_config();
     }
 
     fn slat_flap_system_status_word(&self) -> Arinc429Word<u32> {
@@ -296,16 +101,19 @@ impl SlatFlapControlComputer {
         word.set_bit(14, false);
         word.set_bit(15, false);
         word.set_bit(16, false);
-        word.set_bit(17, self.flaps_handle_position == CSU::Conf0);
-        word.set_bit(18, self.flaps_handle_position == CSU::Conf1);
-        word.set_bit(19, self.flaps_handle_position == CSU::Conf2);
-        word.set_bit(20, self.flaps_handle_position == CSU::Conf3);
-        word.set_bit(21, self.flaps_handle_position == CSU::ConfFull);
-        word.set_bit(22, self.flap_load_relief_active);
+        word.set_bit(17, self.config == FlapsConf::Conf0);
+        word.set_bit(
+            18,
+            self.config == FlapsConf::Conf1 || self.config == FlapsConf::Conf1F,
+        );
+        word.set_bit(19, self.config == FlapsConf::Conf2);
+        word.set_bit(20, self.config == FlapsConf::Conf3);
+        word.set_bit(21, self.config == FlapsConf::ConfFull);
+        word.set_bit(22, false);
         word.set_bit(23, false);
-        word.set_bit(24, self.alpha_speed_lock_active);
-        word.set_bit(25, self.cruise_baulk_active);
-        word.set_bit(26, self.flaps_conf == FlapsConf::Conf1);
+        word.set_bit(24, false);
+        word.set_bit(25, false);
+        word.set_bit(26, self.config == FlapsConf::Conf1);
         word.set_bit(27, false);
         word.set_bit(28, true);
         word.set_bit(29, true);
@@ -317,62 +125,53 @@ impl SlatFlapControlComputer {
         let mut word = Arinc429Word::new(0, SignStatus::NormalOperation);
 
         word.set_bit(11, true);
-        // Slats retracted
         word.set_bit(
             12,
-            self.slats_feedback_angle > Angle::new::<degree>(-5.0)
-                && self.slats_feedback_angle < Angle::new::<degree>(6.2),
+            self.slats_channel.get_feedback_angle() > Angle::new::<degree>(-5.0)
+                && self.slats_channel.get_feedback_angle() < Angle::new::<degree>(6.2),
         );
-        // Slats >= 19°
         word.set_bit(
             13,
-            self.slats_feedback_angle > Angle::new::<degree>(234.7)
-                && self.slats_feedback_angle < Angle::new::<degree>(337.),
+            self.slats_channel.get_feedback_angle() > Angle::new::<degree>(210.4)
+                && self.slats_channel.get_feedback_angle() < Angle::new::<degree>(337.),
         );
-        // Slats >= 22°
         word.set_bit(
             14,
-            self.slats_feedback_angle > Angle::new::<degree>(272.2)
-                && self.slats_feedback_angle < Angle::new::<degree>(337.),
+            self.slats_channel.get_feedback_angle() > Angle::new::<degree>(321.8)
+                && self.slats_channel.get_feedback_angle() < Angle::new::<degree>(337.),
         );
-        // Slats extended 23°
         word.set_bit(
             15,
-            self.slats_feedback_angle > Angle::new::<degree>(280.)
-                && self.slats_feedback_angle < Angle::new::<degree>(337.),
+            self.slats_channel.get_feedback_angle() > Angle::new::<degree>(327.4)
+                && self.slats_channel.get_feedback_angle() < Angle::new::<degree>(337.),
         );
         word.set_bit(16, false);
         word.set_bit(17, false);
         word.set_bit(18, true);
-        // Flaps retracted
         word.set_bit(
             19,
-            self.flaps_feedback_angle > Angle::new::<degree>(-5.0)
-                && self.flaps_feedback_angle < Angle::new::<degree>(2.5),
+            self.flaps_channel.get_feedback_angle() > Angle::new::<degree>(-5.0)
+                && self.flaps_channel.get_feedback_angle() < Angle::new::<degree>(2.5),
         );
-        // Flaps >= 7°
         word.set_bit(
             20,
-            self.flaps_feedback_angle > Angle::new::<degree>(102.1)
-                && self.flaps_feedback_angle < Angle::new::<degree>(254.),
+            self.flaps_channel.get_feedback_angle() > Angle::new::<degree>(140.7)
+                && self.flaps_channel.get_feedback_angle() < Angle::new::<degree>(254.),
         );
-        // Flaps >= 16°
         word.set_bit(
             21,
-            self.flaps_feedback_angle > Angle::new::<degree>(150.0)
-                && self.flaps_feedback_angle < Angle::new::<degree>(254.),
+            self.flaps_channel.get_feedback_angle() > Angle::new::<degree>(163.7)
+                && self.flaps_channel.get_feedback_angle() < Angle::new::<degree>(254.),
         );
-        // Flaps >= 25°
         word.set_bit(
             22,
-            self.flaps_feedback_angle > Angle::new::<degree>(189.8)
-                && self.flaps_feedback_angle < Angle::new::<degree>(254.),
+            self.flaps_channel.get_feedback_angle() > Angle::new::<degree>(247.8)
+                && self.flaps_channel.get_feedback_angle() < Angle::new::<degree>(254.),
         );
-        // Flaps extended 32°
         word.set_bit(
             23,
-            self.flaps_feedback_angle > Angle::new::<degree>(218.)
-                && self.flaps_feedback_angle < Angle::new::<degree>(254.),
+            self.flaps_channel.get_feedback_angle() > Angle::new::<degree>(250.)
+                && self.flaps_channel.get_feedback_angle() < Angle::new::<degree>(254.),
         );
         word.set_bit(24, false);
         word.set_bit(25, false);
@@ -382,20 +181,6 @@ impl SlatFlapControlComputer {
         word.set_bit(29, false);
 
         word
-    }
-
-    fn slat_actual_position_word(&self) -> Arinc429Word<f64> {
-        Arinc429Word::new(
-            self.slats_feedback_angle.get::<degree>(),
-            SignStatus::NormalOperation,
-        )
-    }
-
-    fn flap_actual_position_word(&self) -> Arinc429Word<f64> {
-        Arinc429Word::new(
-            self.flaps_feedback_angle.get::<degree>(),
-            SignStatus::NormalOperation,
-        )
     }
 }
 
@@ -408,19 +193,19 @@ impl SlatFlapLane for SlatFlapControlComputer {
         match surface_type {
             "FLAPS"
                 if Self::surface_movement_required(
-                    self.flaps_demanded_angle,
-                    self.flaps_feedback_angle,
+                    self.flaps_channel.get_demanded_angle(),
+                    self.flaps_channel.get_feedback_angle(),
                 ) =>
             {
-                Some(self.flaps_demanded_angle)
+                Some(self.flaps_channel.get_demanded_angle())
             }
             "SLATS"
                 if Self::surface_movement_required(
-                    self.slats_demanded_angle,
-                    self.slats_feedback_angle,
+                    self.slats_channel.get_demanded_angle(),
+                    self.slats_channel.get_feedback_angle(),
                 ) =>
             {
-                Some(self.slats_demanded_angle)
+                Some(self.slats_channel.get_demanded_angle())
             }
             "FLAPS" | "SLATS" => None,
             _ => panic!("Not a valid slat/flap surface"),
@@ -430,12 +215,13 @@ impl SlatFlapLane for SlatFlapControlComputer {
 
 impl SimulationElement for SlatFlapControlComputer {
     fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
-        self.csu_monitor.accept(visitor);
+        self.flaps_channel.accept(visitor);
+        self.slats_channel.accept(visitor);
         visitor.visit(self);
     }
 
     fn write(&self, writer: &mut SimulatorWriter) {
-        writer.write(&self.flaps_conf_index_id, self.flaps_conf as u8);
+        writer.write(&self.config_index_id, self.config as u8);
 
         writer.write(
             &self.slat_flap_system_status_word_id,
@@ -444,14 +230,6 @@ impl SimulationElement for SlatFlapControlComputer {
         writer.write(
             &self.slat_flap_actual_position_word_id,
             self.slat_flap_actual_position_word(),
-        );
-        writer.write(
-            &self.slat_actual_position_word_id,
-            self.slat_actual_position_word(),
-        );
-        writer.write(
-            &self.flap_actual_position_word_id,
-            self.flap_actual_position_word(),
         );
     }
 }
@@ -473,12 +251,11 @@ impl SlatFlapComplex {
     pub fn update(
         &mut self,
         context: &UpdateContext,
-        adirs: &impl AdirsMeasurementOutputs,
         flaps_feedback: &impl PositionPickoffUnit,
         slats_feedback: &impl PositionPickoffUnit,
     ) {
-        self.sfcc[0].update(context, adirs, flaps_feedback, slats_feedback);
-        self.sfcc[1].update(context, adirs, flaps_feedback, slats_feedback);
+        self.sfcc[0].update(context, flaps_feedback, slats_feedback);
+        self.sfcc[1].update(context, flaps_feedback, slats_feedback);
     }
 
     // `idx` 0 is for SFCC1
@@ -605,7 +382,7 @@ mod tests {
         }
     }
 
-    struct A380FlapsTestAircraft {
+    struct A320FlapsTestAircraft {
         green_hydraulic_pressure_id: VariableIdentifier,
         blue_hydraulic_pressure_id: VariableIdentifier,
         yellow_hydraulic_pressure_id: VariableIdentifier,
@@ -617,11 +394,9 @@ mod tests {
         green_pressure: Pressure,
         blue_pressure: Pressure,
         yellow_pressure: Pressure,
-
-        adirs: TestAdirs,
     }
 
-    impl A380FlapsTestAircraft {
+    impl A320FlapsTestAircraft {
         fn new(context: &mut InitContext) -> Self {
             Self {
                 green_hydraulic_pressure_id: context
@@ -648,20 +423,14 @@ mod tests {
                 green_pressure: Pressure::new::<psi>(0.),
                 blue_pressure: Pressure::new::<psi>(0.),
                 yellow_pressure: Pressure::new::<psi>(0.),
-
-                adirs: TestAdirs::new(),
             }
-        }
-
-        fn set_angle_of_attack(&mut self, v: Angle) {
-            self.adirs.set_angle_of_attack(v);
         }
     }
 
-    impl Aircraft for A380FlapsTestAircraft {
+    impl Aircraft for A320FlapsTestAircraft {
         fn update_after_power_distribution(&mut self, context: &UpdateContext) {
             self.slat_flap_complex
-                .update(context, &self.adirs, &self.flap_gear, &self.slat_gear);
+                .update(context, &self.flap_gear, &self.slat_gear);
             self.flap_gear.update(
                 context,
                 &self.slat_flap_complex.sfcc[0],
@@ -677,7 +446,7 @@ mod tests {
         }
     }
 
-    impl SimulationElement for A380FlapsTestAircraft {
+    impl SimulationElement for A320FlapsTestAircraft {
         fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
             self.slat_flap_complex.accept(visitor);
             self.flap_gear.accept(visitor);
@@ -692,75 +461,16 @@ mod tests {
         }
     }
 
-    struct TestAdirs {
-        is_aligned: bool,
-        latitude: Arinc429Word<Angle>,
-        longitude: Arinc429Word<Angle>,
-        heading: Arinc429Word<Angle>,
-        vertical_speed: Arinc429Word<Velocity>,
-        altitude: Arinc429Word<Length>,
-        angle_of_attack: Arinc429Word<Angle>,
-    }
-    impl TestAdirs {
-        fn new() -> Self {
-            Self {
-                is_aligned: false,
-                latitude: Arinc429Word::new(Angle::default(), SignStatus::FailureWarning),
-                longitude: Arinc429Word::new(Angle::default(), SignStatus::FailureWarning),
-                heading: Arinc429Word::new(Angle::default(), SignStatus::FailureWarning),
-                vertical_speed: Arinc429Word::new(Velocity::default(), SignStatus::FailureWarning),
-                altitude: Arinc429Word::new(Length::default(), SignStatus::FailureWarning),
-                angle_of_attack: Arinc429Word::new(Angle::default(), SignStatus::NormalOperation),
-            }
-        }
-
-        fn set_angle_of_attack(&mut self, v: Angle) {
-            self.angle_of_attack = Arinc429Word::new(v, SignStatus::NormalOperation);
-        }
-    }
-    impl AdirsMeasurementOutputs for TestAdirs {
-        fn is_fully_aligned(&self, _adiru_number: usize) -> bool {
-            self.is_aligned
-        }
-
-        fn latitude(&self, _adiru_number: usize) -> Arinc429Word<Angle> {
-            self.latitude
-        }
-
-        fn longitude(&self, _adiru_number: usize) -> Arinc429Word<Angle> {
-            self.longitude
-        }
-
-        fn heading(&self, _adiru_number: usize) -> Arinc429Word<Angle> {
-            self.heading
-        }
-
-        fn true_heading(&self, _adiru_number: usize) -> Arinc429Word<Angle> {
-            self.heading
-        }
-
-        fn vertical_speed(&self, _adiru_number: usize) -> Arinc429Word<Velocity> {
-            self.vertical_speed
-        }
-
-        fn altitude(&self, _adiru_number: usize) -> Arinc429Word<Length> {
-            self.altitude
-        }
-
-        fn angle_of_attack(&self, _adiru_number: usize) -> Arinc429Word<Angle> {
-            self.angle_of_attack
-        }
-    }
-    struct A380FlapsTestBed {
-        test_bed: SimulationTestBed<A380FlapsTestAircraft>,
+    struct A320FlapsTestBed {
+        test_bed: SimulationTestBed<A320FlapsTestAircraft>,
     }
 
-    impl A380FlapsTestBed {
+    impl A320FlapsTestBed {
         const HYD_TIME_STEP_MILLIS: u64 = 33;
 
         fn new() -> Self {
             Self {
-                test_bed: SimulationTestBed::new(A380FlapsTestAircraft::new),
+                test_bed: SimulationTestBed::new(A320FlapsTestAircraft::new),
             }
         }
 
@@ -792,18 +502,36 @@ mod tests {
             self.read_by_name(&format!("SFCC_{num}_SLAT_FLAP_ACTUAL_POSITION_WORD"))
         }
 
+        fn read_sfcc_fap_1_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_1"))
+        }
+
+        fn read_sfcc_fap_2_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_2"))
+        }
+
+        fn read_sfcc_fap_3_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_3"))
+        }
+
+        fn read_sfcc_fap_4_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_4"))
+        }
+
+        fn read_sfcc_fap_5_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_5"))
+        }
+
+        fn read_sfcc_fap_6_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_6"))
+        }
+
+        fn read_sfcc_fap_7_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_FAP_7"))
+        }
+
         fn set_indicated_airspeed(mut self, indicated_airspeed: f64) -> Self {
             self.write_by_name("AIRSPEED INDICATED", indicated_airspeed);
-            self
-        }
-
-        fn set_angle_of_attack(mut self, angle_of_attack: Angle) -> Self {
-            self.command(|a| a.set_angle_of_attack(angle_of_attack));
-            self
-        }
-
-        fn set_on_ground(mut self, on_ground: bool) -> Self {
-            self.write_by_name("SIM ON GROUND", on_ground);
             self
         }
 
@@ -825,7 +553,8 @@ mod tests {
         fn get_flaps_demanded_angle(&self, idx: usize) -> f64 {
             self.query(|a| {
                 a.slat_flap_complex.sfcc[idx]
-                    .flaps_demanded_angle
+                    .flaps_channel
+                    .get_demanded_angle()
                     .get::<degree>()
             })
         }
@@ -833,13 +562,14 @@ mod tests {
         fn get_slats_demanded_angle(&self, idx: usize) -> f64 {
             self.query(|a| {
                 a.slat_flap_complex.sfcc[idx]
-                    .slats_demanded_angle
+                    .slats_channel
+                    .get_demanded_angle()
                     .get::<degree>()
             })
         }
 
         fn get_flaps_conf(&self, num: usize) -> FlapsConf {
-            self.query(|a| a.slat_flap_complex.sfcc[num].flaps_conf)
+            self.query(|a| a.slat_flap_complex.sfcc[num].config)
         }
 
         fn get_flaps_fppu_feedback(&self) -> f64 {
@@ -848,6 +578,34 @@ mod tests {
 
         fn get_slats_fppu_feedback(&self) -> f64 {
             self.query(|a| a.slat_gear.angle().get::<degree>())
+        }
+
+        fn get_fap_1(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].flaps_channel.get_fap(0))
+        }
+
+        fn get_fap_2(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].flaps_channel.get_fap(1))
+        }
+
+        fn get_fap_3(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].flaps_channel.get_fap(2))
+        }
+
+        fn get_fap_4(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].flaps_channel.get_fap(3))
+        }
+
+        fn get_fap_5(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].flaps_channel.get_fap(4))
+        }
+
+        fn get_fap_6(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].flaps_channel.get_fap(5))
+        }
+
+        fn get_fap_7(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].flaps_channel.get_fap(6))
         }
 
         fn test_flap_conf(
@@ -860,30 +618,31 @@ mod tests {
         ) {
             assert_eq!(self.read_flaps_handle_position(), handle_pos);
             assert!((self.get_flaps_demanded_angle(0) - flaps_demanded_angle).abs() < angle_delta);
-            assert!((self.get_flaps_demanded_angle(1) - flaps_demanded_angle).abs() < angle_delta);
             assert!((self.get_slats_demanded_angle(0) - slats_demanded_angle).abs() < angle_delta);
-            assert!((self.get_slats_demanded_angle(1) - slats_demanded_angle).abs() < angle_delta);
             assert_eq!(self.get_flaps_conf(0), conf);
+
+            assert!((self.get_flaps_demanded_angle(1) - flaps_demanded_angle).abs() < angle_delta);
+            assert!((self.get_slats_demanded_angle(1) - slats_demanded_angle).abs() < angle_delta);
             assert_eq!(self.get_flaps_conf(1), conf);
         }
     }
-    impl TestBed for A380FlapsTestBed {
-        type Aircraft = A380FlapsTestAircraft;
+    impl TestBed for A320FlapsTestBed {
+        type Aircraft = A320FlapsTestAircraft;
 
-        fn test_bed(&self) -> &SimulationTestBed<A380FlapsTestAircraft> {
+        fn test_bed(&self) -> &SimulationTestBed<A320FlapsTestAircraft> {
             &self.test_bed
         }
 
-        fn test_bed_mut(&mut self) -> &mut SimulationTestBed<A380FlapsTestAircraft> {
+        fn test_bed_mut(&mut self) -> &mut SimulationTestBed<A320FlapsTestAircraft> {
             &mut self.test_bed
         }
     }
 
-    fn test_bed() -> A380FlapsTestBed {
-        A380FlapsTestBed::new()
+    fn test_bed() -> A320FlapsTestBed {
+        A320FlapsTestBed::new()
     }
 
-    fn test_bed_with() -> A380FlapsTestBed {
+    fn test_bed_with() -> A320FlapsTestBed {
         test_bed()
     }
 
@@ -903,6 +662,22 @@ mod tests {
 
         assert!(test_bed.contains_variable_with_name("FLAPS_CONF_INDEX"));
 
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_1"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_2"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_3"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_4"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_5"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_6"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_7"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_1"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_2"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_3"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_4"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_5"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_6"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_7"));
+
         assert!(test_bed.contains_variable_with_name("SFCC_1_FLAP_ACTUAL_POSITION_WORD"));
         assert!(test_bed.contains_variable_with_name("SFCC_2_FLAP_ACTUAL_POSITION_WORD"));
 
@@ -917,12 +692,199 @@ mod tests {
     }
 
     #[test]
+    fn sfcc_faps() {
+        let mut test_bed = test_bed_with()
+            .set_green_hyd_pressure()
+            .set_yellow_hyd_pressure()
+            .set_blue_hyd_pressure()
+            .set_indicated_airspeed(0.)
+            .set_flaps_handle_position(0)
+            .run_one_tick();
+
+        assert!(!test_bed.get_fap_1(0));
+        assert!(!test_bed.get_fap_2(0));
+        assert!(!test_bed.get_fap_3(0));
+        assert!(test_bed.get_fap_4(0));
+        assert!(!test_bed.get_fap_5(0));
+        assert!(!test_bed.get_fap_6(0));
+        assert!(!test_bed.get_fap_7(0));
+
+        assert!(!test_bed.get_fap_1(1));
+        assert!(!test_bed.get_fap_2(1));
+        assert!(!test_bed.get_fap_3(1));
+        assert!(test_bed.get_fap_4(1));
+        assert!(!test_bed.get_fap_5(1));
+        assert!(!test_bed.get_fap_6(1));
+        assert!(!test_bed.get_fap_7(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(1));
+        assert!(!test_bed.read_sfcc_fap_2_word(1));
+        assert!(!test_bed.read_sfcc_fap_3_word(1));
+        assert!(test_bed.read_sfcc_fap_4_word(1));
+        assert!(!test_bed.read_sfcc_fap_5_word(1));
+        assert!(!test_bed.read_sfcc_fap_6_word(1));
+        assert!(!test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(2));
+        assert!(!test_bed.read_sfcc_fap_2_word(2));
+        assert!(!test_bed.read_sfcc_fap_3_word(2));
+        assert!(test_bed.read_sfcc_fap_4_word(2));
+        assert!(!test_bed.read_sfcc_fap_5_word(2));
+        assert!(!test_bed.read_sfcc_fap_6_word(2));
+        assert!(!test_bed.read_sfcc_fap_7_word(2));
+
+        test_bed = test_bed
+            .set_flaps_handle_position(1)
+            .run_waiting_for(Duration::from_secs(60));
+
+        assert!(!test_bed.get_fap_1(0));
+        assert!(test_bed.get_fap_2(0));
+        assert!(!test_bed.get_fap_3(0));
+        assert!(!test_bed.get_fap_4(0));
+        assert!(!test_bed.get_fap_5(0));
+        assert!(!test_bed.get_fap_6(0));
+        assert!(test_bed.get_fap_7(0));
+
+        assert!(!test_bed.get_fap_1(1));
+        assert!(test_bed.get_fap_2(1));
+        assert!(!test_bed.get_fap_3(1));
+        assert!(!test_bed.get_fap_4(1));
+        assert!(!test_bed.get_fap_5(1));
+        assert!(!test_bed.get_fap_6(1));
+        assert!(test_bed.get_fap_7(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(1));
+        assert!(test_bed.read_sfcc_fap_2_word(1));
+        assert!(!test_bed.read_sfcc_fap_3_word(1));
+        assert!(!test_bed.read_sfcc_fap_4_word(1));
+        assert!(!test_bed.read_sfcc_fap_5_word(1));
+        assert!(!test_bed.read_sfcc_fap_6_word(1));
+        assert!(test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(2));
+        assert!(test_bed.read_sfcc_fap_2_word(2));
+        assert!(!test_bed.read_sfcc_fap_3_word(2));
+        assert!(!test_bed.read_sfcc_fap_4_word(2));
+        assert!(!test_bed.read_sfcc_fap_5_word(2));
+        assert!(!test_bed.read_sfcc_fap_6_word(2));
+        assert!(test_bed.read_sfcc_fap_7_word(2));
+
+        test_bed = test_bed
+            .set_flaps_handle_position(2)
+            .run_waiting_for(Duration::from_secs(60));
+
+        assert!(!test_bed.get_fap_1(0));
+        assert!(test_bed.get_fap_2(0));
+        assert!(!test_bed.get_fap_3(0));
+        assert!(!test_bed.get_fap_4(0));
+        assert!(!test_bed.get_fap_5(0));
+        assert!(!test_bed.get_fap_6(0));
+        assert!(test_bed.get_fap_7(0));
+
+        assert!(!test_bed.get_fap_1(1));
+        assert!(test_bed.get_fap_2(1));
+        assert!(!test_bed.get_fap_3(1));
+        assert!(!test_bed.get_fap_4(1));
+        assert!(!test_bed.get_fap_5(1));
+        assert!(!test_bed.get_fap_6(1));
+        assert!(test_bed.get_fap_7(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(1));
+        assert!(test_bed.read_sfcc_fap_2_word(1));
+        assert!(!test_bed.read_sfcc_fap_3_word(1));
+        assert!(!test_bed.read_sfcc_fap_4_word(1));
+        assert!(!test_bed.read_sfcc_fap_5_word(1));
+        assert!(!test_bed.read_sfcc_fap_6_word(1));
+        assert!(test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(2));
+        assert!(test_bed.read_sfcc_fap_2_word(2));
+        assert!(!test_bed.read_sfcc_fap_3_word(2));
+        assert!(!test_bed.read_sfcc_fap_4_word(2));
+        assert!(!test_bed.read_sfcc_fap_5_word(2));
+        assert!(!test_bed.read_sfcc_fap_6_word(2));
+        assert!(test_bed.read_sfcc_fap_7_word(2));
+
+        test_bed = test_bed
+            .set_flaps_handle_position(3)
+            .run_waiting_for(Duration::from_secs(60));
+
+        assert!(!test_bed.get_fap_1(0));
+        assert!(test_bed.get_fap_2(0));
+        assert!(test_bed.get_fap_3(0));
+        assert!(!test_bed.get_fap_4(0));
+        assert!(test_bed.get_fap_5(0));
+        assert!(!test_bed.get_fap_6(0));
+        assert!(test_bed.get_fap_7(0));
+
+        assert!(!test_bed.get_fap_1(1));
+        assert!(test_bed.get_fap_2(1));
+        assert!(test_bed.get_fap_3(1));
+        assert!(!test_bed.get_fap_4(1));
+        assert!(test_bed.get_fap_5(1));
+        assert!(!test_bed.get_fap_6(1));
+        assert!(test_bed.get_fap_7(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(1));
+        assert!(test_bed.read_sfcc_fap_2_word(1));
+        assert!(test_bed.read_sfcc_fap_3_word(1));
+        assert!(!test_bed.read_sfcc_fap_4_word(1));
+        assert!(test_bed.read_sfcc_fap_5_word(1));
+        assert!(!test_bed.read_sfcc_fap_6_word(1));
+        assert!(test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_fap_1_word(2));
+        assert!(test_bed.read_sfcc_fap_2_word(2));
+        assert!(test_bed.read_sfcc_fap_3_word(2));
+        assert!(!test_bed.read_sfcc_fap_4_word(2));
+        assert!(test_bed.read_sfcc_fap_5_word(2));
+        assert!(!test_bed.read_sfcc_fap_6_word(2));
+        assert!(test_bed.read_sfcc_fap_7_word(2));
+
+        test_bed = test_bed
+            .set_flaps_handle_position(4)
+            .run_waiting_for(Duration::from_secs(60));
+
+        assert!(test_bed.get_fap_1(0));
+        assert!(test_bed.get_fap_2(0));
+        assert!(test_bed.get_fap_3(0));
+        assert!(!test_bed.get_fap_4(0));
+        assert!(test_bed.get_fap_5(0));
+        assert!(test_bed.get_fap_6(0));
+        assert!(test_bed.get_fap_7(0));
+
+        assert!(test_bed.get_fap_1(1));
+        assert!(test_bed.get_fap_2(1));
+        assert!(test_bed.get_fap_3(1));
+        assert!(!test_bed.get_fap_4(1));
+        assert!(test_bed.get_fap_5(1));
+        assert!(test_bed.get_fap_6(1));
+        assert!(test_bed.get_fap_7(1));
+
+        assert!(test_bed.read_sfcc_fap_1_word(1));
+        assert!(test_bed.read_sfcc_fap_2_word(1));
+        assert!(test_bed.read_sfcc_fap_3_word(1));
+        assert!(!test_bed.read_sfcc_fap_4_word(1));
+        assert!(test_bed.read_sfcc_fap_5_word(1));
+        assert!(test_bed.read_sfcc_fap_6_word(1));
+        assert!(test_bed.read_sfcc_fap_7_word(1));
+
+        assert!(test_bed.read_sfcc_fap_1_word(2));
+        assert!(test_bed.read_sfcc_fap_2_word(2));
+        assert!(test_bed.read_sfcc_fap_3_word(2));
+        assert!(!test_bed.read_sfcc_fap_4_word(2));
+        assert!(test_bed.read_sfcc_fap_5_word(2));
+        assert!(test_bed.read_sfcc_fap_6_word(2));
+        assert!(test_bed.read_sfcc_fap_7_word(2));
+    }
+
+    #[test]
     fn flaps_test_correct_bus_output_clean_config() {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_yellow_hyd_pressure()
             .set_blue_hyd_pressure()
-            .set_indicated_airspeed(160.)
+            .set_indicated_airspeed(0.)
             .set_flaps_handle_position(0)
             .run_one_tick();
 
@@ -969,7 +931,7 @@ mod tests {
             .set_green_hyd_pressure()
             .set_yellow_hyd_pressure()
             .set_blue_hyd_pressure()
-            .set_indicated_airspeed(215.)
+            .set_indicated_airspeed(200.)
             .set_flaps_handle_position(1)
             .run_one_tick();
 
@@ -987,7 +949,7 @@ mod tests {
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
         assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
-        test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
+        test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
 
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
@@ -1034,14 +996,14 @@ mod tests {
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
-        test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
+        test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
 
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
@@ -1051,7 +1013,7 @@ mod tests {
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
@@ -1081,7 +1043,7 @@ mod tests {
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
-        test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
+        test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
 
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
@@ -1089,7 +1051,7 @@ mod tests {
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
-        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
 
@@ -1099,7 +1061,7 @@ mod tests {
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
         assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
-        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
@@ -1128,26 +1090,26 @@ mod tests {
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
-        test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
+        test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
 
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
-        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
-        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
-        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
 
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
         assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
-        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
-        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
         assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
         assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
-        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
@@ -1175,7 +1137,7 @@ mod tests {
         assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(21));
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
-        test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
+        test_bed = test_bed.run_waiting_for(Duration::from_secs(45));
 
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
@@ -1200,65 +1162,65 @@ mod tests {
 
     // Tests flaps configuration and angles for regular
     // increasing handle transitions, i.e 0->1->2->3->4 in sequence
-    // below 205 knots
+    // below 100 knots
     #[test]
-    fn flaps_test_regular_handle_increase_transitions_flaps_target_airspeed_below_205() {
+    fn flaps_test_regular_handle_increase_transitions_flaps_target_airspeed_below_100() {
         let angle_delta: f64 = 0.1;
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
-            .set_indicated_airspeed(160.)
+            .set_indicated_airspeed(50.)
             .run_one_tick();
 
         test_bed.test_flap_conf(0, 0., 0., FlapsConf::Conf0, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
 
-        test_bed.test_flap_conf(1, 108.28, 247.27, FlapsConf::Conf1F, angle_delta);
+        test_bed.test_flap_conf(1, 120.22, 222.27, FlapsConf::Conf1F, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
 
-        test_bed.test_flap_conf(2, 154.65, 247.27, FlapsConf::Conf2, angle_delta);
+        test_bed.test_flap_conf(2, 145.51, 272.27, FlapsConf::Conf2, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
 
-        test_bed.test_flap_conf(3, 194.03, 284.65, FlapsConf::Conf3, angle_delta);
+        test_bed.test_flap_conf(3, 168.35, 272.27, FlapsConf::Conf3, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
 
-        test_bed.test_flap_conf(4, 218.91, 284.65, FlapsConf::ConfFull, angle_delta);
+        test_bed.test_flap_conf(4, 251.97, 334.16, FlapsConf::ConfFull, angle_delta);
     }
 
     // Tests flaps configuration and angles for regular
     // increasing handle transitions, i.e 0->1->2->3->4 in sequence
-    // above 205 knots
+    // above 100 knots
     #[test]
-    fn flaps_test_regular_handle_increase_transitions_flaps_target_airspeed_above_205() {
+    fn flaps_test_regular_handle_increase_transitions_flaps_target_airspeed_above_100() {
         let angle_delta: f64 = 0.1;
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
-            .set_indicated_airspeed(215.)
+            .set_indicated_airspeed(150.)
             .run_one_tick();
 
         test_bed.test_flap_conf(0, 0., 0., FlapsConf::Conf0, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
 
-        test_bed.test_flap_conf(1, 0., 247.27, FlapsConf::Conf1, angle_delta);
+        test_bed.test_flap_conf(1, 0., 222.27, FlapsConf::Conf1, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
 
-        test_bed.test_flap_conf(2, 154.65, 247.27, FlapsConf::Conf2, angle_delta);
+        test_bed.test_flap_conf(2, 145.51, 272.27, FlapsConf::Conf2, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
 
-        test_bed.test_flap_conf(3, 154.65, 284.65, FlapsConf::Conf2S, angle_delta);
+        test_bed.test_flap_conf(3, 168.35, 272.27, FlapsConf::Conf3, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
 
-        test_bed.test_flap_conf(4, 194.03, 284.65, FlapsConf::Conf3, angle_delta);
+        test_bed.test_flap_conf(4, 251.97, 334.16, FlapsConf::ConfFull, angle_delta);
     }
 
-    //Tests regular transition 2->1 below and above 212 knots
+    //Tests regular transition 2->1 below and above 210 knots
     #[test]
     fn flaps_test_regular_handle_transition_pos_2_to_1() {
         let mut test_bed = test_bed_with()
@@ -1288,7 +1250,7 @@ mod tests {
         assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
     }
 
-    //Tests transition between Conf1F to Conf1 above 212 knots
+    //Tests transition between Conf1F to Conf1 above 210 knots
     #[test]
     fn flaps_test_regular_handle_transition_pos_1_to_1() {
         let mut test_bed = test_bed_with()
@@ -1313,30 +1275,30 @@ mod tests {
 
     // Tests flaps configuration and angles for regular
     // decreasing handle transitions, i.e 4->3->2->1->0 in sequence
-    // below 212 knots
+    // below 210 knots
     #[test]
-    fn flaps_test_regular_decrease_handle_transition_flaps_target_airspeed_below_212() {
+    fn flaps_test_regular_decrease_handle_transition_flaps_target_airspeed_below_210() {
         let angle_delta: f64 = 0.1;
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
-            .set_indicated_airspeed(160.)
+            .set_indicated_airspeed(150.)
             .run_one_tick();
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
 
-        test_bed.test_flap_conf(4, 218.91, 284.65, FlapsConf::ConfFull, angle_delta);
+        test_bed.test_flap_conf(4, 251.97, 334.16, FlapsConf::ConfFull, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
 
-        test_bed.test_flap_conf(3, 194.03, 284.65, FlapsConf::Conf3, angle_delta);
+        test_bed.test_flap_conf(3, 168.35, 272.27, FlapsConf::Conf3, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
 
-        test_bed.test_flap_conf(2, 154.65, 247.27, FlapsConf::Conf2, angle_delta);
+        test_bed.test_flap_conf(2, 145.51, 272.27, FlapsConf::Conf2, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
 
-        test_bed.test_flap_conf(1, 108.28, 247.27, FlapsConf::Conf1F, angle_delta);
+        test_bed.test_flap_conf(1, 120.22, 222.27, FlapsConf::Conf1F, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
 
@@ -1347,7 +1309,7 @@ mod tests {
     // decreasing handle transitions, i.e 4->3->2->1->0 in sequence
     // above 210 knots
     #[test]
-    fn flaps_test_regular_decrease_handle_transition_flaps_target_airspeed_above_212() {
+    fn flaps_test_regular_decrease_handle_transition_flaps_target_airspeed_above_210() {
         let angle_delta: f64 = 0.1;
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1356,19 +1318,19 @@ mod tests {
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
 
-        test_bed.test_flap_conf(4, 218.91, 284.65, FlapsConf::ConfFull, angle_delta);
+        test_bed.test_flap_conf(4, 251.97, 334.16, FlapsConf::ConfFull, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
 
-        test_bed.test_flap_conf(3, 194.03, 284.65, FlapsConf::Conf3, angle_delta);
+        test_bed.test_flap_conf(3, 168.35, 272.27, FlapsConf::Conf3, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
 
-        test_bed.test_flap_conf(2, 154.65, 247.27, FlapsConf::Conf2, angle_delta);
+        test_bed.test_flap_conf(2, 145.51, 272.27, FlapsConf::Conf2, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
 
-        test_bed.test_flap_conf(1, 0., 247.27, FlapsConf::Conf1, angle_delta);
+        test_bed.test_flap_conf(1, 0., 222.27, FlapsConf::Conf1, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
 
@@ -1393,23 +1355,23 @@ mod tests {
         assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
         assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
         assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
         assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
         assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed
-            .set_indicated_airspeed(160.)
+            .set_indicated_airspeed(110.)
             .set_flaps_handle_position(0)
             .run_one_tick();
 
@@ -1484,7 +1446,7 @@ mod tests {
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
-            .set_indicated_airspeed(210.)
+            .set_indicated_airspeed(110.)
             .set_flaps_handle_position(1)
             .run_one_tick();
 
@@ -1501,7 +1463,7 @@ mod tests {
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
-            .set_indicated_airspeed(205.)
+            .set_indicated_airspeed(110.)
             .set_flaps_handle_position(1)
             .run_one_tick();
 
@@ -1580,8 +1542,8 @@ mod tests {
         assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
         assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
@@ -1592,7 +1554,7 @@ mod tests {
     fn flaps_test_irregular_handle_transition_init_pos_3() {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
-            .set_indicated_airspeed(205.)
+            .set_indicated_airspeed(150.)
             .set_flaps_handle_position(3)
             .run_one_tick();
 
@@ -1634,8 +1596,8 @@ mod tests {
         assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
         assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
@@ -1646,7 +1608,7 @@ mod tests {
     fn flaps_test_irregular_handle_transition_init_pos_4() {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
-            .set_indicated_airspeed(205.)
+            .set_indicated_airspeed(150.)
             .set_flaps_handle_position(4)
             .run_one_tick();
 
@@ -1688,8 +1650,8 @@ mod tests {
         assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
         assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
@@ -1710,7 +1672,6 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
-            .set_on_ground(true)
             .set_flaps_handle_position(0)
             .run_one_tick();
 
@@ -1737,7 +1698,6 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
-            .set_on_ground(true)
             .set_flaps_handle_position(1)
             .run_one_tick();
 
@@ -1746,7 +1706,7 @@ mod tests {
 
         test_bed = test_bed
             .set_flaps_handle_position(2)
-            .run_waiting_for(Duration::from_secs(35));
+            .run_waiting_for(Duration::from_secs(20));
 
         assert!(
             (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
@@ -1764,7 +1724,6 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
-            .set_on_ground(true)
             .set_flaps_handle_position(2)
             .run_one_tick();
 
@@ -1791,7 +1750,6 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
-            .set_on_ground(true)
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(20));
 
@@ -1818,7 +1776,6 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
-            .set_on_ground(true)
             .set_flaps_handle_position(0)
             .run_one_tick();
 
@@ -1827,7 +1784,7 @@ mod tests {
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
-            .run_waiting_for(Duration::from_secs(60));
+            .run_waiting_for(Duration::from_secs(30));
 
         assert!(
             (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
@@ -1854,7 +1811,7 @@ mod tests {
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
-            .run_waiting_for(Duration::from_secs(60));
+            .run_waiting_for(Duration::from_secs(30));
 
         assert!(
             (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
@@ -1880,7 +1837,6 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
-            .set_on_ground(true)
             .set_flaps_handle_position(1)
             .run_one_tick();
 
@@ -1889,7 +1845,7 @@ mod tests {
 
         test_bed = test_bed
             .set_flaps_handle_position(2)
-            .run_waiting_for(Duration::from_secs(60));
+            .run_waiting_for(Duration::from_secs(40));
 
         assert!(
             (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
@@ -1907,7 +1863,6 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
-            .set_on_ground(true)
             .set_flaps_handle_position(2)
             .run_one_tick();
 
@@ -1916,7 +1871,7 @@ mod tests {
 
         test_bed = test_bed
             .set_flaps_handle_position(3)
-            .run_waiting_for(Duration::from_secs(60));
+            .run_waiting_for(Duration::from_secs(40));
 
         assert!(
             (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
@@ -1934,7 +1889,6 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
-            .set_on_ground(true)
             .set_flaps_handle_position(3)
             .run_one_tick();
 
@@ -1953,134 +1907,5 @@ mod tests {
             (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
-    }
-
-    #[test]
-    fn config_test_flrs_full() {
-        let mut test_bed = test_bed_with()
-            .set_green_hyd_pressure()
-            .set_indicated_airspeed(186.)
-            .set_flaps_handle_position(0)
-            .run_one_tick();
-
-        test_bed = test_bed
-            .set_flaps_handle_position(4)
-            .run_waiting_for(Duration::from_secs(50));
-
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
-    }
-
-    #[test]
-    fn config_test_flrs_3() {
-        let mut test_bed = test_bed_with()
-            .set_green_hyd_pressure()
-            .set_indicated_airspeed(200.)
-            .set_flaps_handle_position(0)
-            .run_one_tick();
-
-        test_bed = test_bed
-            .set_flaps_handle_position(3)
-            .run_waiting_for(Duration::from_secs(50));
-
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2S);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2S);
-    }
-
-    #[test]
-    fn config_test_flrs_2() {
-        let mut test_bed = test_bed_with()
-            .set_green_hyd_pressure()
-            .set_indicated_airspeed(224.)
-            .set_flaps_handle_position(0)
-            .run_one_tick();
-
-        test_bed = test_bed
-            .set_flaps_handle_position(2)
-            .run_waiting_for(Duration::from_secs(50));
-
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
-    }
-
-    #[test]
-    fn config_test_cruise_baulk() {
-        let mut test_bed = test_bed_with()
-            .set_green_hyd_pressure()
-            .set_indicated_airspeed(280.)
-            .set_on_ground(false)
-            .set_flaps_handle_position(0)
-            .run_one_tick();
-
-        test_bed = test_bed
-            .set_flaps_handle_position(1)
-            .run_waiting_for(Duration::from_secs(20));
-
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
-        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(25));
-        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(25));
-    }
-
-    #[test]
-    fn config_test_alpha_lock_speed() {
-        let mut test_bed = test_bed_with()
-            .set_green_hyd_pressure()
-            .set_indicated_airspeed(130.)
-            .set_angle_of_attack(Angle::new::<degree>(5.))
-            .set_on_ground(false)
-            .set_flaps_handle_position(1)
-            .run_one_tick();
-
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
-        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
-        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
-
-        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
-        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(24));
-        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(24));
-
-        test_bed = test_bed.set_indicated_airspeed(200.).run_one_tick();
-
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
-        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
-        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
-    }
-
-    #[test]
-    fn config_test_alpha_lock_aoa() {
-        let mut test_bed = test_bed_with()
-            .set_green_hyd_pressure()
-            .set_indicated_airspeed(200.)
-            .set_angle_of_attack(Angle::new::<degree>(10.))
-            .set_on_ground(false)
-            .set_flaps_handle_position(1)
-            .run_one_tick();
-
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
-        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
-        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
-
-        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
-        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(24));
-        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(24));
-
-        test_bed = test_bed
-            .set_angle_of_attack(Angle::new::<degree>(9.1))
-            .run_one_tick();
-
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
-        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
-        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
     }
 }

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/slats_channel.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/slats_channel.rs
@@ -1,0 +1,109 @@
+use crate::systems::shared::arinc429::{Arinc429Word, SignStatus};
+use systems::hydraulic::command_sensor_unit::{CSUMonitor, CSU};
+use systems::shared::PositionPickoffUnit;
+
+use systems::simulation::{
+    InitContext, SimulationElement, SimulationElementVisitor, SimulatorWriter, UpdateContext,
+    VariableIdentifier, Write,
+};
+
+use uom::si::{angle::degree, f64::*, velocity::knot};
+
+pub struct SlatsChannel {
+    slats_fppu_angle_id: VariableIdentifier,
+    slat_actual_position_word_id: VariableIdentifier,
+
+    slats_demanded_angle: Angle,
+    slats_feedback_angle: Angle,
+
+    csu_monitor: CSUMonitor,
+}
+
+impl SlatsChannel {
+    const HANDLE_ONE_CONF_AIRSPEED_THRESHOLD_KNOTS: f64 = 100.;
+    const CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS: f64 = 210.;
+
+    pub fn new(context: &mut InitContext, num: u8) -> Self {
+        Self {
+            slats_fppu_angle_id: context.get_identifier("SLATS_FPPU_ANGLE".to_owned()),
+            slat_actual_position_word_id: context
+                .get_identifier(format!("SFCC_{num}_SLAT_ACTUAL_POSITION_WORD")),
+
+            slats_demanded_angle: Angle::new::<degree>(0.),
+            slats_feedback_angle: Angle::new::<degree>(0.),
+
+            csu_monitor: CSUMonitor::new(context),
+        }
+    }
+
+    fn generate_configuration(&self, context: &UpdateContext) -> Angle {
+        // Ignored `CSU::OutOfDetent` and `CSU::Fault` positions due to simplified SFCC.
+        match (
+            self.csu_monitor.get_previous_detent(),
+            self.csu_monitor.get_current_detent(),
+        ) {
+            (CSU::Conf0, CSU::Conf1)
+                if context.indicated_airspeed().get::<knot>()
+                    <= Self::HANDLE_ONE_CONF_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::new::<degree>(222.27)
+            }
+            (CSU::Conf0, CSU::Conf1) => Angle::new::<degree>(222.27),
+            (CSU::Conf1, CSU::Conf1)
+                if context.indicated_airspeed().get::<knot>()
+                    > Self::CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::new::<degree>(222.27)
+            }
+            (CSU::Conf1, CSU::Conf1) => self.slats_demanded_angle,
+            (_, CSU::Conf1)
+                if context.indicated_airspeed().get::<knot>()
+                    <= Self::CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::new::<degree>(222.27)
+            }
+            (_, CSU::Conf1) => Angle::new::<degree>(222.27),
+            (_, CSU::Conf0) => Angle::default(),
+            (from, CSU::Conf2) if from != CSU::Conf2 => Angle::new::<degree>(272.27),
+            (from, CSU::Conf3) if from != CSU::Conf3 => Angle::new::<degree>(272.27),
+            (from, CSU::ConfFull) if from != CSU::ConfFull => Angle::new::<degree>(334.16),
+            (_, _) => self.slats_demanded_angle,
+        }
+    }
+
+    pub fn update(&mut self, context: &UpdateContext, slats_feedback: &impl PositionPickoffUnit) {
+        self.csu_monitor.update(context);
+        self.slats_demanded_angle = self.generate_configuration(context);
+        self.slats_feedback_angle = slats_feedback.angle();
+    }
+
+    pub fn get_demanded_angle(&self) -> Angle {
+        self.slats_demanded_angle
+    }
+
+    pub fn get_feedback_angle(&self) -> Angle {
+        self.slats_feedback_angle
+    }
+
+    fn slat_actual_position_word(&self) -> Arinc429Word<f64> {
+        Arinc429Word::new(
+            self.slats_feedback_angle.get::<degree>(),
+            SignStatus::NormalOperation,
+        )
+    }
+}
+impl SimulationElement for SlatsChannel {
+    fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
+        self.csu_monitor.accept(visitor);
+        visitor.visit(self);
+    }
+
+    fn write(&self, writer: &mut SimulatorWriter) {
+        writer.write(&self.slats_fppu_angle_id, self.slats_feedback_angle);
+
+        writer.write(
+            &self.slat_actual_position_word_id,
+            self.slat_actual_position_word(),
+        );
+    }
+}

--- a/fbw-a380x/docs/a380-simvars.md
+++ b/fbw-a380x/docs/a380-simvars.md
@@ -891,6 +891,7 @@
       | 29  | SEC 3 Fault                              |
 
 - A32NX_SFCC_{number}_SLAT_FLAP_ACTUAL_POSITION_WORD
+    - {number} is 1 or 2
     - Slat/Flap actual position discrete word of the SFCC bus output
     - Arinc429<Discrete>
     - | Bit |      Description A380X, if different     |

--- a/fbw-a380x/docs/a380-simvars.md
+++ b/fbw-a380x/docs/a380-simvars.md
@@ -890,10 +890,9 @@
       | 28  | FCDC Opposite Fault                      |
       | 29  | SEC 3 Fault                              |
 
-- A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD
+- A32NX_SFCC_{number}_SLAT_FLAP_ACTUAL_POSITION_WORD
     - Slat/Flap actual position discrete word of the SFCC bus output
     - Arinc429<Discrete>
-    - Note that multiple SFCC are not yet implemented, thus no {number} in the name.
     - | Bit |      Description A380X, if different     |
       |:---:|:----------------------------------------:|
       | 11  | Slat Data Valid                          |

--- a/fbw-a380x/src/systems/instruments/src/PFD/shared/PFDSimvarPublisher.tsx
+++ b/fbw-a380x/src/systems/instruments/src/PFD/shared/PFDSimvarPublisher.tsx
@@ -179,9 +179,10 @@ export interface PFDSimvars {
 }
 
 export enum PFDVars {
-  slatsFlapsStatusRaw = 'L:A32NX_SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD',
-  slatsPositionRaw = 'L:A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD',
-  flapsPositionRaw = 'L:A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD',
+  // TODO: add switching between SFCC_1 and SFCC_2
+  slatsFlapsStatusRaw = 'L:A32NX_SFCC_1_SLAT_FLAP_SYSTEM_STATUS_WORD',
+  slatsPositionRaw = 'L:A32NX_SFCC_1_SLAT_ACTUAL_POSITION_WORD',
+  flapsPositionRaw = 'L:A32NX_SFCC_1_FLAP_ACTUAL_POSITION_WORD',
   coldDark = 'L:A32NX_COLD_AND_DARK_SPAWN',
   elec = 'L:A32NX_ELEC_AC_ESS_BUS_IS_POWERED',
   elecFo = 'L:A32NX_ELEC_AC_2_BUS_IS_POWERED',

--- a/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsCore.ts
+++ b/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsCore.ts
@@ -2238,7 +2238,8 @@ export class FwsCore {
     this.flapsAngle.set(SimVar.GetSimVarValue('L:A32NX_FLAPS_IPPU_ANGLE', 'degrees'));
     this.flapsHandle.set(SimVar.GetSimVarValue('L:A32NX_FLAPS_HANDLE_INDEX', 'enum'));
     this.slatsAngle.set(SimVar.GetSimVarValue('L:A32NX_SLATS_IPPU_ANGLE', 'degrees'));
-    this.flapsBaulkActiveWord.setFromSimVar('L:A32NX_SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD');
+    // TODO: add switching between SFCC_1 and SFCC_2
+    this.flapsBaulkActiveWord.setFromSimVar('L:A32NX_SFCC_1_SLAT_FLAP_SYSTEM_STATUS_WORD');
 
     // FIXME move out of acquisition to logic below
     const oneEngineAboveMinPower = this.engine1AboveIdle.get() || this.engine2AboveIdle.get();
@@ -3592,9 +3593,9 @@ export class FwsCore {
     this.spoilersArmed.set(fcdc1DiscreteWord4.bitValueOr(27, false) || fcdc2DiscreteWord4.bitValueOr(27, false));
     this.speedBrakeCommand.set(fcdc1DiscreteWord4.bitValueOr(28, false) || fcdc2DiscreteWord4.bitValueOr(28, false));
 
-    // FIXME these should be split between the two systems and the two sides
-    const flapsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD');
-    const slatsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD');
+    // TODO: add switching between SFCC_1 and SFCC_2
+    const flapsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_1_FLAP_ACTUAL_POSITION_WORD');
+    const slatsPos = Arinc429Word.fromSimVarValue('L:A32NX_SFCC_1_SLAT_ACTUAL_POSITION_WORD');
 
     // WARNING these vary for other variants... A320 CFM LEAP values here
     // flap/slat internal signals

--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
@@ -509,11 +509,14 @@ void FlyByWireInterface::setupLocalVariables() {
     idLgciuDiscreteWord4[i] = std::make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_DISCRETE_WORD_4");
   }
 
-  idSfccSlatFlapComponentStatusWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_COMPONENT_STATUS_WORD");
-  idSfccSlatFlapSystemStatusWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD");
-  idSfccSlatFlapActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD");
-  idSfccSlatActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD");
-  idSfccFlapActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD");
+  for (int i = 0; i < 2; i++) {
+    std::string idString = std::to_string(i + 1);
+    idSfccSlatFlapComponentStatusWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_FLAP_COMPONENT_STATUS_WORD");
+    idSfccSlatFlapSystemStatusWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_FLAP_SYSTEM_STATUS_WORD");
+    idSfccSlatFlapActualPositionWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_FLAP_ACTUAL_POSITION_WORD");
+    idSfccSlatActualPositionWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_SLAT_ACTUAL_POSITION_WORD");
+    idSfccFlapActualPositionWord[i] = std::make_unique<LocalVariable>("A32NX_SFCC_" + idString + "_FLAP_ACTUAL_POSITION_WORD");
+  }
 
   for (int i = 0; i < 3; i++) {
     std::string idString = std::to_string(i + 1);
@@ -1197,11 +1200,11 @@ bool FlyByWireInterface::updateLgciu(int lgciuIndex) {
 }
 
 bool FlyByWireInterface::updateSfcc(int sfccIndex) {
-  sfccBusOutputs[sfccIndex].slat_flap_component_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapComponentStatusWord->get());
-  sfccBusOutputs[sfccIndex].slat_flap_system_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapSystemStatusWord->get());
-  sfccBusOutputs[sfccIndex].slat_flap_actual_position_word = Arinc429Utils::fromSimVar(idSfccSlatFlapActualPositionWord->get());
-  sfccBusOutputs[sfccIndex].slat_actual_position_deg = Arinc429Utils::fromSimVar(idSfccSlatActualPositionWord->get());
-  sfccBusOutputs[sfccIndex].flap_actual_position_deg = Arinc429Utils::fromSimVar(idSfccFlapActualPositionWord->get());
+  sfccBusOutputs[sfccIndex].slat_flap_component_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapComponentStatusWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].slat_flap_system_status_word = Arinc429Utils::fromSimVar(idSfccSlatFlapSystemStatusWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].slat_flap_actual_position_word = Arinc429Utils::fromSimVar(idSfccSlatFlapActualPositionWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].slat_actual_position_deg = Arinc429Utils::fromSimVar(idSfccSlatActualPositionWord[sfccIndex]->get());
+  sfccBusOutputs[sfccIndex].flap_actual_position_deg = Arinc429Utils::fromSimVar(idSfccFlapActualPositionWord[sfccIndex]->get());
 
   if (clientDataEnabled) {
     simConnectInterface.setClientDataSfcc(sfccBusOutputs[sfccIndex], sfccIndex);

--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.h
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.h
@@ -374,11 +374,11 @@ class FlyByWireInterface {
   std::unique_ptr<LocalVariable> idLgciuDiscreteWord4[2];
 
   // SFCC inputs
-  std::unique_ptr<LocalVariable> idSfccSlatFlapComponentStatusWord;
-  std::unique_ptr<LocalVariable> idSfccSlatFlapSystemStatusWord;
-  std::unique_ptr<LocalVariable> idSfccSlatFlapActualPositionWord;
-  std::unique_ptr<LocalVariable> idSfccSlatActualPositionWord;
-  std::unique_ptr<LocalVariable> idSfccFlapActualPositionWord;
+  std::unique_ptr<LocalVariable> idSfccSlatFlapComponentStatusWord[2];
+  std::unique_ptr<LocalVariable> idSfccSlatFlapSystemStatusWord[2];
+  std::unique_ptr<LocalVariable> idSfccSlatFlapActualPositionWord[2];
+  std::unique_ptr<LocalVariable> idSfccSlatActualPositionWord[2];
+  std::unique_ptr<LocalVariable> idSfccFlapActualPositionWord[2];
 
   // ADR bus inputs
   std::unique_ptr<LocalVariable> idAdrAltitudeCorrected[3];

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/flaps_channel.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/flaps_channel.rs
@@ -1,0 +1,265 @@
+use crate::systems::shared::arinc429::{Arinc429Word, SignStatus};
+use systems::hydraulic::command_sensor_unit::{CSUMonitor, CSU};
+use systems::shared::{AdirsMeasurementOutputs, PositionPickoffUnit};
+
+use systems::simulation::{
+    InitContext, SimulationElement, SimulationElementVisitor, SimulatorWriter, UpdateContext,
+    VariableIdentifier, Write,
+};
+
+use uom::si::length::foot;
+use uom::si::{angle::degree, f64::*, velocity::knot};
+use uom::ConstZero;
+
+pub struct FlapsChannel {
+    flaps_fppu_angle_id: VariableIdentifier,
+    flap_actual_position_word_id: VariableIdentifier,
+
+    flaps_demanded_angle: Angle,
+    flaps_feedback_angle: Angle,
+
+    flap_load_relief_active: bool,
+    alpha_speed_lock_active: bool,
+
+    csu_monitor: CSUMonitor,
+}
+
+impl FlapsChannel {
+    const HANDLE_ONE_CONF_AIRSPEED_THRESHOLD_KNOTS: f64 = 205.;
+    const CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS: f64 = 212.;
+    const CRUISE_BAULK_AIRSPEED_THRESHOLD_KNOTS: f64 = 265.5;
+    const CRUISE_BAULK_ALTITUDE_THRESHOLD_FEET: f64 = 22000.;
+    const ALPHA_SPEED_LOCK_IN_AIRSPEED_THRESHOLD_KNOTS: f64 = 155.;
+    const ALPHA_SPEED_LOCK_OUT_AIRSPEED_THRESHOLD_KNOTS: f64 = 161.;
+    const ALPHA_SPEED_LOCK_IN_AOA_THRESHOLD_DEGREES: f64 = 9.5;
+    const ALPHA_SPEED_LOCK_OUT_AOA_THRESHOLD_DEGREES: f64 = 9.2;
+
+    const FLRS_CONFFULL_TO_CONF3_AIRSPEED_THRESHOLD_KNOTS: f64 = 184.5;
+    const FLRS_CONF3_TO_CONF2S_AIRSPEED_THRESHOLD_KNOTS: f64 = 198.5;
+    const FLRS_CONF2_TO_CONF1F_AIRSPEED_THRESHOLD_KNOTS: f64 = 222.5;
+    const FLRS_CONF1F_TO_CONF2_AIRSPEED_THRESHOLD_KNOTS: f64 = 217.5;
+    const FLRS_CONF2S_TO_CONF3_AIRSPEED_THRESHOLD_KNOTS: f64 = 193.5;
+    const FLRS_CONF3_TO_CONFFULL_AIRSPEED_THRESHOLD_KNOTS: f64 = 179.5;
+
+    pub fn new(context: &mut InitContext, num: u8) -> Self {
+        Self {
+            flaps_fppu_angle_id: context.get_identifier("FLAPS_FPPU_ANGLE".to_owned()),
+            flap_actual_position_word_id: context
+                .get_identifier(format!("SFCC_{num}_FLAP_ACTUAL_POSITION_WORD")),
+
+            flaps_demanded_angle: Angle::new::<degree>(0.),
+            flaps_feedback_angle: Angle::new::<degree>(0.),
+            flap_load_relief_active: false,
+            alpha_speed_lock_active: false,
+            csu_monitor: CSUMonitor::new(context),
+        }
+    }
+
+    // FIXME This is not the correct ADR input selection yet, due to missing references
+    fn angle_of_attack(&self, adirs: &impl AdirsMeasurementOutputs) -> Option<Angle> {
+        [1, 2, 3]
+            .iter()
+            .find_map(|&adiru_number| adirs.angle_of_attack(adiru_number).normal_value())
+    }
+
+    fn flap_load_relief_active(&self, csu_monitor: &CSUMonitor) -> bool {
+        (csu_monitor.get_current_detent() == CSU::Conf2
+            && self.flaps_demanded_angle != Angle::new::<degree>(154.65))
+            || (csu_monitor.get_current_detent() == CSU::Conf3
+                && self.flaps_demanded_angle != Angle::new::<degree>(194.03))
+            || (csu_monitor.get_current_detent() == CSU::ConfFull
+                && self.flaps_demanded_angle != Angle::new::<degree>(218.91))
+    }
+
+    fn alpha_speed_lock_active(&self, csu_monitor: &CSUMonitor) -> bool {
+        csu_monitor.get_current_detent() == CSU::Conf0
+            && (self.flaps_demanded_angle == Angle::ZERO
+                || self.flaps_demanded_angle == Angle::new::<degree>(108.28))
+    }
+
+    fn generate_configuration(
+        &self,
+        csu_monitor: &CSUMonitor,
+        context: &UpdateContext,
+        adirs: &impl AdirsMeasurementOutputs,
+    ) -> Angle {
+        // Ignored `CSU::OutOfDetent` and `CSU::Fault` positions due to simplified SFCC.
+        match (
+            csu_monitor.get_previous_detent(),
+            csu_monitor.get_current_detent(),
+        ) {
+            (CSU::Conf0 | CSU::Conf1, CSU::Conf1)
+                if context.indicated_airspeed().get::<knot>()
+                    < Self::HANDLE_ONE_CONF_AIRSPEED_THRESHOLD_KNOTS
+                    || context.is_on_ground() =>
+            {
+                Angle::new::<degree>(108.28)
+            }
+            (CSU::Conf0 | CSU::Conf1, CSU::Conf1)
+                if context.indicated_airspeed().get::<knot>()
+                    > Self::CRUISE_BAULK_AIRSPEED_THRESHOLD_KNOTS
+                    // FIXME use ADRs
+                    || context.pressure_altitude().get::<foot>()
+                        > Self::CRUISE_BAULK_ALTITUDE_THRESHOLD_FEET =>
+            {
+                Angle::ZERO
+            }
+            (CSU::Conf0, CSU::Conf1) => Angle::ZERO,
+            (CSU::Conf1, CSU::Conf1)
+                if context.indicated_airspeed().get::<knot>()
+                    > Self::CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::ZERO
+            }
+            (CSU::Conf1, CSU::Conf1) => self.flaps_demanded_angle,
+            (_, CSU::Conf1)
+                if context.indicated_airspeed().get::<knot>()
+                    <= Self::CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::new::<degree>(108.28)
+            }
+            (_, CSU::Conf1) => Angle::ZERO,
+            (_, CSU::Conf0) if context.is_in_flight() && self.alpha_speed_lock_active => {
+                if context.indicated_airspeed().get::<knot>()
+                    > Self::ALPHA_SPEED_LOCK_OUT_AIRSPEED_THRESHOLD_KNOTS
+                    || self
+                        .angle_of_attack(adirs)
+                        .unwrap_or_default()
+                        .get::<degree>()
+                        < Self::ALPHA_SPEED_LOCK_OUT_AOA_THRESHOLD_DEGREES
+                {
+                    Angle::ZERO
+                } else {
+                    self.flaps_demanded_angle
+                }
+            }
+            (CSU::Conf1, CSU::Conf0)
+            | (CSU::Conf2, CSU::Conf0)
+            | (CSU::Conf3, CSU::Conf0)
+            | (CSU::ConfFull, CSU::Conf0)
+                if context.is_in_flight()
+                    && (context.indicated_airspeed().get::<knot>()
+                        < Self::ALPHA_SPEED_LOCK_IN_AIRSPEED_THRESHOLD_KNOTS
+                        || self
+                            .angle_of_attack(adirs)
+                            .unwrap_or_default()
+                            .get::<degree>()
+                            > Self::ALPHA_SPEED_LOCK_IN_AOA_THRESHOLD_DEGREES) =>
+            {
+                Angle::new::<degree>(108.28)
+            }
+            (_, CSU::Conf0) => Angle::ZERO,
+            (CSU::Conf1 | CSU::Conf2, CSU::Conf2)
+                if context.indicated_airspeed().get::<knot>()
+                    > Self::FLRS_CONF2_TO_CONF1F_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::new::<degree>(108.28)
+            }
+            (CSU::Conf2, CSU::Conf2)
+                if self.flaps_demanded_angle == Angle::new::<degree>(108.28) =>
+            {
+                if context.indicated_airspeed().get::<knot>()
+                    < Self::FLRS_CONF1F_TO_CONF2_AIRSPEED_THRESHOLD_KNOTS
+                {
+                    Angle::new::<degree>(154.65)
+                } else {
+                    Angle::new::<degree>(108.28)
+                }
+            }
+            (CSU::Conf2 | CSU::Conf3, CSU::Conf3)
+                if context.indicated_airspeed().get::<knot>()
+                    > Self::FLRS_CONF3_TO_CONF2S_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::new::<degree>(154.65)
+            }
+            (CSU::Conf3, CSU::Conf3)
+                if self.flaps_demanded_angle == Angle::new::<degree>(154.65) =>
+            {
+                if context.indicated_airspeed().get::<knot>()
+                    < Self::FLRS_CONF2S_TO_CONF3_AIRSPEED_THRESHOLD_KNOTS
+                {
+                    Angle::new::<degree>(194.03)
+                } else {
+                    Angle::new::<degree>(154.65)
+                }
+            }
+            (CSU::Conf3 | CSU::ConfFull, CSU::ConfFull)
+                if context.indicated_airspeed().get::<knot>()
+                    > Self::FLRS_CONFFULL_TO_CONF3_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::new::<degree>(194.03)
+            }
+            (CSU::ConfFull, CSU::ConfFull)
+                if self.flaps_demanded_angle == Angle::new::<degree>(194.03) =>
+            {
+                if context.indicated_airspeed().get::<knot>()
+                    < Self::FLRS_CONF3_TO_CONFFULL_AIRSPEED_THRESHOLD_KNOTS
+                {
+                    Angle::new::<degree>(218.91)
+                } else {
+                    Angle::new::<degree>(194.03)
+                }
+            }
+            (from, CSU::Conf2) if from != CSU::Conf2 => Angle::new::<degree>(154.65),
+            (from, CSU::Conf3) if from != CSU::Conf3 => Angle::new::<degree>(194.03),
+            (from, CSU::ConfFull) if from != CSU::ConfFull => Angle::new::<degree>(218.91),
+            (_, _) => self.flaps_demanded_angle,
+        }
+    }
+
+    pub fn update(
+        &mut self,
+        context: &UpdateContext,
+        flaps_feedback: &impl PositionPickoffUnit,
+        adirs: &impl AdirsMeasurementOutputs,
+    ) {
+        self.csu_monitor.update(context);
+        self.flaps_demanded_angle = self.generate_configuration(&self.csu_monitor, context, adirs);
+        self.flaps_feedback_angle = flaps_feedback.angle();
+
+        self.alpha_speed_lock_active = self.alpha_speed_lock_active(&self.csu_monitor);
+        self.flap_load_relief_active = self.flap_load_relief_active(&self.csu_monitor);
+    }
+
+    pub fn get_demanded_angle(&self) -> Angle {
+        self.flaps_demanded_angle
+    }
+
+    pub fn get_feedback_angle(&self) -> Angle {
+        self.flaps_feedback_angle
+    }
+
+    // pub fn get_alpha_speed_lock(&self) -> bool {
+    //     self.alpha_speed_lock_active
+    // }
+
+    pub fn get_flap_load_relief(&self) -> bool {
+        self.flap_load_relief_active
+    }
+
+    pub fn get_handle_detent(&self) -> CSU {
+        self.csu_monitor.get_current_detent()
+    }
+
+    fn flap_actual_position_word(&self) -> Arinc429Word<f64> {
+        Arinc429Word::new(
+            self.flaps_feedback_angle.get::<degree>(),
+            SignStatus::NormalOperation,
+        )
+    }
+}
+impl SimulationElement for FlapsChannel {
+    fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
+        self.csu_monitor.accept(visitor);
+        visitor.visit(self);
+    }
+
+    fn write(&self, writer: &mut SimulatorWriter) {
+        writer.write(&self.flaps_fppu_angle_id, self.flaps_feedback_angle);
+
+        writer.write(
+            &self.flap_actual_position_word_id,
+            self.flap_actual_position_word(),
+        );
+    }
+}

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/flaps_computer.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/flaps_computer.rs
@@ -1,4 +1,5 @@
 use crate::systems::shared::arinc429::{Arinc429Word, SignStatus};
+use systems::accept_iterable;
 use systems::hydraulic::command_sensor_unit::{CSUMonitor, CSU};
 use systems::shared::{AdirsMeasurementOutputs, PositionPickoffUnit};
 
@@ -37,6 +38,8 @@ struct SlatFlapControlComputer {
     flap_load_relief_active: bool,
     cruise_baulk_active: bool,
     alpha_speed_lock_active: bool,
+
+    csu_monitor: CSUMonitor,
 }
 
 impl SlatFlapControlComputer {
@@ -57,17 +60,17 @@ impl SlatFlapControlComputer {
     const FLRS_CONF2S_TO_CONF3_AIRSPEED_THRESHOLD_KNOTS: f64 = 193.5;
     const FLRS_CONF3_TO_CONFFULL_AIRSPEED_THRESHOLD_KNOTS: f64 = 179.5;
 
-    fn new(context: &mut InitContext) -> Self {
+    fn new(context: &mut InitContext, num: u8) -> Self {
         Self {
             flaps_conf_index_id: context.get_identifier("FLAPS_CONF_INDEX".to_owned()),
             slat_flap_system_status_word_id: context
-                .get_identifier("SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_SLAT_FLAP_SYSTEM_STATUS_WORD")),
             slat_flap_actual_position_word_id: context
-                .get_identifier("SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_SLAT_FLAP_ACTUAL_POSITION_WORD")),
             slat_actual_position_word_id: context
-                .get_identifier("SFCC_SLAT_ACTUAL_POSITION_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_SLAT_ACTUAL_POSITION_WORD")),
             flap_actual_position_word_id: context
-                .get_identifier("SFCC_FLAP_ACTUAL_POSITION_WORD".to_owned()),
+                .get_identifier(format!("SFCC_{num}_FLAP_ACTUAL_POSITION_WORD")),
 
             flaps_demanded_angle: Angle::new::<degree>(0.),
             slats_demanded_angle: Angle::new::<degree>(0.),
@@ -78,6 +81,8 @@ impl SlatFlapControlComputer {
             flap_load_relief_active: false,
             cruise_baulk_active: false,
             alpha_speed_lock_active: false,
+
+            csu_monitor: CSUMonitor::new(context),
         }
     }
 
@@ -265,15 +270,16 @@ impl SlatFlapControlComputer {
         &mut self,
         context: &UpdateContext,
         adirs: &impl AdirsMeasurementOutputs,
-        flaps_handle: &CSUMonitor,
         flaps_feedback: &impl PositionPickoffUnit,
         slats_feedback: &impl PositionPickoffUnit,
     ) {
-        self.flaps_handle_position = flaps_handle.get_current_detent();
-        self.flaps_conf = self.generate_configuration(flaps_handle, context, adirs);
-        self.flap_load_relief_active = self.flap_load_relief_active(flaps_handle);
-        self.cruise_baulk_active = self.cruise_baulk_active(flaps_handle);
-        self.alpha_speed_lock_active = self.alpha_speed_lock_active(flaps_handle);
+        self.csu_monitor.update(context);
+
+        self.flaps_handle_position = self.csu_monitor.get_current_detent();
+        self.flaps_conf = self.generate_configuration(&self.csu_monitor, context, adirs);
+        self.flap_load_relief_active = self.flap_load_relief_active(&self.csu_monitor);
+        self.cruise_baulk_active = self.cruise_baulk_active(&self.csu_monitor);
+        self.alpha_speed_lock_active = self.alpha_speed_lock_active(&self.csu_monitor);
 
         self.flaps_demanded_angle = Self::demanded_flaps_fppu_angle_from_conf(self.flaps_conf);
         self.slats_demanded_angle = Self::demanded_slats_fppu_angle_from_conf(self.flaps_conf);
@@ -423,6 +429,11 @@ impl SlatFlapLane for SlatFlapControlComputer {
 }
 
 impl SimulationElement for SlatFlapControlComputer {
+    fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
+        self.csu_monitor.accept(visitor);
+        visitor.visit(self);
+    }
+
     fn write(&self, writer: &mut SimulatorWriter) {
         writer.write(&self.flaps_conf_index_id, self.flaps_conf as u8);
 
@@ -446,15 +457,16 @@ impl SimulationElement for SlatFlapControlComputer {
 }
 
 pub struct SlatFlapComplex {
-    sfcc: SlatFlapControlComputer,
-    csu_monitor: CSUMonitor,
+    sfcc: [SlatFlapControlComputer; 2],
 }
 
 impl SlatFlapComplex {
     pub fn new(context: &mut InitContext) -> Self {
         Self {
-            sfcc: SlatFlapControlComputer::new(context),
-            csu_monitor: CSUMonitor::new(context),
+            sfcc: [
+                SlatFlapControlComputer::new(context, 1),
+                SlatFlapControlComputer::new(context, 2),
+            ],
         }
     }
 
@@ -465,28 +477,25 @@ impl SlatFlapComplex {
         flaps_feedback: &impl PositionPickoffUnit,
         slats_feedback: &impl PositionPickoffUnit,
     ) {
-        self.csu_monitor.update(context);
-        self.sfcc.update(
-            context,
-            adirs,
-            &self.csu_monitor,
-            flaps_feedback,
-            slats_feedback,
-        );
+        self.sfcc[0].update(context, adirs, flaps_feedback, slats_feedback);
+        self.sfcc[1].update(context, adirs, flaps_feedback, slats_feedback);
     }
 
-    pub fn flap_demand(&self) -> Option<Angle> {
-        self.sfcc.signal_demanded_angle("FLAPS")
+    // `idx` 0 is for SFCC1
+    // `idx` 1 is for SFCC2
+    pub fn flap_demand(&self, idx: usize) -> Option<Angle> {
+        self.sfcc[idx].signal_demanded_angle("FLAPS")
     }
 
-    pub fn slat_demand(&self) -> Option<Angle> {
-        self.sfcc.signal_demanded_angle("SLATS")
+    // `idx` 0 is for SFCC1
+    // `idx` 1 is for SFCC2
+    pub fn slat_demand(&self, idx: usize) -> Option<Angle> {
+        self.sfcc[idx].signal_demanded_angle("SLATS")
     }
 }
 impl SimulationElement for SlatFlapComplex {
     fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
-        self.csu_monitor.accept(visitor);
-        self.sfcc.accept(visitor);
+        accept_iterable!(self.sfcc, visitor);
         visitor.visit(self);
     }
 }
@@ -655,13 +664,13 @@ mod tests {
                 .update(context, &self.adirs, &self.flap_gear, &self.slat_gear);
             self.flap_gear.update(
                 context,
-                &self.slat_flap_complex.sfcc,
+                &self.slat_flap_complex.sfcc[0],
                 self.green_pressure,
                 self.yellow_pressure,
             );
             self.slat_gear.update(
                 context,
-                &self.slat_flap_complex.sfcc,
+                &self.slat_flap_complex.sfcc[0],
                 self.blue_pressure,
                 self.green_pressure,
             );
@@ -775,12 +784,12 @@ mod tests {
             self.read_by_name("FLAPS_HANDLE_INDEX")
         }
 
-        fn read_slat_flap_system_status_word(&mut self) -> Arinc429Word<u32> {
-            self.read_by_name("SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD")
+        fn read_slat_flap_system_status_word(&mut self, num: u8) -> Arinc429Word<u32> {
+            self.read_by_name(&format!("SFCC_{num}_SLAT_FLAP_SYSTEM_STATUS_WORD"))
         }
 
-        fn read_slat_flap_actual_position_word(&mut self) -> Arinc429Word<u32> {
-            self.read_by_name("SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD")
+        fn read_slat_flap_actual_position_word(&mut self, num: u8) -> Arinc429Word<u32> {
+            self.read_by_name(&format!("SFCC_{num}_SLAT_FLAP_ACTUAL_POSITION_WORD"))
         }
 
         fn set_indicated_airspeed(mut self, indicated_airspeed: f64) -> Self {
@@ -813,26 +822,24 @@ mod tests {
             self
         }
 
-        fn get_flaps_demanded_angle(&self) -> f64 {
+        fn get_flaps_demanded_angle(&self, idx: usize) -> f64 {
             self.query(|a| {
-                a.slat_flap_complex
-                    .sfcc
+                a.slat_flap_complex.sfcc[idx]
                     .flaps_demanded_angle
                     .get::<degree>()
             })
         }
 
-        fn get_slats_demanded_angle(&self) -> f64 {
+        fn get_slats_demanded_angle(&self, idx: usize) -> f64 {
             self.query(|a| {
-                a.slat_flap_complex
-                    .sfcc
+                a.slat_flap_complex.sfcc[idx]
                     .slats_demanded_angle
                     .get::<degree>()
             })
         }
 
-        fn get_flaps_conf(&self) -> FlapsConf {
-            self.query(|a| a.slat_flap_complex.sfcc.flaps_conf)
+        fn get_flaps_conf(&self, num: usize) -> FlapsConf {
+            self.query(|a| a.slat_flap_complex.sfcc[num].flaps_conf)
         }
 
         fn get_flaps_fppu_feedback(&self) -> f64 {
@@ -852,9 +859,12 @@ mod tests {
             angle_delta: f64,
         ) {
             assert_eq!(self.read_flaps_handle_position(), handle_pos);
-            assert!((self.get_flaps_demanded_angle() - flaps_demanded_angle).abs() < angle_delta);
-            assert!((self.get_slats_demanded_angle() - slats_demanded_angle).abs() < angle_delta);
-            assert_eq!(self.get_flaps_conf(), conf);
+            assert!((self.get_flaps_demanded_angle(0) - flaps_demanded_angle).abs() < angle_delta);
+            assert!((self.get_flaps_demanded_angle(1) - flaps_demanded_angle).abs() < angle_delta);
+            assert!((self.get_slats_demanded_angle(0) - slats_demanded_angle).abs() < angle_delta);
+            assert!((self.get_slats_demanded_angle(1) - slats_demanded_angle).abs() < angle_delta);
+            assert_eq!(self.get_flaps_conf(0), conf);
+            assert_eq!(self.get_flaps_conf(1), conf);
         }
     }
     impl TestBed for A380FlapsTestBed {
@@ -892,6 +902,18 @@ mod tests {
         assert!(test_bed.contains_variable_with_name("RIGHT_SLATS_POSITION_PERCENT"));
 
         assert!(test_bed.contains_variable_with_name("FLAPS_CONF_INDEX"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_FLAP_ACTUAL_POSITION_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_FLAP_ACTUAL_POSITION_WORD"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SLAT_ACTUAL_POSITION_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SLAT_ACTUAL_POSITION_WORD"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SLAT_FLAP_ACTUAL_POSITION_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SLAT_FLAP_ACTUAL_POSITION_WORD"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SLAT_FLAP_SYSTEM_STATUS_WORD"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SLAT_FLAP_SYSTEM_STATUS_WORD"));
     }
 
     #[test]
@@ -904,24 +926,41 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(10));
 
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -934,24 +973,41 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -964,24 +1020,41 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -994,24 +1067,41 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -1024,24 +1114,41 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     #[test]
@@ -1054,24 +1161,41 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(17));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(18));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(19));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(20));
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(21));
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(26));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(26));
+
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(17));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(18));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(19));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(21));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
         test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(12));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(13));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(14));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(15));
-        assert!(!test_bed.read_slat_flap_actual_position_word().get_bit(19));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(20));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(21));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(22));
-        assert!(test_bed.read_slat_flap_actual_position_word().get_bit(23));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
+
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
     // Tests flaps configuration and angles for regular
@@ -1143,21 +1267,25 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed
             .set_indicated_airspeed(220.)
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
     }
 
     //Tests transition between Conf1F to Conf1 above 212 knots
@@ -1169,15 +1297,18 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_indicated_airspeed(150.).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_indicated_airspeed(220.).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
     }
 
     // Tests flaps configuration and angles for regular
@@ -1258,19 +1389,24 @@ mod tests {
             .run_one_tick();
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed
             .set_indicated_airspeed(160.)
@@ -1278,19 +1414,24 @@ mod tests {
             .run_one_tick();
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed
             .set_indicated_airspeed(220.)
@@ -1298,19 +1439,24 @@ mod tests {
             .run_one_tick();
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
     }
 
     #[test]
@@ -1321,16 +1467,20 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1338,13 +1488,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1352,12 +1505,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
+
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1365,13 +1522,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1379,13 +1539,16 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
     }
 
     #[test]
@@ -1396,13 +1559,16 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1410,13 +1576,16 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
     }
 
     #[test]
@@ -1427,13 +1596,16 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1441,13 +1613,16 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1455,13 +1630,16 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
     }
 
     #[test]
@@ -1472,13 +1650,16 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1486,13 +1667,16 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1500,19 +1684,24 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
     }
 
     #[test]
@@ -1525,14 +1714,19 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(20));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1547,14 +1741,19 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed
             .set_flaps_handle_position(2)
             .run_waiting_for(Duration::from_secs(35));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1569,14 +1768,19 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(30));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1591,14 +1795,19 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(20));
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed
             .set_flaps_handle_position(4)
             .run_waiting_for(Duration::from_secs(20));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1613,14 +1822,19 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(60));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1635,18 +1849,27 @@ mod tests {
             .set_flaps_handle_position(0)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(60));
 
         assert!(
-            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
                 <= angle_delta
         );
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(1)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1661,14 +1884,19 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
 
         test_bed = test_bed
             .set_flaps_handle_position(2)
             .run_waiting_for(Duration::from_secs(60));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1683,14 +1911,19 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(60));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1705,14 +1938,19 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed
             .set_flaps_handle_position(4)
             .run_waiting_for(Duration::from_secs(50));
 
         assert!(
-            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle()).abs()
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
+                <= angle_delta
+        );
+        assert!(
+            (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
     }
@@ -1729,7 +1967,8 @@ mod tests {
             .set_flaps_handle_position(4)
             .run_waiting_for(Duration::from_secs(50));
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
     }
 
     #[test]
@@ -1744,7 +1983,8 @@ mod tests {
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(50));
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf2S);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2S);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2S);
     }
 
     #[test]
@@ -1759,7 +1999,8 @@ mod tests {
             .set_flaps_handle_position(2)
             .run_waiting_for(Duration::from_secs(50));
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
     }
 
     #[test]
@@ -1775,8 +2016,10 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_waiting_for(Duration::from_secs(20));
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(25));
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(25));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(25));
     }
 
     #[test]
@@ -1789,18 +2032,24 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(24));
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(24));
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(24));
 
         test_bed = test_bed.set_indicated_airspeed(200.).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(24));
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
     }
 
     #[test]
@@ -1813,19 +2062,25 @@ mod tests {
             .set_flaps_handle_position(1)
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(24));
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf1F);
-        assert!(test_bed.read_slat_flap_system_status_word().get_bit(24));
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(24));
 
         test_bed = test_bed
             .set_angle_of_attack(Angle::new::<degree>(9.1))
             .run_one_tick();
 
-        assert_eq!(test_bed.get_flaps_conf(), FlapsConf::Conf0);
-        assert!(!test_bed.read_slat_flap_system_status_word().get_bit(24));
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
     }
 }

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
@@ -2005,7 +2005,7 @@ impl A380Hydraulic {
                 left_flaps,
                 right_flaps,
                 Volume::new::<cubic_inch>(0.32),
-                AngularVelocity::new::<radian_per_second>(0.047),
+                AngularVelocity::new::<radian_per_second>(0.046),
                 Angle::new::<degree>(218.912),
                 Ratio::new::<ratio>(140.),
                 Ratio::new::<ratio>(16.632),
@@ -2537,16 +2537,16 @@ impl A380Hydraulic {
 
         self.flap_system.update(
             context,
-            self.slats_flaps_complex.flap_demand(0),
-            self.slats_flaps_complex.flap_demand(1),
+            self.slats_flaps_complex.flap_command(0),
+            self.slats_flaps_complex.flap_command(1),
             self.green_circuit.system_section(),
             self.yellow_circuit.system_section(),
         );
 
         self.slat_system.update(
             context,
-            self.slats_flaps_complex.slat_demand(0),
-            self.slats_flaps_complex.slat_demand(1),
+            self.slats_flaps_complex.slat_command(0),
+            self.slats_flaps_complex.slat_command(1),
             self.green_circuit.system_section(),
             self.green_circuit.system_section(),
         );

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
@@ -65,8 +65,10 @@ use systems::{
 
 use std::fmt::Debug;
 
-mod flaps_computer;
-use flaps_computer::SlatFlapComplex;
+mod flaps_channel;
+mod sfcc;
+mod slats_channel;
+use sfcc::SlatFlapComplex;
 mod engine_pump_disc;
 use engine_pump_disc::EnginePumpDisconnectionClutch;
 pub mod autobrakes;

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
@@ -2535,16 +2535,16 @@ impl A380Hydraulic {
 
         self.flap_system.update(
             context,
-            self.slats_flaps_complex.flap_demand(),
-            self.slats_flaps_complex.flap_demand(),
+            self.slats_flaps_complex.flap_demand(0),
+            self.slats_flaps_complex.flap_demand(1),
             self.green_circuit.system_section(),
             self.yellow_circuit.system_section(),
         );
 
         self.slat_system.update(
             context,
-            self.slats_flaps_complex.slat_demand(),
-            self.slats_flaps_complex.slat_demand(),
+            self.slats_flaps_complex.slat_demand(0),
+            self.slats_flaps_complex.slat_demand(1),
             self.green_circuit.system_section(),
             self.green_circuit.system_section(),
         );

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/sfcc.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/sfcc.rs
@@ -1,6 +1,7 @@
 use crate::systems::shared::arinc429::{Arinc429Word, SignStatus};
 use systems::accept_iterable;
 use systems::hydraulic::command_sensor_unit::CSU;
+use systems::hydraulic::flap_slat::ChannelCommand;
 use systems::shared::{AdirsMeasurementOutputs, PositionPickoffUnit};
 
 use systems::simulation::{
@@ -74,11 +75,9 @@ impl SlatFlapControlComputer {
         } else if s == Angle::new::<degree>(284.65) && f == Angle::new::<degree>(218.91) {
             return FlapsConf::ConfFull;
         } else {
-            panic!(
-                "Invalid combination sfcc {} {}",
-                s.get::<degree>(),
-                f.get::<degree>()
-            );
+            // Should never reach this!
+            // Included to avoid panic.
+            return self.config;
         }
     }
 
@@ -252,6 +251,8 @@ pub struct SlatFlapComplex {
 }
 
 impl SlatFlapComplex {
+    const POSITIONING_THRESHOLD_ANGLE: f64 = 6.69;
+
     pub fn new(context: &mut InitContext) -> Self {
         Self {
             sfcc: [
@@ -282,6 +283,52 @@ impl SlatFlapComplex {
     // `idx` 1 is for SFCC2
     pub fn slat_demand(&self, idx: usize) -> Option<Angle> {
         self.sfcc[idx].signal_demanded_angle("SLATS")
+    }
+
+    fn is_approaching_requested_position(
+        &self,
+        synchro_angle_request: Angle,
+        synchro_angle_feedback: Angle,
+    ) -> bool {
+        let angle_threshold = Angle::new::<degree>(Self::POSITIONING_THRESHOLD_ANGLE);
+
+        (synchro_angle_request - synchro_angle_feedback).abs() < angle_threshold
+    }
+
+    pub fn flap_command(&self, idx: usize) -> Option<ChannelCommand> {
+        let flaps_in_target_position = self.is_approaching_requested_position(
+            self.sfcc[idx].flaps_channel.get_demanded_angle(),
+            self.sfcc[idx].flaps_channel.get_feedback_angle(),
+        );
+        if flaps_in_target_position {
+            return None;
+        } else {
+            if self.sfcc[idx].flaps_channel.get_demanded_angle()
+                > self.sfcc[idx].flaps_channel.get_feedback_angle()
+            {
+                return Some(ChannelCommand::Extend);
+            } else {
+                return Some(ChannelCommand::Retract);
+            }
+        }
+    }
+
+    pub fn slat_command(&self, idx: usize) -> Option<ChannelCommand> {
+        let slats_in_target_position = self.is_approaching_requested_position(
+            self.sfcc[idx].slats_channel.get_demanded_angle(),
+            self.sfcc[idx].slats_channel.get_feedback_angle(),
+        );
+        if slats_in_target_position {
+            return None;
+        } else {
+            if self.sfcc[idx].slats_channel.get_demanded_angle()
+                > self.sfcc[idx].slats_channel.get_feedback_angle()
+            {
+                return Some(ChannelCommand::Extend);
+            } else {
+                return Some(ChannelCommand::Retract);
+            }
+        }
     }
 }
 impl SimulationElement for SlatFlapComplex {
@@ -643,6 +690,17 @@ mod tests {
             self.query(|a| a.slat_gear.angle().get::<degree>())
         }
 
+        fn get_is_approaching_position(
+            &self,
+            demanded_angle: Angle,
+            feedback_angle: Angle,
+        ) -> bool {
+            self.query(|a| {
+                a.slat_flap_complex
+                    .is_approaching_requested_position(demanded_angle, feedback_angle)
+            })
+        }
+
         fn test_flap_conf(
             &mut self,
             handle_pos: u8,
@@ -707,6 +765,22 @@ mod tests {
 
         assert!(test_bed.contains_variable_with_name("SFCC_1_SLAT_FLAP_SYSTEM_STATUS_WORD"));
         assert!(test_bed.contains_variable_with_name("SFCC_2_SLAT_FLAP_SYSTEM_STATUS_WORD"));
+    }
+
+    #[test]
+    fn flaps_approaching_position() {
+        let test_bed = test_bed_with().run_one_tick();
+        let angle_tolerance = Angle::new::<degree>(6.69);
+        let demanded_angle = Angle::new::<degree>(251.);
+
+        let feedback_angle = Angle::new::<degree>(251.);
+        assert!(test_bed.get_is_approaching_position(demanded_angle, feedback_angle));
+
+        let feedback_angle = Angle::new::<degree>(250.9) - angle_tolerance;
+        assert!(!test_bed.get_is_approaching_position(demanded_angle, feedback_angle));
+
+        let feedback_angle = Angle::new::<degree>(251.1) + angle_tolerance;
+        assert!(!test_bed.get_is_approaching_position(demanded_angle, feedback_angle));
     }
 
     #[test]

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/sfcc.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/sfcc.rs
@@ -1,7 +1,7 @@
 use crate::systems::shared::arinc429::{Arinc429Word, SignStatus};
 use systems::accept_iterable;
-use systems::hydraulic::command_sensor_unit::{CSUMonitor, CSU};
-use systems::shared::PositionPickoffUnit;
+use systems::hydraulic::command_sensor_unit::CSU;
+use systems::shared::{AdirsMeasurementOutputs, PositionPickoffUnit};
 
 use systems::simulation::{
     InitContext, SimulationElement, SimulationElementVisitor, SimulatorWriter, UpdateContext,
@@ -9,7 +9,10 @@ use systems::simulation::{
 };
 
 use std::panic;
-use uom::si::{angle::degree, f64::*, velocity::knot};
+use uom::si::{angle::degree, f64::*};
+
+use super::flaps_channel::FlapsChannel;
+use super::slats_channel::SlatsChannel;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 enum FlapsConf {
@@ -17,121 +20,65 @@ enum FlapsConf {
     Conf1,
     Conf1F,
     Conf2,
+    Conf2S,
     Conf3,
     ConfFull,
 }
 
 struct SlatFlapControlComputer {
-    flaps_conf_index_id: VariableIdentifier,
+    config_index_id: VariableIdentifier,
     slat_flap_system_status_word_id: VariableIdentifier,
     slat_flap_actual_position_word_id: VariableIdentifier,
-    slat_actual_position_word_id: VariableIdentifier,
-    flap_actual_position_word_id: VariableIdentifier,
-    fap_ids: [VariableIdentifier; 7],
 
-    flaps_demanded_angle: Angle,
-    slats_demanded_angle: Angle,
-    flaps_feedback_angle: Angle,
-    slats_feedback_angle: Angle,
-    flaps_conf: FlapsConf,
-    fap: [bool; 7],
-    csu_monitor: CSUMonitor,
+    flaps_channel: FlapsChannel,
+    slats_channel: SlatsChannel,
+
+    config: FlapsConf,
 }
 
 impl SlatFlapControlComputer {
     const EQUAL_ANGLE_DELTA_DEGREE: f64 = 0.177;
-    const HANDLE_ONE_CONF_AIRSPEED_THRESHOLD_KNOTS: f64 = 100.;
-    const CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS: f64 = 210.;
 
     fn new(context: &mut InitContext, num: u8) -> Self {
         Self {
-            flaps_conf_index_id: context.get_identifier("FLAPS_CONF_INDEX".to_owned()),
+            config_index_id: context.get_identifier("FLAPS_CONF_INDEX".to_owned()),
             slat_flap_system_status_word_id: context
                 .get_identifier(format!("SFCC_{num}_SLAT_FLAP_SYSTEM_STATUS_WORD")),
             slat_flap_actual_position_word_id: context
                 .get_identifier(format!("SFCC_{num}_SLAT_FLAP_ACTUAL_POSITION_WORD")),
-            slat_actual_position_word_id: context
-                .get_identifier(format!("SFCC_{num}_SLAT_ACTUAL_POSITION_WORD")),
-            flap_actual_position_word_id: context
-                .get_identifier(format!("SFCC_{num}_FLAP_ACTUAL_POSITION_WORD")),
-            fap_ids: [
-                context.get_identifier(format!("SFCC_{num}_FAP_1")),
-                context.get_identifier(format!("SFCC_{num}_FAP_2")),
-                context.get_identifier(format!("SFCC_{num}_FAP_3")),
-                context.get_identifier(format!("SFCC_{num}_FAP_4")),
-                context.get_identifier(format!("SFCC_{num}_FAP_5")),
-                context.get_identifier(format!("SFCC_{num}_FAP_6")),
-                context.get_identifier(format!("SFCC_{num}_FAP_7")),
-            ],
 
-            flaps_demanded_angle: Angle::new::<degree>(0.),
-            slats_demanded_angle: Angle::new::<degree>(0.),
-            flaps_feedback_angle: Angle::new::<degree>(0.),
-            slats_feedback_angle: Angle::new::<degree>(0.),
-            flaps_conf: FlapsConf::Conf0,
+            flaps_channel: FlapsChannel::new(context, num),
+            slats_channel: SlatsChannel::new(context, num),
 
-            // Set to false to match power-off state
-            fap: [false; 7],
-            csu_monitor: CSUMonitor::new(context),
+            config: FlapsConf::Conf0,
         }
     }
 
-    // Returns a flap demanded angle in FPPU reference degree (feedback sensor)
-    fn demanded_flaps_fppu_angle_from_conf(flap_conf: FlapsConf) -> Angle {
-        match flap_conf {
-            FlapsConf::Conf0 => Angle::new::<degree>(0.),
-            FlapsConf::Conf1 => Angle::new::<degree>(0.),
-            FlapsConf::Conf1F => Angle::new::<degree>(120.22),
-            FlapsConf::Conf2 => Angle::new::<degree>(145.51),
-            FlapsConf::Conf3 => Angle::new::<degree>(168.35),
-            FlapsConf::ConfFull => Angle::new::<degree>(251.97),
-        }
-    }
+    // Interpolated from A320 FPPU references, assuming we're using the A320 FPPU
+    pub fn calculate_config(&self) -> FlapsConf {
+        let s = self.slats_channel.get_demanded_angle();
+        let f = self.flaps_channel.get_demanded_angle();
 
-    // Returns a slat demanded angle in FPPU reference degree (feedback sensor)
-    fn demanded_slats_fppu_angle_from_conf(flap_conf: FlapsConf) -> Angle {
-        match flap_conf {
-            FlapsConf::Conf0 => Angle::new::<degree>(0.),
-            FlapsConf::Conf1 => Angle::new::<degree>(222.27),
-            FlapsConf::Conf1F => Angle::new::<degree>(222.27),
-            FlapsConf::Conf2 => Angle::new::<degree>(272.27),
-            FlapsConf::Conf3 => Angle::new::<degree>(272.27),
-            FlapsConf::ConfFull => Angle::new::<degree>(334.16),
-        }
-    }
-
-    fn generate_configuration(&self, context: &UpdateContext) -> FlapsConf {
-        // Ignored `CSU::OutOfDetent` and `CSU::Fault` positions due to simplified SFCC.
-        match (
-            self.csu_monitor.get_previous_detent(),
-            self.csu_monitor.get_current_detent(),
-        ) {
-            (CSU::Conf0, CSU::Conf1)
-                if context.indicated_airspeed().get::<knot>()
-                    <= Self::HANDLE_ONE_CONF_AIRSPEED_THRESHOLD_KNOTS =>
-            {
-                FlapsConf::Conf1F
-            }
-            (CSU::Conf0, CSU::Conf1) => FlapsConf::Conf1,
-            (CSU::Conf1, CSU::Conf1)
-                if context.indicated_airspeed().get::<knot>()
-                    > Self::CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS =>
-            {
-                FlapsConf::Conf1
-            }
-            (CSU::Conf1, CSU::Conf1) => self.flaps_conf,
-            (_, CSU::Conf1)
-                if context.indicated_airspeed().get::<knot>()
-                    <= Self::CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS =>
-            {
-                FlapsConf::Conf1F
-            }
-            (_, CSU::Conf1) => FlapsConf::Conf1,
-            (_, CSU::Conf0) => FlapsConf::Conf0,
-            (from, CSU::Conf2) if from != CSU::Conf2 => FlapsConf::Conf2,
-            (from, CSU::Conf3) if from != CSU::Conf3 => FlapsConf::Conf3,
-            (from, CSU::ConfFull) if from != CSU::ConfFull => FlapsConf::ConfFull,
-            (_, _) => self.flaps_conf,
+        if s == Angle::default() && f == Angle::default() {
+            return FlapsConf::Conf0;
+        } else if s == Angle::new::<degree>(247.27) && f == Angle::default() {
+            return FlapsConf::Conf1;
+        } else if s == Angle::new::<degree>(247.27) && f == Angle::new::<degree>(108.28) {
+            return FlapsConf::Conf1F;
+        } else if s == Angle::new::<degree>(247.27) && f == Angle::new::<degree>(154.65) {
+            return FlapsConf::Conf2;
+        } else if s == Angle::new::<degree>(284.65) && f == Angle::new::<degree>(154.65) {
+            return FlapsConf::Conf2S;
+        } else if s == Angle::new::<degree>(284.65) && f == Angle::new::<degree>(194.03) {
+            return FlapsConf::Conf3;
+        } else if s == Angle::new::<degree>(284.65) && f == Angle::new::<degree>(218.91) {
+            return FlapsConf::ConfFull;
+        } else {
+            panic!(
+                "Invalid combination sfcc {} {}",
+                s.get::<degree>(),
+                f.get::<degree>()
+            );
         }
     }
 
@@ -142,31 +89,14 @@ impl SlatFlapControlComputer {
     pub fn update(
         &mut self,
         context: &UpdateContext,
+        adirs: &impl AdirsMeasurementOutputs,
         flaps_feedback: &impl PositionPickoffUnit,
         slats_feedback: &impl PositionPickoffUnit,
     ) {
-        self.csu_monitor.update(context);
+        self.flaps_channel.update(context, flaps_feedback, adirs);
+        self.slats_channel.update(context, slats_feedback, adirs);
 
-        self.flaps_conf = self.generate_configuration(context);
-
-        self.flaps_demanded_angle = Self::demanded_flaps_fppu_angle_from_conf(self.flaps_conf);
-        self.slats_demanded_angle = Self::demanded_slats_fppu_angle_from_conf(self.flaps_conf);
-        self.flaps_feedback_angle = flaps_feedback.angle();
-        self.slats_feedback_angle = slats_feedback.angle();
-
-        self.fap_update();
-    }
-
-    fn fap_update(&mut self) {
-        let fppu_angle = self.flaps_feedback_angle.get::<degree>();
-
-        self.fap[0] = fppu_angle > 247.8 && fppu_angle < 254.0;
-        self.fap[1] = fppu_angle > 114.6 && fppu_angle < 254.0;
-        self.fap[2] = fppu_angle > 163.7 && fppu_angle < 254.0;
-        self.fap[3] = self.csu_monitor.get_current_detent() == CSU::Conf0;
-        self.fap[4] = fppu_angle > 163.7 && fppu_angle < 254.0;
-        self.fap[5] = fppu_angle > 247.8 && fppu_angle < 254.0;
-        self.fap[6] = fppu_angle > 114.6 && fppu_angle < 254.0;
+        self.config = self.calculate_config();
     }
 
     fn slat_flap_system_status_word(&self) -> Arinc429Word<u32> {
@@ -178,19 +108,16 @@ impl SlatFlapControlComputer {
         word.set_bit(14, false);
         word.set_bit(15, false);
         word.set_bit(16, false);
-        word.set_bit(17, self.flaps_conf == FlapsConf::Conf0);
-        word.set_bit(
-            18,
-            self.flaps_conf == FlapsConf::Conf1 || self.flaps_conf == FlapsConf::Conf1F,
-        );
-        word.set_bit(19, self.flaps_conf == FlapsConf::Conf2);
-        word.set_bit(20, self.flaps_conf == FlapsConf::Conf3);
-        word.set_bit(21, self.flaps_conf == FlapsConf::ConfFull);
-        word.set_bit(22, false);
+        word.set_bit(17, self.flaps_channel.get_handle_detent() == CSU::Conf0);
+        word.set_bit(18, self.flaps_channel.get_handle_detent() == CSU::Conf1);
+        word.set_bit(19, self.flaps_channel.get_handle_detent() == CSU::Conf2);
+        word.set_bit(20, self.flaps_channel.get_handle_detent() == CSU::Conf3);
+        word.set_bit(21, self.flaps_channel.get_handle_detent() == CSU::ConfFull);
+        word.set_bit(22, self.flaps_channel.get_flap_load_relief());
         word.set_bit(23, false);
-        word.set_bit(24, false);
-        word.set_bit(25, false);
-        word.set_bit(26, self.flaps_conf == FlapsConf::Conf1);
+        word.set_bit(24, self.slats_channel.get_alpha_speed_lock());
+        word.set_bit(25, self.slats_channel.get_cruise_baulk());
+        word.set_bit(26, self.config == FlapsConf::Conf1);
         word.set_bit(27, false);
         word.set_bit(28, true);
         word.set_bit(29, true);
@@ -202,53 +129,62 @@ impl SlatFlapControlComputer {
         let mut word = Arinc429Word::new(0, SignStatus::NormalOperation);
 
         word.set_bit(11, true);
+        // Slats retracted
         word.set_bit(
             12,
-            self.slats_feedback_angle > Angle::new::<degree>(-5.0)
-                && self.slats_feedback_angle < Angle::new::<degree>(6.2),
+            self.slats_channel.get_feedback_angle() > Angle::new::<degree>(-5.0)
+                && self.slats_channel.get_feedback_angle() < Angle::new::<degree>(6.2),
         );
+        // Slats >= 19°
         word.set_bit(
             13,
-            self.slats_feedback_angle > Angle::new::<degree>(210.4)
-                && self.slats_feedback_angle < Angle::new::<degree>(337.),
+            self.slats_channel.get_feedback_angle() > Angle::new::<degree>(234.7)
+                && self.slats_channel.get_feedback_angle() < Angle::new::<degree>(337.),
         );
+        // Slats >= 22°
         word.set_bit(
             14,
-            self.slats_feedback_angle > Angle::new::<degree>(321.8)
-                && self.slats_feedback_angle < Angle::new::<degree>(337.),
+            self.slats_channel.get_feedback_angle() > Angle::new::<degree>(272.2)
+                && self.slats_channel.get_feedback_angle() < Angle::new::<degree>(337.),
         );
+        // Slats extended 23°
         word.set_bit(
             15,
-            self.slats_feedback_angle > Angle::new::<degree>(327.4)
-                && self.slats_feedback_angle < Angle::new::<degree>(337.),
+            self.slats_channel.get_feedback_angle() > Angle::new::<degree>(280.)
+                && self.slats_channel.get_feedback_angle() < Angle::new::<degree>(337.),
         );
         word.set_bit(16, false);
         word.set_bit(17, false);
         word.set_bit(18, true);
+        // Flaps retracted
         word.set_bit(
             19,
-            self.flaps_feedback_angle > Angle::new::<degree>(-5.0)
-                && self.flaps_feedback_angle < Angle::new::<degree>(2.5),
+            self.flaps_channel.get_feedback_angle() > Angle::new::<degree>(-5.0)
+                && self.flaps_channel.get_feedback_angle() < Angle::new::<degree>(2.5),
         );
+        // Flaps >= 7°
         word.set_bit(
             20,
-            self.flaps_feedback_angle > Angle::new::<degree>(140.7)
-                && self.flaps_feedback_angle < Angle::new::<degree>(254.),
+            self.flaps_channel.get_feedback_angle() > Angle::new::<degree>(102.1)
+                && self.flaps_channel.get_feedback_angle() < Angle::new::<degree>(254.),
         );
+        // Flaps >= 16°
         word.set_bit(
             21,
-            self.flaps_feedback_angle > Angle::new::<degree>(163.7)
-                && self.flaps_feedback_angle < Angle::new::<degree>(254.),
+            self.flaps_channel.get_feedback_angle() > Angle::new::<degree>(150.0)
+                && self.flaps_channel.get_feedback_angle() < Angle::new::<degree>(254.),
         );
+        // Flaps >= 25°
         word.set_bit(
             22,
-            self.flaps_feedback_angle > Angle::new::<degree>(247.8)
-                && self.flaps_feedback_angle < Angle::new::<degree>(254.),
+            self.flaps_channel.get_feedback_angle() > Angle::new::<degree>(189.8)
+                && self.flaps_channel.get_feedback_angle() < Angle::new::<degree>(254.),
         );
+        // Flaps extended 32°
         word.set_bit(
             23,
-            self.flaps_feedback_angle > Angle::new::<degree>(250.)
-                && self.flaps_feedback_angle < Angle::new::<degree>(254.),
+            self.flaps_channel.get_feedback_angle() > Angle::new::<degree>(218.)
+                && self.flaps_channel.get_feedback_angle() < Angle::new::<degree>(254.),
         );
         word.set_bit(24, false);
         word.set_bit(25, false);
@@ -258,20 +194,6 @@ impl SlatFlapControlComputer {
         word.set_bit(29, false);
 
         word
-    }
-
-    fn slat_actual_position_word(&self) -> Arinc429Word<f64> {
-        Arinc429Word::new(
-            self.slats_feedback_angle.get::<degree>(),
-            SignStatus::NormalOperation,
-        )
-    }
-
-    fn flap_actual_position_word(&self) -> Arinc429Word<f64> {
-        Arinc429Word::new(
-            self.flaps_feedback_angle.get::<degree>(),
-            SignStatus::NormalOperation,
-        )
     }
 }
 
@@ -284,19 +206,19 @@ impl SlatFlapLane for SlatFlapControlComputer {
         match surface_type {
             "FLAPS"
                 if Self::surface_movement_required(
-                    self.flaps_demanded_angle,
-                    self.flaps_feedback_angle,
+                    self.flaps_channel.get_demanded_angle(),
+                    self.flaps_channel.get_feedback_angle(),
                 ) =>
             {
-                Some(self.flaps_demanded_angle)
+                Some(self.flaps_channel.get_demanded_angle())
             }
             "SLATS"
                 if Self::surface_movement_required(
-                    self.slats_demanded_angle,
-                    self.slats_feedback_angle,
+                    self.slats_channel.get_demanded_angle(),
+                    self.slats_channel.get_feedback_angle(),
                 ) =>
             {
-                Some(self.slats_demanded_angle)
+                Some(self.slats_channel.get_demanded_angle())
             }
             "FLAPS" | "SLATS" => None,
             _ => panic!("Not a valid slat/flap surface"),
@@ -306,16 +228,13 @@ impl SlatFlapLane for SlatFlapControlComputer {
 
 impl SimulationElement for SlatFlapControlComputer {
     fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
-        self.csu_monitor.accept(visitor);
+        self.flaps_channel.accept(visitor);
+        self.slats_channel.accept(visitor);
         visitor.visit(self);
     }
 
     fn write(&self, writer: &mut SimulatorWriter) {
-        for (id, fap) in self.fap_ids.iter().zip(self.fap) {
-            writer.write(id, fap);
-        }
-
-        writer.write(&self.flaps_conf_index_id, self.flaps_conf as u8);
+        writer.write(&self.config_index_id, self.config as u8);
 
         writer.write(
             &self.slat_flap_system_status_word_id,
@@ -324,14 +243,6 @@ impl SimulationElement for SlatFlapControlComputer {
         writer.write(
             &self.slat_flap_actual_position_word_id,
             self.slat_flap_actual_position_word(),
-        );
-        writer.write(
-            &self.slat_actual_position_word_id,
-            self.slat_actual_position_word(),
-        );
-        writer.write(
-            &self.flap_actual_position_word_id,
-            self.flap_actual_position_word(),
         );
     }
 }
@@ -353,11 +264,12 @@ impl SlatFlapComplex {
     pub fn update(
         &mut self,
         context: &UpdateContext,
+        adirs: &impl AdirsMeasurementOutputs,
         flaps_feedback: &impl PositionPickoffUnit,
         slats_feedback: &impl PositionPickoffUnit,
     ) {
-        self.sfcc[0].update(context, flaps_feedback, slats_feedback);
-        self.sfcc[1].update(context, flaps_feedback, slats_feedback);
+        self.sfcc[0].update(context, adirs, flaps_feedback, slats_feedback);
+        self.sfcc[1].update(context, adirs, flaps_feedback, slats_feedback);
     }
 
     // `idx` 0 is for SFCC1
@@ -484,7 +396,7 @@ mod tests {
         }
     }
 
-    struct A320FlapsTestAircraft {
+    struct A380FlapsTestAircraft {
         green_hydraulic_pressure_id: VariableIdentifier,
         blue_hydraulic_pressure_id: VariableIdentifier,
         yellow_hydraulic_pressure_id: VariableIdentifier,
@@ -496,9 +408,11 @@ mod tests {
         green_pressure: Pressure,
         blue_pressure: Pressure,
         yellow_pressure: Pressure,
+
+        adirs: TestAdirs,
     }
 
-    impl A320FlapsTestAircraft {
+    impl A380FlapsTestAircraft {
         fn new(context: &mut InitContext) -> Self {
             Self {
                 green_hydraulic_pressure_id: context
@@ -525,14 +439,20 @@ mod tests {
                 green_pressure: Pressure::new::<psi>(0.),
                 blue_pressure: Pressure::new::<psi>(0.),
                 yellow_pressure: Pressure::new::<psi>(0.),
+
+                adirs: TestAdirs::new(),
             }
+        }
+
+        fn set_angle_of_attack(&mut self, v: Angle) {
+            self.adirs.set_angle_of_attack(v);
         }
     }
 
-    impl Aircraft for A320FlapsTestAircraft {
+    impl Aircraft for A380FlapsTestAircraft {
         fn update_after_power_distribution(&mut self, context: &UpdateContext) {
             self.slat_flap_complex
-                .update(context, &self.flap_gear, &self.slat_gear);
+                .update(context, &self.adirs, &self.flap_gear, &self.slat_gear);
             self.flap_gear.update(
                 context,
                 &self.slat_flap_complex.sfcc[0],
@@ -548,7 +468,7 @@ mod tests {
         }
     }
 
-    impl SimulationElement for A320FlapsTestAircraft {
+    impl SimulationElement for A380FlapsTestAircraft {
         fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
             self.slat_flap_complex.accept(visitor);
             self.flap_gear.accept(visitor);
@@ -563,16 +483,75 @@ mod tests {
         }
     }
 
-    struct A320FlapsTestBed {
-        test_bed: SimulationTestBed<A320FlapsTestAircraft>,
+    struct TestAdirs {
+        is_aligned: bool,
+        latitude: Arinc429Word<Angle>,
+        longitude: Arinc429Word<Angle>,
+        heading: Arinc429Word<Angle>,
+        vertical_speed: Arinc429Word<Velocity>,
+        altitude: Arinc429Word<Length>,
+        angle_of_attack: Arinc429Word<Angle>,
+    }
+    impl TestAdirs {
+        fn new() -> Self {
+            Self {
+                is_aligned: false,
+                latitude: Arinc429Word::new(Angle::default(), SignStatus::FailureWarning),
+                longitude: Arinc429Word::new(Angle::default(), SignStatus::FailureWarning),
+                heading: Arinc429Word::new(Angle::default(), SignStatus::FailureWarning),
+                vertical_speed: Arinc429Word::new(Velocity::default(), SignStatus::FailureWarning),
+                altitude: Arinc429Word::new(Length::default(), SignStatus::FailureWarning),
+                angle_of_attack: Arinc429Word::new(Angle::default(), SignStatus::NormalOperation),
+            }
+        }
+
+        fn set_angle_of_attack(&mut self, v: Angle) {
+            self.angle_of_attack = Arinc429Word::new(v, SignStatus::NormalOperation);
+        }
+    }
+    impl AdirsMeasurementOutputs for TestAdirs {
+        fn is_fully_aligned(&self, _adiru_number: usize) -> bool {
+            self.is_aligned
+        }
+
+        fn latitude(&self, _adiru_number: usize) -> Arinc429Word<Angle> {
+            self.latitude
+        }
+
+        fn longitude(&self, _adiru_number: usize) -> Arinc429Word<Angle> {
+            self.longitude
+        }
+
+        fn heading(&self, _adiru_number: usize) -> Arinc429Word<Angle> {
+            self.heading
+        }
+
+        fn true_heading(&self, _adiru_number: usize) -> Arinc429Word<Angle> {
+            self.heading
+        }
+
+        fn vertical_speed(&self, _adiru_number: usize) -> Arinc429Word<Velocity> {
+            self.vertical_speed
+        }
+
+        fn altitude(&self, _adiru_number: usize) -> Arinc429Word<Length> {
+            self.altitude
+        }
+
+        fn angle_of_attack(&self, _adiru_number: usize) -> Arinc429Word<Angle> {
+            self.angle_of_attack
+        }
+    }
+    struct A380FlapsTestBed {
+        test_bed: SimulationTestBed<A380FlapsTestAircraft>,
     }
 
-    impl A320FlapsTestBed {
+    impl A380FlapsTestBed {
         const HYD_TIME_STEP_MILLIS: u64 = 33;
 
         fn new() -> Self {
             Self {
-                test_bed: SimulationTestBed::new(A320FlapsTestAircraft::new),
+                test_bed: SimulationTestBed::new(A380FlapsTestAircraft::new),
             }
         }
 
@@ -604,36 +583,18 @@ mod tests {
             self.read_by_name(&format!("SFCC_{num}_SLAT_FLAP_ACTUAL_POSITION_WORD"))
         }
 
-        fn read_sfcc_fap_1_word(&mut self, num: u8) -> bool {
-            self.read_by_name(&format!("SFCC_{num}_FAP_1"))
-        }
-
-        fn read_sfcc_fap_2_word(&mut self, num: u8) -> bool {
-            self.read_by_name(&format!("SFCC_{num}_FAP_2"))
-        }
-
-        fn read_sfcc_fap_3_word(&mut self, num: u8) -> bool {
-            self.read_by_name(&format!("SFCC_{num}_FAP_3"))
-        }
-
-        fn read_sfcc_fap_4_word(&mut self, num: u8) -> bool {
-            self.read_by_name(&format!("SFCC_{num}_FAP_4"))
-        }
-
-        fn read_sfcc_fap_5_word(&mut self, num: u8) -> bool {
-            self.read_by_name(&format!("SFCC_{num}_FAP_5"))
-        }
-
-        fn read_sfcc_fap_6_word(&mut self, num: u8) -> bool {
-            self.read_by_name(&format!("SFCC_{num}_FAP_6"))
-        }
-
-        fn read_sfcc_fap_7_word(&mut self, num: u8) -> bool {
-            self.read_by_name(&format!("SFCC_{num}_FAP_7"))
-        }
-
         fn set_indicated_airspeed(mut self, indicated_airspeed: f64) -> Self {
             self.write_by_name("AIRSPEED INDICATED", indicated_airspeed);
+            self
+        }
+
+        fn set_angle_of_attack(mut self, angle_of_attack: Angle) -> Self {
+            self.command(|a| a.set_angle_of_attack(angle_of_attack));
+            self
+        }
+
+        fn set_on_ground(mut self, on_ground: bool) -> Self {
+            self.write_by_name("SIM ON GROUND", on_ground);
             self
         }
 
@@ -655,7 +616,8 @@ mod tests {
         fn get_flaps_demanded_angle(&self, idx: usize) -> f64 {
             self.query(|a| {
                 a.slat_flap_complex.sfcc[idx]
-                    .flaps_demanded_angle
+                    .flaps_channel
+                    .get_demanded_angle()
                     .get::<degree>()
             })
         }
@@ -663,13 +625,14 @@ mod tests {
         fn get_slats_demanded_angle(&self, idx: usize) -> f64 {
             self.query(|a| {
                 a.slat_flap_complex.sfcc[idx]
-                    .slats_demanded_angle
+                    .slats_channel
+                    .get_demanded_angle()
                     .get::<degree>()
             })
         }
 
         fn get_flaps_conf(&self, num: usize) -> FlapsConf {
-            self.query(|a| a.slat_flap_complex.sfcc[num].flaps_conf)
+            self.query(|a| a.slat_flap_complex.sfcc[num].config)
         }
 
         fn get_flaps_fppu_feedback(&self) -> f64 {
@@ -678,34 +641,6 @@ mod tests {
 
         fn get_slats_fppu_feedback(&self) -> f64 {
             self.query(|a| a.slat_gear.angle().get::<degree>())
-        }
-
-        fn get_fap_1(&self, idx: usize) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[0])
-        }
-
-        fn get_fap_2(&self, idx: usize) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[1])
-        }
-
-        fn get_fap_3(&self, idx: usize) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[2])
-        }
-
-        fn get_fap_4(&self, idx: usize) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[3])
-        }
-
-        fn get_fap_5(&self, idx: usize) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[4])
-        }
-
-        fn get_fap_6(&self, idx: usize) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[5])
-        }
-
-        fn get_fap_7(&self, idx: usize) -> bool {
-            self.query(|a| a.slat_flap_complex.sfcc[idx].fap[6])
         }
 
         fn test_flap_conf(
@@ -718,31 +653,30 @@ mod tests {
         ) {
             assert_eq!(self.read_flaps_handle_position(), handle_pos);
             assert!((self.get_flaps_demanded_angle(0) - flaps_demanded_angle).abs() < angle_delta);
-            assert!((self.get_slats_demanded_angle(0) - slats_demanded_angle).abs() < angle_delta);
-            assert_eq!(self.get_flaps_conf(0), conf);
-
             assert!((self.get_flaps_demanded_angle(1) - flaps_demanded_angle).abs() < angle_delta);
+            assert!((self.get_slats_demanded_angle(0) - slats_demanded_angle).abs() < angle_delta);
             assert!((self.get_slats_demanded_angle(1) - slats_demanded_angle).abs() < angle_delta);
+            assert_eq!(self.get_flaps_conf(0), conf);
             assert_eq!(self.get_flaps_conf(1), conf);
         }
     }
-    impl TestBed for A320FlapsTestBed {
-        type Aircraft = A320FlapsTestAircraft;
+    impl TestBed for A380FlapsTestBed {
+        type Aircraft = A380FlapsTestAircraft;
 
-        fn test_bed(&self) -> &SimulationTestBed<A320FlapsTestAircraft> {
+        fn test_bed(&self) -> &SimulationTestBed<A380FlapsTestAircraft> {
             &self.test_bed
         }
 
-        fn test_bed_mut(&mut self) -> &mut SimulationTestBed<A320FlapsTestAircraft> {
+        fn test_bed_mut(&mut self) -> &mut SimulationTestBed<A380FlapsTestAircraft> {
             &mut self.test_bed
         }
     }
 
-    fn test_bed() -> A320FlapsTestBed {
-        A320FlapsTestBed::new()
+    fn test_bed() -> A380FlapsTestBed {
+        A380FlapsTestBed::new()
     }
 
-    fn test_bed_with() -> A320FlapsTestBed {
+    fn test_bed_with() -> A380FlapsTestBed {
         test_bed()
     }
 
@@ -762,22 +696,6 @@ mod tests {
 
         assert!(test_bed.contains_variable_with_name("FLAPS_CONF_INDEX"));
 
-        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_1"));
-        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_2"));
-        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_3"));
-        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_4"));
-        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_5"));
-        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_6"));
-        assert!(test_bed.contains_variable_with_name("SFCC_1_FAP_7"));
-
-        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_1"));
-        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_2"));
-        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_3"));
-        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_4"));
-        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_5"));
-        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_6"));
-        assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_7"));
-
         assert!(test_bed.contains_variable_with_name("SFCC_1_FLAP_ACTUAL_POSITION_WORD"));
         assert!(test_bed.contains_variable_with_name("SFCC_2_FLAP_ACTUAL_POSITION_WORD"));
 
@@ -792,199 +710,12 @@ mod tests {
     }
 
     #[test]
-    fn sfcc_faps() {
-        let mut test_bed = test_bed_with()
-            .set_green_hyd_pressure()
-            .set_yellow_hyd_pressure()
-            .set_blue_hyd_pressure()
-            .set_indicated_airspeed(0.)
-            .set_flaps_handle_position(0)
-            .run_one_tick();
-
-        assert!(!test_bed.get_fap_1(0));
-        assert!(!test_bed.get_fap_2(0));
-        assert!(!test_bed.get_fap_3(0));
-        assert!(test_bed.get_fap_4(0));
-        assert!(!test_bed.get_fap_5(0));
-        assert!(!test_bed.get_fap_6(0));
-        assert!(!test_bed.get_fap_7(0));
-
-        assert!(!test_bed.get_fap_1(1));
-        assert!(!test_bed.get_fap_2(1));
-        assert!(!test_bed.get_fap_3(1));
-        assert!(test_bed.get_fap_4(1));
-        assert!(!test_bed.get_fap_5(1));
-        assert!(!test_bed.get_fap_6(1));
-        assert!(!test_bed.get_fap_7(1));
-
-        assert!(!test_bed.read_sfcc_fap_1_word(1));
-        assert!(!test_bed.read_sfcc_fap_2_word(1));
-        assert!(!test_bed.read_sfcc_fap_3_word(1));
-        assert!(test_bed.read_sfcc_fap_4_word(1));
-        assert!(!test_bed.read_sfcc_fap_5_word(1));
-        assert!(!test_bed.read_sfcc_fap_6_word(1));
-        assert!(!test_bed.read_sfcc_fap_7_word(1));
-
-        assert!(!test_bed.read_sfcc_fap_1_word(2));
-        assert!(!test_bed.read_sfcc_fap_2_word(2));
-        assert!(!test_bed.read_sfcc_fap_3_word(2));
-        assert!(test_bed.read_sfcc_fap_4_word(2));
-        assert!(!test_bed.read_sfcc_fap_5_word(2));
-        assert!(!test_bed.read_sfcc_fap_6_word(2));
-        assert!(!test_bed.read_sfcc_fap_7_word(2));
-
-        test_bed = test_bed
-            .set_flaps_handle_position(1)
-            .run_waiting_for(Duration::from_secs(60));
-
-        assert!(!test_bed.get_fap_1(0));
-        assert!(test_bed.get_fap_2(0));
-        assert!(!test_bed.get_fap_3(0));
-        assert!(!test_bed.get_fap_4(0));
-        assert!(!test_bed.get_fap_5(0));
-        assert!(!test_bed.get_fap_6(0));
-        assert!(test_bed.get_fap_7(0));
-
-        assert!(!test_bed.get_fap_1(1));
-        assert!(test_bed.get_fap_2(1));
-        assert!(!test_bed.get_fap_3(1));
-        assert!(!test_bed.get_fap_4(1));
-        assert!(!test_bed.get_fap_5(1));
-        assert!(!test_bed.get_fap_6(1));
-        assert!(test_bed.get_fap_7(1));
-
-        assert!(!test_bed.read_sfcc_fap_1_word(1));
-        assert!(test_bed.read_sfcc_fap_2_word(1));
-        assert!(!test_bed.read_sfcc_fap_3_word(1));
-        assert!(!test_bed.read_sfcc_fap_4_word(1));
-        assert!(!test_bed.read_sfcc_fap_5_word(1));
-        assert!(!test_bed.read_sfcc_fap_6_word(1));
-        assert!(test_bed.read_sfcc_fap_7_word(1));
-
-        assert!(!test_bed.read_sfcc_fap_1_word(2));
-        assert!(test_bed.read_sfcc_fap_2_word(2));
-        assert!(!test_bed.read_sfcc_fap_3_word(2));
-        assert!(!test_bed.read_sfcc_fap_4_word(2));
-        assert!(!test_bed.read_sfcc_fap_5_word(2));
-        assert!(!test_bed.read_sfcc_fap_6_word(2));
-        assert!(test_bed.read_sfcc_fap_7_word(2));
-
-        test_bed = test_bed
-            .set_flaps_handle_position(2)
-            .run_waiting_for(Duration::from_secs(60));
-
-        assert!(!test_bed.get_fap_1(0));
-        assert!(test_bed.get_fap_2(0));
-        assert!(!test_bed.get_fap_3(0));
-        assert!(!test_bed.get_fap_4(0));
-        assert!(!test_bed.get_fap_5(0));
-        assert!(!test_bed.get_fap_6(0));
-        assert!(test_bed.get_fap_7(0));
-
-        assert!(!test_bed.get_fap_1(1));
-        assert!(test_bed.get_fap_2(1));
-        assert!(!test_bed.get_fap_3(1));
-        assert!(!test_bed.get_fap_4(1));
-        assert!(!test_bed.get_fap_5(1));
-        assert!(!test_bed.get_fap_6(1));
-        assert!(test_bed.get_fap_7(1));
-
-        assert!(!test_bed.read_sfcc_fap_1_word(1));
-        assert!(test_bed.read_sfcc_fap_2_word(1));
-        assert!(!test_bed.read_sfcc_fap_3_word(1));
-        assert!(!test_bed.read_sfcc_fap_4_word(1));
-        assert!(!test_bed.read_sfcc_fap_5_word(1));
-        assert!(!test_bed.read_sfcc_fap_6_word(1));
-        assert!(test_bed.read_sfcc_fap_7_word(1));
-
-        assert!(!test_bed.read_sfcc_fap_1_word(2));
-        assert!(test_bed.read_sfcc_fap_2_word(2));
-        assert!(!test_bed.read_sfcc_fap_3_word(2));
-        assert!(!test_bed.read_sfcc_fap_4_word(2));
-        assert!(!test_bed.read_sfcc_fap_5_word(2));
-        assert!(!test_bed.read_sfcc_fap_6_word(2));
-        assert!(test_bed.read_sfcc_fap_7_word(2));
-
-        test_bed = test_bed
-            .set_flaps_handle_position(3)
-            .run_waiting_for(Duration::from_secs(60));
-
-        assert!(!test_bed.get_fap_1(0));
-        assert!(test_bed.get_fap_2(0));
-        assert!(test_bed.get_fap_3(0));
-        assert!(!test_bed.get_fap_4(0));
-        assert!(test_bed.get_fap_5(0));
-        assert!(!test_bed.get_fap_6(0));
-        assert!(test_bed.get_fap_7(0));
-
-        assert!(!test_bed.get_fap_1(1));
-        assert!(test_bed.get_fap_2(1));
-        assert!(test_bed.get_fap_3(1));
-        assert!(!test_bed.get_fap_4(1));
-        assert!(test_bed.get_fap_5(1));
-        assert!(!test_bed.get_fap_6(1));
-        assert!(test_bed.get_fap_7(1));
-
-        assert!(!test_bed.read_sfcc_fap_1_word(1));
-        assert!(test_bed.read_sfcc_fap_2_word(1));
-        assert!(test_bed.read_sfcc_fap_3_word(1));
-        assert!(!test_bed.read_sfcc_fap_4_word(1));
-        assert!(test_bed.read_sfcc_fap_5_word(1));
-        assert!(!test_bed.read_sfcc_fap_6_word(1));
-        assert!(test_bed.read_sfcc_fap_7_word(1));
-
-        assert!(!test_bed.read_sfcc_fap_1_word(2));
-        assert!(test_bed.read_sfcc_fap_2_word(2));
-        assert!(test_bed.read_sfcc_fap_3_word(2));
-        assert!(!test_bed.read_sfcc_fap_4_word(2));
-        assert!(test_bed.read_sfcc_fap_5_word(2));
-        assert!(!test_bed.read_sfcc_fap_6_word(2));
-        assert!(test_bed.read_sfcc_fap_7_word(2));
-
-        test_bed = test_bed
-            .set_flaps_handle_position(4)
-            .run_waiting_for(Duration::from_secs(60));
-
-        assert!(test_bed.get_fap_1(0));
-        assert!(test_bed.get_fap_2(0));
-        assert!(test_bed.get_fap_3(0));
-        assert!(!test_bed.get_fap_4(0));
-        assert!(test_bed.get_fap_5(0));
-        assert!(test_bed.get_fap_6(0));
-        assert!(test_bed.get_fap_7(0));
-
-        assert!(test_bed.get_fap_1(1));
-        assert!(test_bed.get_fap_2(1));
-        assert!(test_bed.get_fap_3(1));
-        assert!(!test_bed.get_fap_4(1));
-        assert!(test_bed.get_fap_5(1));
-        assert!(test_bed.get_fap_6(1));
-        assert!(test_bed.get_fap_7(1));
-
-        assert!(test_bed.read_sfcc_fap_1_word(1));
-        assert!(test_bed.read_sfcc_fap_2_word(1));
-        assert!(test_bed.read_sfcc_fap_3_word(1));
-        assert!(!test_bed.read_sfcc_fap_4_word(1));
-        assert!(test_bed.read_sfcc_fap_5_word(1));
-        assert!(test_bed.read_sfcc_fap_6_word(1));
-        assert!(test_bed.read_sfcc_fap_7_word(1));
-
-        assert!(test_bed.read_sfcc_fap_1_word(2));
-        assert!(test_bed.read_sfcc_fap_2_word(2));
-        assert!(test_bed.read_sfcc_fap_3_word(2));
-        assert!(!test_bed.read_sfcc_fap_4_word(2));
-        assert!(test_bed.read_sfcc_fap_5_word(2));
-        assert!(test_bed.read_sfcc_fap_6_word(2));
-        assert!(test_bed.read_sfcc_fap_7_word(2));
-    }
-
-    #[test]
     fn flaps_test_correct_bus_output_clean_config() {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_yellow_hyd_pressure()
             .set_blue_hyd_pressure()
-            .set_indicated_airspeed(0.)
+            .set_indicated_airspeed(160.)
             .set_flaps_handle_position(0)
             .run_one_tick();
 
@@ -1031,7 +762,7 @@ mod tests {
             .set_green_hyd_pressure()
             .set_yellow_hyd_pressure()
             .set_blue_hyd_pressure()
-            .set_indicated_airspeed(200.)
+            .set_indicated_airspeed(215.)
             .set_flaps_handle_position(1)
             .run_one_tick();
 
@@ -1049,7 +780,7 @@ mod tests {
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
         assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
-        test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
+        test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
@@ -1096,14 +827,14 @@ mod tests {
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
-        test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
+        test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
-        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
@@ -1113,7 +844,7 @@ mod tests {
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
-        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
@@ -1143,7 +874,7 @@ mod tests {
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
-        test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
+        test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
@@ -1151,7 +882,7 @@ mod tests {
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
 
@@ -1161,7 +892,7 @@ mod tests {
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
         assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
-        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
@@ -1190,26 +921,26 @@ mod tests {
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(21));
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
-        test_bed = test_bed.run_waiting_for(Duration::from_secs(31));
+        test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(14));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(15));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(19));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(20));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
+        assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(22));
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(23));
 
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(12));
         assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(13));
-        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
-        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(14));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(15));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(19));
         assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(20));
         assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(21));
-        assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
+        assert!(test_bed.read_slat_flap_actual_position_word(2).get_bit(22));
         assert!(!test_bed.read_slat_flap_actual_position_word(2).get_bit(23));
     }
 
@@ -1237,7 +968,7 @@ mod tests {
         assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(21));
         assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(26));
 
-        test_bed = test_bed.run_waiting_for(Duration::from_secs(45));
+        test_bed = test_bed.run_waiting_for(Duration::from_secs(60));
 
         assert!(!test_bed.read_slat_flap_actual_position_word(1).get_bit(12));
         assert!(test_bed.read_slat_flap_actual_position_word(1).get_bit(13));
@@ -1262,65 +993,65 @@ mod tests {
 
     // Tests flaps configuration and angles for regular
     // increasing handle transitions, i.e 0->1->2->3->4 in sequence
-    // below 100 knots
+    // below 205 knots
     #[test]
-    fn flaps_test_regular_handle_increase_transitions_flaps_target_airspeed_below_100() {
+    fn flaps_test_regular_handle_increase_transitions_flaps_target_airspeed_below_205() {
         let angle_delta: f64 = 0.1;
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
-            .set_indicated_airspeed(50.)
+            .set_indicated_airspeed(160.)
             .run_one_tick();
 
         test_bed.test_flap_conf(0, 0., 0., FlapsConf::Conf0, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
 
-        test_bed.test_flap_conf(1, 120.22, 222.27, FlapsConf::Conf1F, angle_delta);
+        test_bed.test_flap_conf(1, 108.28, 247.27, FlapsConf::Conf1F, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
 
-        test_bed.test_flap_conf(2, 145.51, 272.27, FlapsConf::Conf2, angle_delta);
+        test_bed.test_flap_conf(2, 154.65, 247.27, FlapsConf::Conf2, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
 
-        test_bed.test_flap_conf(3, 168.35, 272.27, FlapsConf::Conf3, angle_delta);
+        test_bed.test_flap_conf(3, 194.03, 284.65, FlapsConf::Conf3, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
 
-        test_bed.test_flap_conf(4, 251.97, 334.16, FlapsConf::ConfFull, angle_delta);
+        test_bed.test_flap_conf(4, 218.91, 284.65, FlapsConf::ConfFull, angle_delta);
     }
 
     // Tests flaps configuration and angles for regular
     // increasing handle transitions, i.e 0->1->2->3->4 in sequence
-    // above 100 knots
+    // above 205 knots
     #[test]
-    fn flaps_test_regular_handle_increase_transitions_flaps_target_airspeed_above_100() {
+    fn flaps_test_regular_handle_increase_transitions_flaps_target_airspeed_above_205() {
         let angle_delta: f64 = 0.1;
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
-            .set_indicated_airspeed(150.)
+            .set_indicated_airspeed(215.)
             .run_one_tick();
 
         test_bed.test_flap_conf(0, 0., 0., FlapsConf::Conf0, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
 
-        test_bed.test_flap_conf(1, 0., 222.27, FlapsConf::Conf1, angle_delta);
+        test_bed.test_flap_conf(1, 0., 247.27, FlapsConf::Conf1, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
 
-        test_bed.test_flap_conf(2, 145.51, 272.27, FlapsConf::Conf2, angle_delta);
+        test_bed.test_flap_conf(2, 154.65, 247.27, FlapsConf::Conf2, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
 
-        test_bed.test_flap_conf(3, 168.35, 272.27, FlapsConf::Conf3, angle_delta);
+        test_bed.test_flap_conf(3, 154.65, 284.65, FlapsConf::Conf2S, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
 
-        test_bed.test_flap_conf(4, 251.97, 334.16, FlapsConf::ConfFull, angle_delta);
+        test_bed.test_flap_conf(4, 194.03, 284.65, FlapsConf::Conf3, angle_delta);
     }
 
-    //Tests regular transition 2->1 below and above 210 knots
+    //Tests regular transition 2->1 below and above 212 knots
     #[test]
     fn flaps_test_regular_handle_transition_pos_2_to_1() {
         let mut test_bed = test_bed_with()
@@ -1350,7 +1081,7 @@ mod tests {
         assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1);
     }
 
-    //Tests transition between Conf1F to Conf1 above 210 knots
+    //Tests transition between Conf1F to Conf1 above 212 knots
     #[test]
     fn flaps_test_regular_handle_transition_pos_1_to_1() {
         let mut test_bed = test_bed_with()
@@ -1375,30 +1106,30 @@ mod tests {
 
     // Tests flaps configuration and angles for regular
     // decreasing handle transitions, i.e 4->3->2->1->0 in sequence
-    // below 210 knots
+    // below 212 knots
     #[test]
-    fn flaps_test_regular_decrease_handle_transition_flaps_target_airspeed_below_210() {
+    fn flaps_test_regular_decrease_handle_transition_flaps_target_airspeed_below_212() {
         let angle_delta: f64 = 0.1;
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
-            .set_indicated_airspeed(150.)
+            .set_indicated_airspeed(160.)
             .run_one_tick();
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
 
-        test_bed.test_flap_conf(4, 251.97, 334.16, FlapsConf::ConfFull, angle_delta);
+        test_bed.test_flap_conf(4, 218.91, 284.65, FlapsConf::ConfFull, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
 
-        test_bed.test_flap_conf(3, 168.35, 272.27, FlapsConf::Conf3, angle_delta);
+        test_bed.test_flap_conf(3, 194.03, 284.65, FlapsConf::Conf3, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
 
-        test_bed.test_flap_conf(2, 145.51, 272.27, FlapsConf::Conf2, angle_delta);
+        test_bed.test_flap_conf(2, 154.65, 247.27, FlapsConf::Conf2, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
 
-        test_bed.test_flap_conf(1, 120.22, 222.27, FlapsConf::Conf1F, angle_delta);
+        test_bed.test_flap_conf(1, 108.28, 247.27, FlapsConf::Conf1F, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
 
@@ -1409,7 +1140,7 @@ mod tests {
     // decreasing handle transitions, i.e 4->3->2->1->0 in sequence
     // above 210 knots
     #[test]
-    fn flaps_test_regular_decrease_handle_transition_flaps_target_airspeed_above_210() {
+    fn flaps_test_regular_decrease_handle_transition_flaps_target_airspeed_above_212() {
         let angle_delta: f64 = 0.1;
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
@@ -1418,19 +1149,19 @@ mod tests {
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
 
-        test_bed.test_flap_conf(4, 251.97, 334.16, FlapsConf::ConfFull, angle_delta);
+        test_bed.test_flap_conf(4, 218.91, 284.65, FlapsConf::ConfFull, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
 
-        test_bed.test_flap_conf(3, 168.35, 272.27, FlapsConf::Conf3, angle_delta);
+        test_bed.test_flap_conf(3, 194.03, 284.65, FlapsConf::Conf3, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
 
-        test_bed.test_flap_conf(2, 145.51, 272.27, FlapsConf::Conf2, angle_delta);
+        test_bed.test_flap_conf(2, 154.65, 247.27, FlapsConf::Conf2, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
 
-        test_bed.test_flap_conf(1, 0., 222.27, FlapsConf::Conf1, angle_delta);
+        test_bed.test_flap_conf(1, 0., 247.27, FlapsConf::Conf1, angle_delta);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
 
@@ -1455,23 +1186,23 @@ mod tests {
         assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
         assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
         assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
         assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
         assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed
-            .set_indicated_airspeed(110.)
+            .set_indicated_airspeed(160.)
             .set_flaps_handle_position(0)
             .run_one_tick();
 
@@ -1546,7 +1277,7 @@ mod tests {
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
-            .set_indicated_airspeed(110.)
+            .set_indicated_airspeed(210.)
             .set_flaps_handle_position(1)
             .run_one_tick();
 
@@ -1563,7 +1294,7 @@ mod tests {
 
         test_bed = test_bed_with()
             .set_green_hyd_pressure()
-            .set_indicated_airspeed(110.)
+            .set_indicated_airspeed(205.)
             .set_flaps_handle_position(1)
             .run_one_tick();
 
@@ -1642,8 +1373,8 @@ mod tests {
         assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
         assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2);
@@ -1654,7 +1385,7 @@ mod tests {
     fn flaps_test_irregular_handle_transition_init_pos_3() {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
-            .set_indicated_airspeed(150.)
+            .set_indicated_airspeed(205.)
             .set_flaps_handle_position(3)
             .run_one_tick();
 
@@ -1696,8 +1427,8 @@ mod tests {
         assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
         assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
@@ -1708,7 +1439,7 @@ mod tests {
     fn flaps_test_irregular_handle_transition_init_pos_4() {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
-            .set_indicated_airspeed(150.)
+            .set_indicated_airspeed(205.)
             .set_flaps_handle_position(4)
             .run_one_tick();
 
@@ -1750,8 +1481,8 @@ mod tests {
         assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::ConfFull);
 
         test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
-        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
-        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F); // alpha lock
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F); // alpha lock
 
         test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
         assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::ConfFull);
@@ -1772,6 +1503,7 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
+            .set_on_ground(true)
             .set_flaps_handle_position(0)
             .run_one_tick();
 
@@ -1798,6 +1530,7 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
+            .set_on_ground(true)
             .set_flaps_handle_position(1)
             .run_one_tick();
 
@@ -1806,7 +1539,7 @@ mod tests {
 
         test_bed = test_bed
             .set_flaps_handle_position(2)
-            .run_waiting_for(Duration::from_secs(20));
+            .run_waiting_for(Duration::from_secs(35));
 
         assert!(
             (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
@@ -1824,6 +1557,7 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
+            .set_on_ground(true)
             .set_flaps_handle_position(2)
             .run_one_tick();
 
@@ -1850,6 +1584,7 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
+            .set_on_ground(true)
             .set_flaps_handle_position(3)
             .run_waiting_for(Duration::from_secs(20));
 
@@ -1876,6 +1611,7 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
+            .set_on_ground(true)
             .set_flaps_handle_position(0)
             .run_one_tick();
 
@@ -1884,7 +1620,7 @@ mod tests {
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
-            .run_waiting_for(Duration::from_secs(30));
+            .run_waiting_for(Duration::from_secs(60));
 
         assert!(
             (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
@@ -1911,7 +1647,7 @@ mod tests {
 
         test_bed = test_bed
             .set_flaps_handle_position(1)
-            .run_waiting_for(Duration::from_secs(30));
+            .run_waiting_for(Duration::from_secs(60));
 
         assert!(
             (test_bed.get_flaps_fppu_feedback() - test_bed.get_flaps_demanded_angle(0)).abs()
@@ -1937,6 +1673,7 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
+            .set_on_ground(true)
             .set_flaps_handle_position(1)
             .run_one_tick();
 
@@ -1945,7 +1682,7 @@ mod tests {
 
         test_bed = test_bed
             .set_flaps_handle_position(2)
-            .run_waiting_for(Duration::from_secs(40));
+            .run_waiting_for(Duration::from_secs(60));
 
         assert!(
             (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
@@ -1963,6 +1700,7 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
+            .set_on_ground(true)
             .set_flaps_handle_position(2)
             .run_one_tick();
 
@@ -1971,7 +1709,7 @@ mod tests {
 
         test_bed = test_bed
             .set_flaps_handle_position(3)
-            .run_waiting_for(Duration::from_secs(40));
+            .run_waiting_for(Duration::from_secs(60));
 
         assert!(
             (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(0)).abs()
@@ -1989,6 +1727,7 @@ mod tests {
         let mut test_bed = test_bed_with()
             .set_green_hyd_pressure()
             .set_indicated_airspeed(0.)
+            .set_on_ground(true)
             .set_flaps_handle_position(3)
             .run_one_tick();
 
@@ -2007,5 +1746,134 @@ mod tests {
             (test_bed.get_slats_fppu_feedback() - test_bed.get_slats_demanded_angle(1)).abs()
                 <= angle_delta
         );
+    }
+
+    #[test]
+    fn config_test_flrs_full() {
+        let mut test_bed = test_bed_with()
+            .set_green_hyd_pressure()
+            .set_indicated_airspeed(186.)
+            .set_flaps_handle_position(0)
+            .run_one_tick();
+
+        test_bed = test_bed
+            .set_flaps_handle_position(4)
+            .run_waiting_for(Duration::from_secs(50));
+
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf3);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf3);
+    }
+
+    #[test]
+    fn config_test_flrs_3() {
+        let mut test_bed = test_bed_with()
+            .set_green_hyd_pressure()
+            .set_indicated_airspeed(200.)
+            .set_flaps_handle_position(0)
+            .run_one_tick();
+
+        test_bed = test_bed
+            .set_flaps_handle_position(3)
+            .run_waiting_for(Duration::from_secs(50));
+
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf2S);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf2S);
+    }
+
+    #[test]
+    fn config_test_flrs_2() {
+        let mut test_bed = test_bed_with()
+            .set_green_hyd_pressure()
+            .set_indicated_airspeed(224.)
+            .set_flaps_handle_position(0)
+            .run_one_tick();
+
+        test_bed = test_bed
+            .set_flaps_handle_position(2)
+            .run_waiting_for(Duration::from_secs(50));
+
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
+    }
+
+    #[test]
+    fn config_test_cruise_baulk() {
+        let mut test_bed = test_bed_with()
+            .set_green_hyd_pressure()
+            .set_indicated_airspeed(280.)
+            .set_on_ground(false)
+            .set_flaps_handle_position(0)
+            .run_one_tick();
+
+        test_bed = test_bed
+            .set_flaps_handle_position(1)
+            .run_waiting_for(Duration::from_secs(20));
+
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(25));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(25));
+    }
+
+    #[test]
+    fn config_test_alpha_lock_speed() {
+        let mut test_bed = test_bed_with()
+            .set_green_hyd_pressure()
+            .set_indicated_airspeed(130.)
+            .set_angle_of_attack(Angle::new::<degree>(5.))
+            .set_on_ground(false)
+            .set_flaps_handle_position(1)
+            .run_one_tick();
+
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
+
+        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
+
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(24));
+
+        test_bed = test_bed.set_indicated_airspeed(200.).run_one_tick();
+
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
+    }
+
+    #[test]
+    fn config_test_alpha_lock_aoa() {
+        let mut test_bed = test_bed_with()
+            .set_green_hyd_pressure()
+            .set_indicated_airspeed(200.)
+            .set_angle_of_attack(Angle::new::<degree>(10.))
+            .set_on_ground(false)
+            .set_flaps_handle_position(1)
+            .run_one_tick();
+
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
+
+        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
+
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf1F);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf1F);
+        assert!(test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(test_bed.read_slat_flap_system_status_word(2).get_bit(24));
+
+        test_bed = test_bed
+            .set_angle_of_attack(Angle::new::<degree>(9.1))
+            .run_one_tick();
+
+        assert_eq!(test_bed.get_flaps_conf(0), FlapsConf::Conf0);
+        assert_eq!(test_bed.get_flaps_conf(1), FlapsConf::Conf0);
+        assert!(!test_bed.read_slat_flap_system_status_word(1).get_bit(24));
+        assert!(!test_bed.read_slat_flap_system_status_word(2).get_bit(24));
     }
 }

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/slats_channel.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/slats_channel.rs
@@ -1,0 +1,238 @@
+use crate::systems::shared::arinc429::{Arinc429Word, SignStatus};
+use systems::hydraulic::command_sensor_unit::{CSUMonitor, CSU};
+use systems::shared::{AdirsMeasurementOutputs, PositionPickoffUnit};
+
+use systems::simulation::{
+    InitContext, SimulationElement, SimulationElementVisitor, SimulatorWriter, UpdateContext,
+    VariableIdentifier, Write,
+};
+
+use uom::si::length::foot;
+use uom::si::{angle::degree, f64::*, velocity::knot};
+use uom::ConstZero;
+
+pub struct SlatsChannel {
+    slats_fppu_angle_id: VariableIdentifier,
+    slat_actual_position_word_id: VariableIdentifier,
+
+    slats_demanded_angle: Angle,
+    slats_feedback_angle: Angle,
+
+    cruise_baulk_active: bool,
+    alpha_speed_lock_active: bool,
+
+    csu_monitor: CSUMonitor,
+}
+
+impl SlatsChannel {
+    const HANDLE_ONE_CONF_AIRSPEED_THRESHOLD_KNOTS: f64 = 205.;
+    const CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS: f64 = 212.;
+    const CRUISE_BAULK_AIRSPEED_THRESHOLD_KNOTS: f64 = 265.5;
+    const CRUISE_BAULK_ALTITUDE_THRESHOLD_FEET: f64 = 22000.;
+    const ALPHA_SPEED_LOCK_IN_AIRSPEED_THRESHOLD_KNOTS: f64 = 155.;
+    const ALPHA_SPEED_LOCK_OUT_AIRSPEED_THRESHOLD_KNOTS: f64 = 161.;
+    const ALPHA_SPEED_LOCK_IN_AOA_THRESHOLD_DEGREES: f64 = 9.5;
+    const ALPHA_SPEED_LOCK_OUT_AOA_THRESHOLD_DEGREES: f64 = 9.2;
+
+    const FLRS_CONFFULL_TO_CONF3_AIRSPEED_THRESHOLD_KNOTS: f64 = 184.5;
+    const FLRS_CONF3_TO_CONF2S_AIRSPEED_THRESHOLD_KNOTS: f64 = 198.5;
+    const FLRS_CONF2_TO_CONF1F_AIRSPEED_THRESHOLD_KNOTS: f64 = 222.5;
+
+    pub fn new(context: &mut InitContext, num: u8) -> Self {
+        Self {
+            slats_fppu_angle_id: context.get_identifier("SLATS_FPPU_ANGLE".to_owned()),
+            slat_actual_position_word_id: context
+                .get_identifier(format!("SFCC_{num}_SLAT_ACTUAL_POSITION_WORD")),
+
+            slats_demanded_angle: Angle::new::<degree>(0.),
+            slats_feedback_angle: Angle::new::<degree>(0.),
+            cruise_baulk_active: false,
+            alpha_speed_lock_active: false,
+            csu_monitor: CSUMonitor::new(context),
+        }
+    }
+
+    // FIXME This is not the correct ADR input selection yet, due to missing references
+    fn angle_of_attack(&self, adirs: &impl AdirsMeasurementOutputs) -> Option<Angle> {
+        [1, 2, 3]
+            .iter()
+            .find_map(|&adiru_number| adirs.angle_of_attack(adiru_number).normal_value())
+    }
+
+    fn cruise_baulk_active(&self, csu_monitor: &CSUMonitor) -> bool {
+        csu_monitor.get_current_detent() == CSU::Conf1 && self.slats_demanded_angle == Angle::ZERO
+    }
+
+    fn alpha_speed_lock_active(&self, csu_monitor: &CSUMonitor) -> bool {
+        csu_monitor.get_current_detent() == CSU::Conf0
+            && self.slats_demanded_angle == Angle::new::<degree>(247.27)
+    }
+
+    fn generate_configuration(
+        &self,
+        csu_monitor: &CSUMonitor,
+        context: &UpdateContext,
+        adirs: &impl AdirsMeasurementOutputs,
+    ) -> Angle {
+        // Ignored `CSU::OutOfDetent` and `CSU::Fault` positions due to simplified SFCC.
+        match (
+            csu_monitor.get_previous_detent(),
+            csu_monitor.get_current_detent(),
+        ) {
+            (CSU::Conf0 | CSU::Conf1, CSU::Conf1)
+                if context.indicated_airspeed().get::<knot>()
+                    < Self::HANDLE_ONE_CONF_AIRSPEED_THRESHOLD_KNOTS
+                    || context.is_on_ground() =>
+            {
+                Angle::new::<degree>(247.27)
+            }
+            (CSU::Conf0 | CSU::Conf1, CSU::Conf1)
+                if context.indicated_airspeed().get::<knot>()
+                    > Self::CRUISE_BAULK_AIRSPEED_THRESHOLD_KNOTS
+                    // FIXME use ADRs
+                    || context.pressure_altitude().get::<foot>()
+                        > Self::CRUISE_BAULK_ALTITUDE_THRESHOLD_FEET =>
+            {
+                Angle::ZERO
+            }
+            (CSU::Conf0, CSU::Conf1) => Angle::new::<degree>(247.27),
+            (CSU::Conf1, CSU::Conf1)
+                if context.indicated_airspeed().get::<knot>()
+                    > Self::CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::new::<degree>(247.27)
+            }
+            (CSU::Conf1, CSU::Conf1) => self.slats_demanded_angle,
+            (_, CSU::Conf1)
+                if context.indicated_airspeed().get::<knot>()
+                    <= Self::CONF1F_TO_CONF1_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::new::<degree>(247.27)
+            }
+            (_, CSU::Conf1) => Angle::new::<degree>(247.27),
+            (_, CSU::Conf0) if context.is_in_flight() && self.alpha_speed_lock_active => {
+                if context.indicated_airspeed().get::<knot>()
+                    > Self::ALPHA_SPEED_LOCK_OUT_AIRSPEED_THRESHOLD_KNOTS
+                    || self
+                        .angle_of_attack(adirs)
+                        .unwrap_or_default()
+                        .get::<degree>()
+                        < Self::ALPHA_SPEED_LOCK_OUT_AOA_THRESHOLD_DEGREES
+                {
+                    Angle::ZERO
+                } else {
+                    self.slats_demanded_angle
+                }
+            }
+            (CSU::Conf1, CSU::Conf0)
+            | (CSU::Conf2, CSU::Conf0)
+            | (CSU::Conf3, CSU::Conf0)
+            | (CSU::ConfFull, CSU::Conf0)
+                if context.is_in_flight()
+                    && (context.indicated_airspeed().get::<knot>()
+                        < Self::ALPHA_SPEED_LOCK_IN_AIRSPEED_THRESHOLD_KNOTS
+                        || self
+                            .angle_of_attack(adirs)
+                            .unwrap_or_default()
+                            .get::<degree>()
+                            > Self::ALPHA_SPEED_LOCK_IN_AOA_THRESHOLD_DEGREES) =>
+            {
+                Angle::new::<degree>(247.27)
+            }
+            (_, CSU::Conf0) => Angle::ZERO,
+            (CSU::Conf1 | CSU::Conf2, CSU::Conf2)
+                if context.indicated_airspeed().get::<knot>()
+                    > Self::FLRS_CONF2_TO_CONF1F_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::new::<degree>(247.27)
+            }
+            (CSU::Conf2, CSU::Conf2)
+                if self.slats_demanded_angle == Angle::new::<degree>(247.27) =>
+            {
+                Angle::new::<degree>(247.27)
+            }
+            (CSU::Conf2 | CSU::Conf3, CSU::Conf3)
+                if context.indicated_airspeed().get::<knot>()
+                    > Self::FLRS_CONF3_TO_CONF2S_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::new::<degree>(284.65)
+            }
+            (CSU::Conf3, CSU::Conf3)
+                if self.slats_demanded_angle == Angle::new::<degree>(284.65) =>
+            {
+                Angle::new::<degree>(284.65)
+            }
+            (CSU::Conf3 | CSU::ConfFull, CSU::ConfFull)
+                if context.indicated_airspeed().get::<knot>()
+                    > Self::FLRS_CONFFULL_TO_CONF3_AIRSPEED_THRESHOLD_KNOTS =>
+            {
+                Angle::new::<degree>(284.65)
+            }
+            (CSU::ConfFull, CSU::ConfFull)
+                if self.slats_demanded_angle == Angle::new::<degree>(284.65) =>
+            {
+                Angle::new::<degree>(284.65)
+            }
+            (from, CSU::Conf2) if from != CSU::Conf2 => Angle::new::<degree>(247.27),
+            (from, CSU::Conf3) if from != CSU::Conf3 => Angle::new::<degree>(284.65),
+            (from, CSU::ConfFull) if from != CSU::ConfFull => Angle::new::<degree>(284.65),
+            (_, _) => self.slats_demanded_angle,
+        }
+    }
+
+    pub fn update(
+        &mut self,
+        context: &UpdateContext,
+        slats_feedback: &impl PositionPickoffUnit,
+        adirs: &impl AdirsMeasurementOutputs,
+    ) {
+        self.csu_monitor.update(context);
+        self.slats_demanded_angle = self.generate_configuration(&self.csu_monitor, context, adirs);
+        self.slats_feedback_angle = slats_feedback.angle();
+
+        self.alpha_speed_lock_active = self.alpha_speed_lock_active(&self.csu_monitor);
+        self.cruise_baulk_active = self.cruise_baulk_active(&self.csu_monitor);
+    }
+
+    pub fn get_demanded_angle(&self) -> Angle {
+        self.slats_demanded_angle
+    }
+
+    pub fn get_feedback_angle(&self) -> Angle {
+        self.slats_feedback_angle
+    }
+
+    pub fn get_alpha_speed_lock(&self) -> bool {
+        self.alpha_speed_lock_active
+    }
+
+    pub fn get_cruise_baulk(&self) -> bool {
+        self.cruise_baulk_active
+    }
+
+    // pub fn get_handle_detent(&self) -> CSU {
+    //     self.csu_monitor.get_current_detent()
+    // }
+
+    fn slat_actual_position_word(&self) -> Arinc429Word<f64> {
+        Arinc429Word::new(
+            self.slats_feedback_angle.get::<degree>(),
+            SignStatus::NormalOperation,
+        )
+    }
+}
+impl SimulationElement for SlatsChannel {
+    fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
+        self.csu_monitor.accept(visitor);
+        visitor.visit(self);
+    }
+
+    fn write(&self, writer: &mut SimulatorWriter) {
+        writer.write(&self.slats_fppu_angle_id, self.slats_feedback_angle);
+
+        writer.write(
+            &self.slat_actual_position_word_id,
+            self.slat_actual_position_word(),
+        );
+    }
+}

--- a/fbw-common/src/wasm/systems/systems/src/hydraulic/flap_slat.rs
+++ b/fbw-common/src/wasm/systems/systems/src/hydraulic/flap_slat.rs
@@ -1,3 +1,4 @@
+use super::hydraulic_motor::FlapSlatHydraulicMotor;
 use super::linear_actuator::Actuator;
 use crate::shared::{
     interpolation, low_pass_filter::LowPassFilter, AverageExt, PositionPickoffUnit, SectionPressure,
@@ -14,114 +15,10 @@ use uom::si::{
     pressure::psi,
     ratio::{percent, ratio},
     torque::pound_force_inch,
-    volume::{cubic_inch, gallon},
-    volume_rate::{gallon_per_minute, gallon_per_second},
 };
 
 use std::fmt;
 use std::time::Duration;
-use uom::si::time::second;
-
-/// Simple hydraulic motor directly driven with a speed.
-/// Speed is smoothly rising or lowering to simulate transients states
-/// Flow is updated from current motor speed
-pub struct FlapSlatHydraulicMotor {
-    speed: LowPassFilter<AngularVelocity>,
-    displacement: Volume,
-    current_flow: VolumeRate,
-
-    total_volume_to_actuator: Volume,
-    total_volume_returned_to_reservoir: Volume,
-}
-impl FlapSlatHydraulicMotor {
-    // Simulates rpm transients.
-    const LOW_PASS_RPM_TRANSIENT_TIME_CONSTANT: Duration = Duration::from_millis(300);
-
-    const MIN_MOTOR_RPM: f64 = 20.;
-
-    // Corrective factor to adjust final flow consumption to tune the model
-    const FLOW_CORRECTION_FACTOR: f64 = 0.6;
-
-    fn new(displacement: Volume) -> Self {
-        Self {
-            speed: LowPassFilter::<AngularVelocity>::new(
-                Self::LOW_PASS_RPM_TRANSIENT_TIME_CONSTANT,
-            ),
-            displacement,
-            current_flow: VolumeRate::new::<gallon_per_second>(0.),
-            total_volume_to_actuator: Volume::new::<gallon>(0.),
-            total_volume_returned_to_reservoir: Volume::new::<gallon>(0.),
-        }
-    }
-
-    fn update_speed(&mut self, context: &UpdateContext, speed: AngularVelocity) {
-        // Low pass filter to simulate motors spool up and down. Will ease pressure impact on transients
-        if !context.aircraft_preset_quick_mode() {
-            self.speed.update(context.delta(), speed);
-        } else {
-            // This is for the Aircraft Presets to expedite the setting of a preset.
-            self.speed.update(Duration::from_secs(2), speed);
-        }
-
-        // Forcing 0 speed at low speed to avoid endless spool down due to low pass filter
-        if self.speed.output().get::<revolution_per_minute>() < Self::MIN_MOTOR_RPM
-            && self.speed.output().get::<revolution_per_minute>() > -Self::MIN_MOTOR_RPM
-        {
-            self.speed.reset(AngularVelocity::default());
-        }
-    }
-
-    fn update_flow(&mut self, context: &UpdateContext) {
-        self.current_flow = VolumeRate::new::<gallon_per_minute>(
-            Self::FLOW_CORRECTION_FACTOR
-                * self.speed().get::<revolution_per_minute>().abs()
-                * self.displacement.get::<cubic_inch>()
-                / 231.,
-        );
-
-        if !context.aircraft_preset_quick_mode() {
-            self.total_volume_to_actuator += self.current_flow * context.delta_as_time();
-            self.total_volume_returned_to_reservoir += self.current_flow * context.delta_as_time();
-        } else {
-            // This is for the Aircraft Presets to expedite the setting of a preset.
-            self.total_volume_to_actuator += self.current_flow * Time::new::<second>(2.);
-            self.total_volume_returned_to_reservoir += self.current_flow * Time::new::<second>(2.);
-        }
-    }
-
-    fn torque(&self, pressure: Pressure) -> Torque {
-        Torque::new::<pound_force_inch>(
-            pressure.get::<psi>() * self.displacement.get::<cubic_inch>()
-                / (2. * std::f64::consts::PI),
-        )
-    }
-
-    fn reset_accumulators(&mut self) {
-        self.total_volume_to_actuator = Volume::new::<gallon>(0.);
-        self.total_volume_returned_to_reservoir = Volume::new::<gallon>(0.);
-    }
-
-    fn speed(&self) -> AngularVelocity {
-        self.speed.output()
-    }
-
-    #[cfg(test)]
-    fn flow(&self) -> VolumeRate {
-        self.current_flow
-    }
-}
-impl Actuator for FlapSlatHydraulicMotor {
-    fn used_volume(&self) -> Volume {
-        self.total_volume_to_actuator
-    }
-    fn reservoir_return(&self) -> Volume {
-        self.total_volume_returned_to_reservoir
-    }
-    fn reset_volumes(&mut self) {
-        self.total_volume_returned_to_reservoir = Volume::new::<gallon>(0.);
-        self.total_volume_to_actuator = Volume::new::<gallon>(0.);
-    }
-}
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum SecondarySurfaceSide {
@@ -665,6 +562,8 @@ mod tests {
 
     use ntest::assert_about_eq;
     use std::time::Duration;
+    use uom::si::volume::cubic_inch;
+    use uom::si::volume_rate::gallon_per_minute;
     use uom::si::{angle::degree, pressure::psi};
     use uom::ConstZero;
 

--- a/fbw-common/src/wasm/systems/systems/src/hydraulic/hydraulic_motor.rs
+++ b/fbw-common/src/wasm/systems/systems/src/hydraulic/hydraulic_motor.rs
@@ -1,0 +1,115 @@
+use super::linear_actuator::Actuator;
+use crate::{shared::low_pass_filter::LowPassFilter, simulation::UpdateContext};
+
+use uom::si::{
+    angular_velocity::revolution_per_minute,
+    f64::*,
+    pressure::psi,
+    torque::pound_force_inch,
+    volume::{cubic_inch, gallon},
+    volume_rate::{gallon_per_minute, gallon_per_second},
+};
+
+use std::time::Duration;
+use uom::si::time::second;
+
+/// Simple hydraulic motor directly driven with a speed.
+/// Speed is smoothly rising or lowering to simulate transients states
+/// Flow is updated from current motor speed
+pub struct FlapSlatHydraulicMotor {
+    speed: LowPassFilter<AngularVelocity>,
+    displacement: Volume,
+    current_flow: VolumeRate,
+
+    total_volume_to_actuator: Volume,
+    total_volume_returned_to_reservoir: Volume,
+}
+impl FlapSlatHydraulicMotor {
+    // Simulates rpm transients.
+    const LOW_PASS_RPM_TRANSIENT_TIME_CONSTANT: Duration = Duration::from_millis(300);
+
+    const MIN_MOTOR_RPM: f64 = 20.;
+
+    // Corrective factor to adjust final flow consumption to tune the model
+    const FLOW_CORRECTION_FACTOR: f64 = 0.6;
+
+    pub fn new(displacement: Volume) -> Self {
+        Self {
+            speed: LowPassFilter::<AngularVelocity>::new(
+                Self::LOW_PASS_RPM_TRANSIENT_TIME_CONSTANT,
+            ),
+            displacement,
+            current_flow: VolumeRate::new::<gallon_per_second>(0.),
+            total_volume_to_actuator: Volume::new::<gallon>(0.),
+            total_volume_returned_to_reservoir: Volume::new::<gallon>(0.),
+        }
+    }
+
+    pub fn update_speed(&mut self, context: &UpdateContext, speed: AngularVelocity) {
+        // Low pass filter to simulate motors spool up and down. Will ease pressure impact on transients
+        if !context.aircraft_preset_quick_mode() {
+            self.speed.update(context.delta(), speed);
+        } else {
+            // This is for the Aircraft Presets to expedite the setting of a preset.
+            self.speed.update(Duration::from_secs(2), speed);
+        }
+
+        // Forcing 0 speed at low speed to avoid endless spool down due to low pass filter
+        if self.speed.output().get::<revolution_per_minute>() < Self::MIN_MOTOR_RPM
+            && self.speed.output().get::<revolution_per_minute>() > -Self::MIN_MOTOR_RPM
+        {
+            self.speed.reset(AngularVelocity::default());
+        }
+    }
+
+    pub fn update_flow(&mut self, context: &UpdateContext) {
+        self.current_flow = VolumeRate::new::<gallon_per_minute>(
+            Self::FLOW_CORRECTION_FACTOR
+                * self.speed().get::<revolution_per_minute>().abs()
+                * self.displacement.get::<cubic_inch>()
+                / 231.,
+        );
+
+        if !context.aircraft_preset_quick_mode() {
+            self.total_volume_to_actuator += self.current_flow * context.delta_as_time();
+            self.total_volume_returned_to_reservoir += self.current_flow * context.delta_as_time();
+        } else {
+            // This is for the Aircraft Presets to expedite the setting of a preset.
+            self.total_volume_to_actuator += self.current_flow * Time::new::<second>(2.);
+            self.total_volume_returned_to_reservoir += self.current_flow * Time::new::<second>(2.);
+        }
+    }
+
+    pub fn torque(&self, pressure: Pressure) -> Torque {
+        Torque::new::<pound_force_inch>(
+            pressure.get::<psi>() * self.displacement.get::<cubic_inch>()
+                / (2. * std::f64::consts::PI),
+        )
+    }
+
+    pub fn reset_accumulators(&mut self) {
+        self.total_volume_to_actuator = Volume::new::<gallon>(0.);
+        self.total_volume_returned_to_reservoir = Volume::new::<gallon>(0.);
+    }
+
+    pub fn speed(&self) -> AngularVelocity {
+        self.speed.output()
+    }
+
+    #[cfg(test)]
+    pub fn flow(&self) -> VolumeRate {
+        self.current_flow
+    }
+}
+impl Actuator for FlapSlatHydraulicMotor {
+    fn used_volume(&self) -> Volume {
+        self.total_volume_to_actuator
+    }
+    fn reservoir_return(&self) -> Volume {
+        self.total_volume_returned_to_reservoir
+    }
+    fn reset_volumes(&mut self) {
+        self.total_volume_returned_to_reservoir = Volume::new::<gallon>(0.);
+        self.total_volume_to_actuator = Volume::new::<gallon>(0.);
+    }
+}

--- a/fbw-common/src/wasm/systems/systems/src/hydraulic/mod.rs
+++ b/fbw-common/src/wasm/systems/systems/src/hydraulic/mod.rs
@@ -41,6 +41,7 @@ pub mod command_sensor_unit;
 pub mod electrical_generator;
 pub mod electrical_pump_physics;
 pub mod flap_slat;
+pub mod hydraulic_motor;
 pub mod landing_gear;
 pub mod linear_actuator;
 pub mod nose_steering;

--- a/fbw-common/src/wasm/systems/systems/src/shared/mod.rs
+++ b/fbw-common/src/wasm/systems/systems/src/shared/mod.rs
@@ -1151,6 +1151,37 @@ impl<D: uom::si::Dimension + ?Sized, U: uom::si::Units<f64> + ?Sized> Clamp
     }
 }
 
+pub fn about_gt_lt<T: std::ops::Sub<Output = T> + PartialOrd>(
+    value: T,
+    expected_value: T,
+    epsilon: T,
+) -> bool {
+    let delta = if value < expected_value {
+        value - expected_value
+    } else {
+        expected_value - value
+    };
+    delta < epsilon
+}
+
+#[macro_export]
+macro_rules! assert_gt_lt {
+    ($a:expr, $b:expr, $eps:expr) => {
+        let eps = $eps;
+        assert!(
+            $crate::shared::about_gt_lt($a, $b, eps),
+            "assertion failed: `(left !== right)` \
+             (left: `{:?}`, right: `{:?}`, epsilon: `{:?}`)",
+            $a,
+            $b,
+            eps
+        );
+    };
+    ($a:expr, $b:expr,$eps:expr,) => {
+        assert_gt_lt!($a, $b, $eps);
+    };
+}
+
 #[cfg(test)]
 mod delayed_true_logic_gate_tests {
     use super::*;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR refactors the structure of the SFCC.

The SFCC is now split into `Slats channel` and `Flaps channel`. Also, the flaps/slats motors control is changed from closed loop to open loop: the SFCC sends the signal extend or retract to the motors not the demanded position.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
N/A

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
ATA27-50

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
To be merged after #10214 

I would like to continue the work started in the draft PR https://github.com/flybywiresim/aircraft/pull/7632 which aims to rewrite the SFCC. Instead of making a big PR, I would like to make incremental changes.
This is the last PR for restructuring the SFCC code to start adding the missing features.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): pythonist

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
This PR applies to both A320 and A380.
With plane ready for takeoff, move the flaps lever through all the positions and verify that the flaps/slats move accordingly on the external model and the EWD.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
