### PR TITLE
Prevent accessing undefined approach

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/guidance/geometry/GeometryFactory.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/geometry/GeometryFactory.ts
@@ -362,7 +362,7 @@ function getMagCorrection(legIndex: number, plan: BaseFlightPlan): number {
 }
 
 function getApproachMagCorrection(legIndex: number, plan: BaseFlightPlan): number | undefined {
-  const approachType = plan.approach.type;
+  const approachType = plan.approach?.type ?? ApproachType.Unknown;
   const currentLeg = plan.legElementAt(legIndex);
 
   // we use station declination for VOR/DME approaches


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes an issue where selecting a runway-only approach would cause the FMS to crash and - among other things - cause the leg distances to be 0. This was because we did not handle the case where the selected approach is `undefined` properly in our magvar code.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before:
<img width="455" height="382" alt="Screenshot 2025-07-22 141215" src="https://github.com/user-attachments/assets/ee60a0e7-4acf-4dc5-8809-209721f728e1" />

After:
<img width="434" height="328" alt="image" src="https://github.com/user-attachments/assets/7f4b060e-4e09-46e2-96a5-518a64eb8c30" />


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
"Strict mode would have fixed this"

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Load in anywhere. Select a runway-only approach. Make sure the leg distances are non-zero and that the approach is displayed correctly on the ND.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
