### PR TITLE
fix(a32nx): fixed lighting issues in SU3

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -101,6 +101,7 @@
 1. [A380X/FMS] Added CHECK MIN FUEL AT DEST & DEST EFOB BELOW MIN message with associated amber EFOB color on MFD pages - @BravoMike99 (bruno_pt99)
 1. [A380X] Fixed wing taxi lights appearing black - @heclak (Heclak)
 1. [A380X] Fixed lighting issues in SU3 - @heclak (Heclak)
+1. [A32NX] Fixed lighting issues in SU3 - @heclak (Heclak)
 
 ## 0.13.0
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_BeaconBelly_Ambient.fx
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_BeaconBelly_Ambient.fx
@@ -70,3 +70,4 @@ SpotInner=25
 SpotOuter=75
 Volumetric=0
 ScatDir=0.0
+ForceFlare=0

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_BeaconTop_Rear.fx
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_BeaconTop_Rear.fx
@@ -70,3 +70,4 @@ SpotInner=3.5
 SpotOuter=14
 Volumetric=0.01
 ScatDir=0.0
+ForceFlare=0

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_DaylightGlare.fx
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_DaylightGlare.fx
@@ -73,3 +73,4 @@ SpotInner=0
 SpotOuter=30
 Volumetric=0
 ScatDir=0
+ForceFlare=0

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_LandingAmbientGnd.fx
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_LandingAmbientGnd.fx
@@ -73,3 +73,4 @@ SpotInner=45
 SpotOuter=90
 Volumetric=0
 ScatDir=0
+ForceFlare=0

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_LandingAmbientLarge.fx
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_LandingAmbientLarge.fx
@@ -73,3 +73,4 @@ SpotInner=15
 SpotOuter=25.5
 Volumetric=0
 ScatDir=0
+ForceFlare=0

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_LandingAmbientMedium.fx
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_LandingAmbientMedium.fx
@@ -73,3 +73,4 @@ SpotInner=0
 SpotOuter=21
 Volumetric=0
 ScatDir=0
+ForceFlare=0

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_LandingAmbientSmall.fx
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_LandingAmbientSmall.fx
@@ -73,3 +73,4 @@ SpotInner=0
 SpotOuter=30
 Volumetric=0
 ScatDir=0
+ForceFlare=0

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_LogoLightAmbient.fx
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_LogoLightAmbient.fx
@@ -71,3 +71,4 @@ SpotInner=25
 SpotOuter=75
 Volumetric=0
 ScatDir=0.0
+ForceFlare=0

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_ParkBrkLight.fx
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_ParkBrkLight.fx
@@ -73,3 +73,4 @@ SpotInner=0
 SpotOuter=20
 Volumetric=0
 ScatDir=0
+ForceFlare=0

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_ParkBrkLightAmbient.fx
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_ParkBrkLightAmbient.fx
@@ -73,3 +73,4 @@ SpotInner=0
 SpotOuter=20
 Volumetric=0
 ScatDir=0
+ForceFlare=0

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_RunwayTurnOffAmbient.fx
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_RunwayTurnOffAmbient.fx
@@ -73,3 +73,4 @@ SpotInner=0
 SpotOuter=30
 Volumetric=0
 ScatDir=0
+ForceFlare=0

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_TakeOffAmbient.fx
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_TakeOffAmbient.fx
@@ -73,3 +73,4 @@ SpotInner=0
 SpotOuter=30
 Volumetric=0
 ScatDir=0
+ForceFlare=0

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_TaxiAmbient.fx
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/effects/A32NX_Exterior_TaxiAmbient.fx
@@ -73,3 +73,4 @@ SpotInner=0
 SpotOuter=30
 Volumetric=0
 ScatDir=0
+ForceFlare=0


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

* Removed flares on lights that shouldn't have light flares in 2024 SU3. No visible change in 2020 or SU2.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Heclak

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Requires 2024 SU3

* Load into aircraft and check the two sets of lights shown in the images above.
* Turn on all exterior lights and move around the cockpit, checking that you don't get a bright light bleed from the exterior light. (this was primarily caused by the runway turnoff lights and the lights on the nose gear.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
