### PR TITLE
fix(fms): adjust fuel burn predictions to match engine model

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/A380AircraftConfig.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/A380AircraftConfig.ts
@@ -55,7 +55,7 @@ const flightModelParams: FlightModelParameters = {
 const engineModelParams: EngineModelParameters = {
   maxThrust: 80_213,
   numberOfEngines: 4,
-  fuelBurnFactor: 1.33,
+  fuelBurnFactor: 2.8,
   cn1ClimbLimit: [
     [-2000, 30.8, 56.87, 80.28, 72.0],
     [2000, 20.99, 48.157, 82.58, 74.159],

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/EngineModel.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/EngineModel.ts
@@ -100,10 +100,14 @@ export class EngineModel {
    * @returns fuel flow, in pounds per hour (per engine)
    */
   static getCorrectedFuelFlow(config: EngineModelParameters, cn1: number, mach: number, alt: number): number {
+    // These coefficients should match
+    // https://github.com/flybywiresim/aircraft/blob/80b2e662a101be890cee0010d1e4bc659ff375a6/fbw-a32nx/src/wasm/fadec_a32nx/src/Fadec/Polynomials_A32NX.hpp#L321
+    // https://github.com/flybywiresim/aircraft/blob/80b2e662a101be890cee0010d1e4bc659ff375a6/fbw-a380x/src/wasm/fadec_a380x/src/Fadec/Polynomials_A380X.hpp#L338
+    // TODO separate between A32NX and A380X
     const coefficients = [
-      -639.6602981, 0.0, 1.03705e2, -2.23264e3, 5.70316e-3, -2.29404, 1.0823e2, 2.77667e-4, -6.1718e2, -7.20713e-2,
-      2.19013e-7, 2.49418e-2, -7.31662e-1, -1.00003e-5, -3.79466e1, 1.34552e-3, 5.72612e-9, -2.7195e2, 8.58469e-2,
-      -2.72912e-6, 2.02928e-11,
+      -1.763e2, -2.1542e-1, 4.7119e1, 6.1519e2, 1.8047e-3, -4.4554e-1, -4.394e1, 4.0459e-5, -3.2912e1, -6.2894e-3,
+      -1.2544e-7, 1.0938e-2, 4.0936e-1, -5.5841e-6, -2.3829e1, 9.3269e-4, 2.0273e-11, -2.41e2, 1.4171e-2, -9.5581e-7,
+      1.2728e-11,
     ];
 
     const flow =

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/Predictions.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/Predictions.ts
@@ -339,7 +339,7 @@ export class Predictions {
     const theta2 = Common.getTheta2(theta, mach);
     const delta2 = Common.getDelta2(delta, mach);
     // Divide by 2 to get thrust per engine
-    const correctedThrust = thrust / delta2 / 2;
+    const correctedThrust = thrust / delta2 / config.engineModelParameters.numberOfEngines;
     // Since table 1506 describes corrected thrust as a fraction of max thrust, divide it
     const correctedN1 = EngineModel.reverseTableInterpolation(
       config.engineModelParameters.table1506,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Adjusts the fuel flow polynomial in the FMS to match the actual polynomial in the engine model
- Adjusts the fuel burn factor of the A380X to match the engine model
- Fixes a really bad bug where we assumed the A380 had two engines 😬
- Use a maximum step size of 10NM when running predictions for the cruise segment

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BlueberryKing

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Generate a SimBrief flight plan, program the same plan into the FMS, make sure the destination EFOB roughly matches as long as there are no significant enroute winds.
Do this for the A32NX and the A380X

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
