### PR TITLE
feat(a32nx/sfcc): implementation of SAP signals for A320 SFCC

### DIFF
--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -3574,6 +3574,11 @@ In the variables below, {number} should be replaced with one item in the set: { 
     - {id} is from 1 to 7
     - Flap actual position discrete output
 
+- A32NX_SFCC_{number}_SAP_{id}
+    - {number} is 1 or 2
+    - {id} is from 1 to 7
+    - Slat actual position discrete output
+
 ## Flight Controls (ATA 27)
 
 - A32NX_FLIGHT_CONTROLS_TRACKING_MODE

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/sfcc/mod.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/sfcc/mod.rs
@@ -673,6 +673,34 @@ mod tests {
             self.read_by_name(&format!("SFCC_{num}_FAP_7"))
         }
 
+        fn read_sfcc_sap_1_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_SAP_1"))
+        }
+
+        fn read_sfcc_sap_2_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_SAP_2"))
+        }
+
+        fn read_sfcc_sap_3_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_SAP_3"))
+        }
+
+        fn read_sfcc_sap_4_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_SAP_4"))
+        }
+
+        fn read_sfcc_sap_5_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_SAP_5"))
+        }
+
+        fn read_sfcc_sap_6_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_SAP_6"))
+        }
+
+        fn read_sfcc_sap_7_word(&mut self, num: u8) -> bool {
+            self.read_by_name(&format!("SFCC_{num}_SAP_7"))
+        }
+
         fn set_indicated_airspeed(mut self, indicated_airspeed: f64) -> Self {
             self.write_by_name("AIRSPEED INDICATED", indicated_airspeed);
             self
@@ -759,6 +787,34 @@ mod tests {
             self.query(|a| a.slat_flap_complex.sfcc[idx].flaps_channel.get_fap(6))
         }
 
+        fn get_sap_1(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].slats_channel.get_sap(0))
+        }
+
+        fn get_sap_2(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].slats_channel.get_sap(1))
+        }
+
+        fn get_sap_3(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].slats_channel.get_sap(2))
+        }
+
+        fn get_sap_4(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].slats_channel.get_sap(3))
+        }
+
+        fn get_sap_5(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].slats_channel.get_sap(4))
+        }
+
+        fn get_sap_6(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].slats_channel.get_sap(5))
+        }
+
+        fn get_sap_7(&self, idx: usize) -> bool {
+            self.query(|a| a.slat_flap_complex.sfcc[idx].slats_channel.get_sap(6))
+        }
+
         fn get_is_approaching_position(
             &self,
             demanded_angle: Angle,
@@ -838,6 +894,22 @@ mod tests {
         assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_5"));
         assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_6"));
         assert!(test_bed.contains_variable_with_name("SFCC_2_FAP_7"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SAP_1"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SAP_2"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SAP_3"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SAP_4"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SAP_5"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SAP_6"));
+        assert!(test_bed.contains_variable_with_name("SFCC_1_SAP_7"));
+
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SAP_1"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SAP_2"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SAP_3"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SAP_4"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SAP_5"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SAP_6"));
+        assert!(test_bed.contains_variable_with_name("SFCC_2_SAP_7"));
 
         assert!(test_bed.contains_variable_with_name("SFCC_1_FLAP_ACTUAL_POSITION_WORD"));
         assert!(test_bed.contains_variable_with_name("SFCC_2_FLAP_ACTUAL_POSITION_WORD"));
@@ -1037,6 +1109,193 @@ mod tests {
         assert!(test_bed.read_sfcc_fap_5_word(2));
         assert!(test_bed.read_sfcc_fap_6_word(2));
         assert!(test_bed.read_sfcc_fap_7_word(2));
+    }
+
+    #[test]
+    fn sfcc_saps() {
+        let mut test_bed = test_bed_with()
+            .set_green_hyd_pressure()
+            .set_yellow_hyd_pressure()
+            .set_blue_hyd_pressure()
+            .set_indicated_airspeed(0.)
+            .set_flaps_handle_position(0)
+            .run_one_tick();
+
+        assert!(test_bed.get_sap_1(0));
+        assert!(!test_bed.get_sap_2(0));
+        assert!(!test_bed.get_sap_3(0));
+        assert!(test_bed.get_sap_4(0));
+        assert!(!test_bed.get_sap_5(0));
+        assert!(!test_bed.get_sap_6(0));
+        assert!(!test_bed.get_sap_7(0));
+
+        assert!(test_bed.get_sap_1(1));
+        assert!(!test_bed.get_sap_2(1));
+        assert!(!test_bed.get_sap_3(1));
+        assert!(test_bed.get_sap_4(1));
+        assert!(!test_bed.get_sap_5(1));
+        assert!(!test_bed.get_sap_6(1));
+        assert!(!test_bed.get_sap_7(1));
+
+        assert!(test_bed.read_sfcc_sap_1_word(1));
+        assert!(!test_bed.read_sfcc_sap_2_word(1));
+        assert!(!test_bed.read_sfcc_sap_3_word(1));
+        assert!(test_bed.read_sfcc_sap_4_word(1));
+        assert!(!test_bed.read_sfcc_sap_5_word(1));
+        assert!(!test_bed.read_sfcc_sap_6_word(1));
+        assert!(!test_bed.read_sfcc_sap_7_word(1));
+
+        assert!(test_bed.read_sfcc_sap_1_word(2));
+        assert!(!test_bed.read_sfcc_sap_2_word(2));
+        assert!(!test_bed.read_sfcc_sap_3_word(2));
+        assert!(test_bed.read_sfcc_sap_4_word(2));
+        assert!(!test_bed.read_sfcc_sap_5_word(2));
+        assert!(!test_bed.read_sfcc_sap_6_word(2));
+        assert!(!test_bed.read_sfcc_sap_7_word(2));
+
+        test_bed = test_bed
+            .set_flaps_handle_position(1)
+            .run_waiting_for(Duration::from_secs(60));
+
+        assert!(!test_bed.get_sap_1(0));
+        assert!(test_bed.get_sap_2(0));
+        assert!(test_bed.get_sap_3(0));
+        assert!(!test_bed.get_sap_4(0));
+        assert!(test_bed.get_sap_5(0));
+        assert!(test_bed.get_sap_6(0));
+        assert!(!test_bed.get_sap_7(0));
+
+        assert!(!test_bed.get_sap_1(1));
+        assert!(test_bed.get_sap_2(1));
+        assert!(test_bed.get_sap_3(1));
+        assert!(!test_bed.get_sap_4(1));
+        assert!(test_bed.get_sap_5(1));
+        assert!(test_bed.get_sap_6(1));
+        assert!(!test_bed.get_sap_7(1));
+
+        assert!(!test_bed.read_sfcc_sap_1_word(1));
+        assert!(test_bed.read_sfcc_sap_2_word(1));
+        assert!(test_bed.read_sfcc_sap_3_word(1));
+        assert!(!test_bed.read_sfcc_sap_4_word(1));
+        assert!(test_bed.read_sfcc_sap_5_word(1));
+        assert!(test_bed.read_sfcc_sap_6_word(1));
+        assert!(!test_bed.read_sfcc_sap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_sap_1_word(2));
+        assert!(test_bed.read_sfcc_sap_2_word(2));
+        assert!(test_bed.read_sfcc_sap_3_word(2));
+        assert!(!test_bed.read_sfcc_sap_4_word(2));
+        assert!(test_bed.read_sfcc_sap_5_word(2));
+        assert!(test_bed.read_sfcc_sap_6_word(2));
+        assert!(!test_bed.read_sfcc_sap_7_word(2));
+
+        test_bed = test_bed
+            .set_flaps_handle_position(2)
+            .run_waiting_for(Duration::from_secs(60));
+
+        assert!(!test_bed.get_sap_1(0));
+        assert!(test_bed.get_sap_2(0));
+        assert!(test_bed.get_sap_3(0));
+        assert!(!test_bed.get_sap_4(0));
+        assert!(test_bed.get_sap_5(0));
+        assert!(test_bed.get_sap_6(0));
+        assert!(!test_bed.get_sap_7(0));
+
+        assert!(!test_bed.get_sap_1(1));
+        assert!(test_bed.get_sap_2(1));
+        assert!(test_bed.get_sap_3(1));
+        assert!(!test_bed.get_sap_4(1));
+        assert!(test_bed.get_sap_5(1));
+        assert!(test_bed.get_sap_6(1));
+        assert!(!test_bed.get_sap_7(1));
+
+        assert!(!test_bed.read_sfcc_sap_1_word(1));
+        assert!(test_bed.read_sfcc_sap_2_word(1));
+        assert!(test_bed.read_sfcc_sap_3_word(1));
+        assert!(!test_bed.read_sfcc_sap_4_word(1));
+        assert!(test_bed.read_sfcc_sap_5_word(1));
+        assert!(test_bed.read_sfcc_sap_6_word(1));
+        assert!(!test_bed.read_sfcc_sap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_sap_1_word(2));
+        assert!(test_bed.read_sfcc_sap_2_word(2));
+        assert!(test_bed.read_sfcc_sap_3_word(2));
+        assert!(!test_bed.read_sfcc_sap_4_word(2));
+        assert!(test_bed.read_sfcc_sap_5_word(2));
+        assert!(test_bed.read_sfcc_sap_6_word(2));
+        assert!(!test_bed.read_sfcc_sap_7_word(2));
+
+        test_bed = test_bed
+            .set_flaps_handle_position(3)
+            .run_waiting_for(Duration::from_secs(60));
+
+        assert!(!test_bed.get_sap_1(0));
+        assert!(test_bed.get_sap_2(0));
+        assert!(test_bed.get_sap_3(0));
+        assert!(!test_bed.get_sap_4(0));
+        assert!(test_bed.get_sap_5(0));
+        assert!(test_bed.get_sap_6(0));
+        assert!(!test_bed.get_sap_7(0));
+
+        assert!(!test_bed.get_sap_1(1));
+        assert!(test_bed.get_sap_2(1));
+        assert!(test_bed.get_sap_3(1));
+        assert!(!test_bed.get_sap_4(1));
+        assert!(test_bed.get_sap_5(1));
+        assert!(test_bed.get_sap_6(1));
+        assert!(!test_bed.get_sap_7(1));
+
+        assert!(!test_bed.read_sfcc_sap_1_word(1));
+        assert!(test_bed.read_sfcc_sap_2_word(1));
+        assert!(test_bed.read_sfcc_sap_3_word(1));
+        assert!(!test_bed.read_sfcc_sap_4_word(1));
+        assert!(test_bed.read_sfcc_sap_5_word(1));
+        assert!(test_bed.read_sfcc_sap_6_word(1));
+        assert!(!test_bed.read_sfcc_sap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_sap_1_word(2));
+        assert!(test_bed.read_sfcc_sap_2_word(2));
+        assert!(test_bed.read_sfcc_sap_3_word(2));
+        assert!(!test_bed.read_sfcc_sap_4_word(2));
+        assert!(test_bed.read_sfcc_sap_5_word(2));
+        assert!(test_bed.read_sfcc_sap_6_word(2));
+        assert!(!test_bed.read_sfcc_sap_7_word(2));
+
+        test_bed = test_bed
+            .set_flaps_handle_position(4)
+            .run_waiting_for(Duration::from_secs(60));
+
+        assert!(!test_bed.get_sap_1(0));
+        assert!(test_bed.get_sap_2(0));
+        assert!(test_bed.get_sap_3(0));
+        assert!(!test_bed.get_sap_4(0));
+        assert!(test_bed.get_sap_5(0));
+        assert!(test_bed.get_sap_6(0));
+        assert!(!test_bed.get_sap_7(0));
+
+        assert!(!test_bed.get_sap_1(1));
+        assert!(test_bed.get_sap_2(1));
+        assert!(test_bed.get_sap_3(1));
+        assert!(!test_bed.get_sap_4(1));
+        assert!(test_bed.get_sap_5(1));
+        assert!(test_bed.get_sap_6(1));
+        assert!(!test_bed.get_sap_7(1));
+
+        assert!(!test_bed.read_sfcc_sap_1_word(1));
+        assert!(test_bed.read_sfcc_sap_2_word(1));
+        assert!(test_bed.read_sfcc_sap_3_word(1));
+        assert!(!test_bed.read_sfcc_sap_4_word(1));
+        assert!(test_bed.read_sfcc_sap_5_word(1));
+        assert!(test_bed.read_sfcc_sap_6_word(1));
+        assert!(!test_bed.read_sfcc_sap_7_word(1));
+
+        assert!(!test_bed.read_sfcc_sap_1_word(2));
+        assert!(test_bed.read_sfcc_sap_2_word(2));
+        assert!(test_bed.read_sfcc_sap_3_word(2));
+        assert!(!test_bed.read_sfcc_sap_4_word(2));
+        assert!(test_bed.read_sfcc_sap_5_word(2));
+        assert!(test_bed.read_sfcc_sap_6_word(2));
+        assert!(!test_bed.read_sfcc_sap_7_word(2));
     }
 
     #[test]


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR adds the implementation of the SAP (Slat Actual Position) Discrete Outputs for the A320 SFCC.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
N/A

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
ATA27-50

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
To be merged after #10245

I would like to continue the work started in the draft PR https://github.com/flybywiresim/aircraft/pull/7632 which aims to rewrite the SFCC. Instead of making a big PR, I would like to make incremental changes.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): pythonist

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
This change improves the SFCC interface, no changes to the systems. Therefore, I don't see the need for testing instructions (happy to be suggested alternatives!)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
