### PR TITLE
fix(a380x/fws): Fix approach cap. downgrade triple click

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -101,6 +101,8 @@
 1. [A380X/FMS] Added CHECK MIN FUEL AT DEST & DEST EFOB BELOW MIN message with associated amber EFOB color on MFD pages - @BravoMike99 (bruno_pt99)
 1. [A380X] Fixed wing taxi lights appearing black - @heclak (Heclak)
 1. [A380X] Fixed lighting issues in SU3 - @heclak (Heclak)
+1. [A380X/FWS] Fix approach capability downgrade triple click - @flogross89 (floridude)
+1. [A380X/FWS] Disable startup time for runway spawns - @flogross89 (floridude)
 
 ## 0.13.0
 

--- a/fbw-a380x/src/systems/instruments/src/PFD/LowerArea.tsx
+++ b/fbw-a380x/src/systems/instruments/src/PFD/LowerArea.tsx
@@ -618,9 +618,9 @@ class RudderTrimIndicator extends DisplayComponent<{ bus: ArincEventBus }> {
           deltaTime,
         );
 
-        if (this.fwcFlightPhase.get() >= 2 && !gnd && this.engineFailedConfirmNode.read()) {
+        if (this.fwcFlightPhase.get() >= 3 && !gnd && this.engineFailedConfirmNode.read()) {
           this.engineHasFailed = true;
-        } else if (this.engineHasFailed && this.fwcFlightPhase.get() < 2) {
+        } else if (this.engineHasFailed && this.fwcFlightPhase.get() < 3) {
           this.engineHasFailed = false;
         }
 

--- a/fbw-a380x/src/systems/instruments/src/PFD/LowerArea.tsx
+++ b/fbw-a380x/src/systems/instruments/src/PFD/LowerArea.tsx
@@ -16,6 +16,7 @@ import {
   Arinc429LocalVarConsumerSubject,
   ArincEventBus,
   MathUtils,
+  NXLogicConfirmNode,
 } from '@flybywiresim/fbw-sdk';
 import { FormattedFwcText } from 'instruments/src/EWD/elements/FormattedFwcText';
 import { FwsPfdSimvars } from '../MsfsAvionicsCommon/providers/FwsPfdPublisher';
@@ -579,6 +580,9 @@ class RudderTrimIndicator extends DisplayComponent<{ bus: ArincEventBus }> {
 
   private rudderTrimWasMoved = false;
 
+  private lastUpdateTime: number | null = null;
+  private readonly engineFailedConfirmNode = new NXLogicConfirmNode(5, true); // Confirm eng failures to avoid transient startup issues
+
   private engineHasFailed = false;
 
   private delayStartTime: number = 0;
@@ -596,6 +600,9 @@ class RudderTrimIndicator extends DisplayComponent<{ bus: ArincEventBus }> {
       .on('simTime')
       .atFrequency(4)
       .handle((t) => {
+        const deltaTime = this.lastUpdateTime ? t - this.lastUpdateTime : 0;
+        this.lastUpdateTime = t;
+
         const gnd = this.onGround.get();
         const cas = this.speed.get();
         const rt = this.rudderTrimOrder.get();
@@ -603,14 +610,15 @@ class RudderTrimIndicator extends DisplayComponent<{ bus: ArincEventBus }> {
         const inFlightOrGroundFaster60Exceeds1Deg = (!gnd || (gnd && cas.valueOr(0) > 60)) && Math.abs(rt) > 1;
         const onGroundSlower60Exceeds0p3 = gnd && cas.valueOr(61) < 60 && Math.abs(rt) > 0.3;
 
-        if (
-          this.fwcFlightPhase.get() >= 2 &&
-          !gnd &&
-          (!this.engine1Running.get() ||
+        this.engineFailedConfirmNode.write(
+          !this.engine1Running.get() ||
             !this.engine2Running.get() ||
             !this.engine3Running.get() ||
-            !this.engine4Running.get())
-        ) {
+            !this.engine4Running.get(),
+          deltaTime,
+        );
+
+        if (this.fwcFlightPhase.get() >= 2 && !gnd && this.engineFailedConfirmNode.read()) {
           this.engineHasFailed = true;
         } else if (this.engineHasFailed && this.fwcFlightPhase.get() < 2) {
           this.engineHasFailed = false;

--- a/fbw-a380x/src/systems/systems-host/systems/EfisTawsBridge.ts
+++ b/fbw-a380x/src/systems/systems-host/systems/EfisTawsBridge.ts
@@ -551,7 +551,7 @@ export class EfisTawsBridge implements Instrument {
     }
 
     const tawsWxrSelected = SimVar.GetSimVarValue('L:A32NX_WXR_TAWS_SYS_SELECTED', SimVarValueType.Number);
-    const extremeLatitude = this.validIrMaintWord.get().bitValueOr(15, false);
+    const extremeLatitude = this.validIrMaintWord ? this.validIrMaintWord.get().bitValueOr(15, false) : false;
     this.terr1Failed.set(
       this.failuresConsumer.isActive(A380Failure.Terr1) ||
         this.aesu1ResetPulled.get() ||

--- a/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsCore.ts
+++ b/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsCore.ts
@@ -2085,7 +2085,8 @@ export class FwsCore {
   private handlePowerChange(powered: boolean) {
     if (powered) {
       // Real time is 60 seconds, i.e. 60_000 ms; Real setting for DMC self test in EFB is 12 seconds.
-      const startupTime = parseInt(NXDataStore.get('CONFIG_SELF_TEST_TIME', '12')) * 5_000;
+      const coldAndDark = SimVar.GetSimVarValue('L:A32NX_COLD_AND_DARK_SPAWN', 'bool');
+      const startupTime = coldAndDark ? parseInt(NXDataStore.get('CONFIG_SELF_TEST_TIME', '12')) * 5_000 : 0;
 
       this.startupTimer.schedule(() => {
         this.startupCompleted.set(true);

--- a/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsCore.ts
+++ b/fbw-a380x/src/systems/systems-host/systems/FlightWarningSystem/FwsCore.ts
@@ -35,6 +35,7 @@ import {
   NXLogicMemoryNode,
   NXLogicPulseNode,
   NXLogicTriggeredMonostableNode,
+  RegisteredSimVar,
   UpdateThrottler,
 } from '@flybywiresim/fbw-sdk';
 import { VerticalMode, LateralMode } from '@shared/autopilot';
@@ -577,6 +578,12 @@ export class FwsCore {
   public readonly approachCapabilityDowngradeSuppress = new NXLogicTriggeredMonostableNode(3, true);
 
   public readonly approachCapabilityDowngradeDebouncePulse = new NXLogicPulseNode(false);
+
+  public readonly modeReversionTripleClickSimvar = RegisteredSimVar.create<boolean>(
+    'L:A32NX_FMA_TRIPLE_CLICK_MODE_REVERSION',
+    SimVarValueType.Bool,
+  );
+  public readonly modeReversionTripleClickPulse = new NXLogicPulseNode(true);
 
   public readonly autoThrustEngaged = Subject.create(false);
 
@@ -2984,6 +2991,12 @@ export class FwsCore {
       this.soundManager.enqueueSound('tripleClick');
     }
     this.approachCapability.set(newCapability);
+
+    // FG mode reversion
+    this.modeReversionTripleClickPulse.write(this.modeReversionTripleClickSimvar.get(), deltaTime);
+    if (this.modeReversionTripleClickPulse.read()) {
+      this.soundManager.enqueueSound('tripleClick');
+    }
 
     // A/THR OFF
     const aThrEngaged = this.autoThrustStatus.get() === 2 || this.autoThrustMode.get() !== 0;

--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
@@ -330,7 +330,7 @@ void FlyByWireInterface::setupLocalVariables() {
   idFmaSoftAltModeActive = std::make_unique<LocalVariable>("A32NX_FMA_SOFT_ALT_MODE");
   idFmaCruiseAltModeActive = std::make_unique<LocalVariable>("A32NX_FMA_CRUISE_ALT_MODE");
   idFmaApproachCapability = std::make_unique<LocalVariable>("A32NX_APPROACH_CAPABILITY");
-  idFmaTripleClick = std::make_unique<LocalVariable>("A32NX_FMA_TRIPLE_CLICK");
+  idFmaTripleClick = std::make_unique<LocalVariable>("A32NX_FMA_TRIPLE_CLICK_MODE_REVERSION");
   idFmaModeReversion = std::make_unique<LocalVariable>("A32NX_FMA_MODE_REVERSION");
 
   idAutopilotTcasMessageDisarm = std::make_unique<LocalVariable>("A32NX_AUTOPILOT_TCAS_MESSAGE_DISARM");


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #10020
Fixes #10261 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes triple click for approach capability downgrades
Sets FWS startup time to 0 for runway spawns
Robustifies the rudder trim visibility for engine failures (confirm time of 5s to tackle transient startup effects, ignore failures in flight phase 2)

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Start cold&dark at gate, set DMC self test time to realistic
2. During startup, FWS 1+2 FAIL should be displayed for around 60s
3. program a/c for short flight (destination could be same as origin)
4. Reset rudder trim, startup the engines, taxi to runway --> RUD TRIM should be visible shortly after rudder trim reset, but then disappear
5. Take-off, fail engine during flight --> rudder trim should be visible in PFD all the time, shouldn't disappear
6. Re-start engine, rudder trim should still be visible until the end of the flight
7. Trigger mode reversion (e.g. start with OP CLB, and set FCU ALT below aircraft) --> triple click shall be heard
8. Perform ILS approach, start with CAT 3 DUAL (AP 1+2)
9. Disable A/THR, should downgrade to CAT 2 --> triple click shall be heard
10. Disconnect autopilots --> triple click shall be heard

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
