### PR TITLE
fix(fms): remove height requirement for approach phase activation when flying through DECEL

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -145,6 +145,7 @@
 1. [A380X] Autoflight: Add ROLLOUT fault (i.e. communication fault between NWS and PRIM) - @flogross89 (floridude)
 1. [A380X/CDS] Change autoland capability designation to Batch 7 standard (LAND instead of CAT) - @flogross89 (floridude)
 1. [A380X/FLIGHT and ENGINE MODELS] Fixed excessive descent rates and takeoff rotation issues, improved fuel burn - @donstim (donbikes)
+1. [FMS] Remove alttiude restriction for approach phase activation when overflying DECEL waypoint . @BravoMike99 (bruno_pt99)
 
 ## 0.13.0
 

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/lnav/PseudoWaypoints.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/lnav/PseudoWaypoints.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-// Copyright (c) 2021-2023 FlyByWire Simulations
+// Copyright (c) 2021-2025 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
 import { GuidanceComponent } from '@fmgc/guidance/GuidanceComponent';
@@ -256,13 +256,10 @@ export class PseudoWaypoints implements GuidanceComponent {
         break;
       case PseudoWaypointSequencingAction.APPROACH_PHASE_AUTO_ENGAGE: {
         const apLateralMode = SimVar.GetSimVarValue('L:A32NX_FMA_LATERAL_MODE', 'Number');
-        const agl = Simplane.getAltitudeAboveGround();
-
         if (
-          agl < 9500 &&
-          (apLateralMode === LateralMode.NAV ||
-            apLateralMode === LateralMode.LOC_CPT ||
-            apLateralMode === LateralMode.LOC_TRACK)
+          apLateralMode === LateralMode.NAV ||
+          apLateralMode === LateralMode.LOC_CPT ||
+          apLateralMode === LateralMode.LOC_TRACK
         ) {
           // Request APPROACH phase engagement for 5 seconds
           SimVar.SetSimVarValue('L:A32NX_FM_ENABLE_APPROACH_PHASE', 'Bool', true).then(() => [


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Removes the height requirement for approach phase activation when overflying pseudo DECEL waypoint.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
FCOM (comparison between R1A & R2)
<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): bruno_pt99

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Fly an approach with DECEL located above 9550AGL (e.g NIMER9E ODILO1A ILS 06 LFPO).
Fly through the DECEL pseudo point in NAV  mode and check that approach phase activates automatically.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
