### PR TITLE
fix(fdr): handle opendir fail

### DIFF
--- a/fbw-a32nx/src/wasm/fbw_a320/src/recording/FlightDataRecorder.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/recording/FlightDataRecorder.cpp
@@ -211,6 +211,10 @@ void FlightDataRecorder::cleanUpFlightDataRecorderFiles() {
 
   // open directory
   DIR* directory = opendir("\\work");
+  if (!directory) {
+    fprintf(stderr, "[FlightDataRecorder::getFlightDataRecorderFilename] Failed to open work dir!");
+    return;
+  }
 
   // read directory until end
   while ((directoryEntry = readdir(directory)) != NULL) {

--- a/fbw-a380x/src/wasm/fbw_a380/src/recording/FlightDataRecorder.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/recording/FlightDataRecorder.cpp
@@ -201,6 +201,10 @@ void FlightDataRecorder::cleanUpFlightDataRecorderFiles() {
 
   // open directory
   DIR* directory = opendir("\\work");
+  if (!directory) {
+    fprintf(stderr, "[FlightDataRecorder::getFlightDataRecorderFilename] Failed to open work dir!");
+    return;
+  }
 
   // read directory until end
   while ((directoryEntry = readdir(directory)) != NULL) {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Handle the failure if opendir fails and returns NULL. Fixes an infinite loop in readdir in SU4 beta.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
Devsupport post: https://devsupport.flightsimulator.com/t/su4-readdir-fails-when-theres-an-open-handle-on-child-file-entry/16720

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Spawn either A32NX or A380X in SU4 beta, and ensure it doesn't lock up the sim.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
