### PR TITLE
perf(oans): reduce VRAM usage

### DIFF
--- a/fbw-a380x/src/systems/instruments/src/ND/OansControlPanel.tsx
+++ b/fbw-a380x/src/systems/instruments/src/ND/OansControlPanel.tsx
@@ -59,7 +59,7 @@ import { Coordinates, distanceTo, placeBearingDistance } from 'msfs-geo';
 import { AdirsSimVars } from 'instruments/src/MsfsAvionicsCommon/SimVarTypes';
 import { InternalKccuKeyEvent } from 'instruments/src/MFD/shared/MFDSimvarPublisher';
 import { NDSimvars } from 'instruments/src/ND/NDSimvarPublisher';
-import { Feature, Geometry, LineString, Point, Position } from '@turf/turf';
+import { Feature, Geometry, LineString, Point, Position } from 'geojson';
 import { NavigationDatabaseService } from '@fmgc/flightplanning/NavigationDatabaseService';
 import { NavigationDatabase, NavigationDatabaseBackend } from '@fmgc/NavigationDatabase';
 import { ResetPanelSimvars } from 'instruments/src/MsfsAvionicsCommon/providers/ResetPanelPublisher';

--- a/fbw-a380x/src/systems/systems-host/PseudoPRIM/BrakeToVacateDistanceUpdater.ts
+++ b/fbw-a380x/src/systems/systems-host/PseudoPRIM/BrakeToVacateDistanceUpdater.ts
@@ -11,7 +11,7 @@ import {
 } from '@flybywiresim/fbw-sdk';
 import { Arinc429Register, Arinc429SignStatusMatrix, MathUtils } from '@flybywiresim/fbw-sdk';
 import { placeBearingDistance } from 'msfs-geo';
-import { Position } from '@turf/turf';
+import { Position } from 'geojson';
 import { NavigationDatabaseService } from '@fmgc/flightplanning/NavigationDatabaseService';
 import { NavigationDatabase, NavigationDatabaseBackend } from '@fmgc/NavigationDatabase';
 import { OansFmsDataStore } from '@flybywiresim/fbw-sdk';

--- a/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
+++ b/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
@@ -161,15 +161,9 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
     FSComponent.createRef<HTMLCanvasElement>(),
     FSComponent.createRef<HTMLCanvasElement>(),
     FSComponent.createRef<HTMLCanvasElement>(),
-    FSComponent.createRef<HTMLCanvasElement>(),
-    FSComponent.createRef<HTMLCanvasElement>(),
-    FSComponent.createRef<HTMLCanvasElement>(),
   ];
 
   private readonly layerCanvasScaleContainerRefs = [
-    FSComponent.createRef<HTMLCanvasElement>(),
-    FSComponent.createRef<HTMLCanvasElement>(),
-    FSComponent.createRef<HTMLCanvasElement>(),
     FSComponent.createRef<HTMLCanvasElement>(),
     FSComponent.createRef<HTMLCanvasElement>(),
     FSComponent.createRef<HTMLCanvasElement>(),
@@ -214,9 +208,6 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
     featureCollection([]), // Layer 2: RUNWAY (with markings)
     featureCollection([]), // Layer 3: TAXIWAY GUIDANCE LINES (unscaled width)
     featureCollection([]), // Layer 4: TAXIWAY GUIDANCE LINES (scaled width), HOLD SHORT LINES
-    featureCollection([]), // Layer 5: RUNWAY (without markings)
-    featureCollection([]), // Layer 6: STAND GUIDANCE LINES (scaled width)
-    featureCollection([]), // Layer 7: DYNAMIC BTV CONTENT (BTV PATH, STOP LINES)
   ];
 
   public readonly amdbClient = new NavigraphAmdbClient();
@@ -340,7 +331,7 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
     this.labelManager,
     this.aircraftOnGround,
     this.projectedPpos,
-    this.layerCanvasRefs[7],
+    this.layerCanvasRefs[this.layerCanvasRefs.length - 1],
     this.canvasCentreX,
     this.canvasCentreY,
     this.zoomLevelIndex,
@@ -1154,6 +1145,7 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
     }
 
     this.aircraftOnGround.set(
+      // FIXME use an enum...
       ![6, 7, 8, 9].includes(SimVar.GetSimVarValue('L:A32NX_FWC_FLIGHT_PHASE', SimVarValueType.Number)),
     );
 

--- a/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
+++ b/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
@@ -122,7 +122,7 @@ export interface Label {
   style: LabelStyle;
   position: Position;
   rotation: number | undefined;
-  associatedFeature?: Feature<Geometry, AmdbProperties>;
+  associatedFeature?: AmdbFeature;
 }
 
 export interface ContextMenuItemData {
@@ -667,32 +667,29 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
       AmdbProjection.Epsg4326,
     );
 
-    const features = Object.values(data).reduce(
-      (acc, it) => {
-        const features = it.features.map((f) => {
-          // FeatureCollection
-          if (f.properties.idthr || f.properties.idrwy) {
-            const nf = Object.assign({}, f);
-            if (nf.properties.idthr && nf.properties.idthr.replace(/[^0-9]/g, '').length < 2) {
-              nf.properties.idthr = `0${nf.properties.idthr}`;
-            }
-
-            if (nf.properties.idrwy) {
-              nf.properties.idrwy = nf.properties.idrwy
-                .split('.')
-                .map((qfu) => (qfu.replace(/[^0-9]/g, '').length < 2 ? `0${qfu}` : qfu))
-                .join('.');
-            }
-
-            return nf;
+    const features = Object.values(data).reduce((acc, it) => {
+      const features = it.features.map((f) => {
+        // FeatureCollection
+        if (f.properties.idthr || f.properties.idrwy) {
+          const nf = Object.assign({}, f);
+          if (nf.properties.idthr && nf.properties.idthr.replace(/[^0-9]/g, '').length < 2) {
+            nf.properties.idthr = `0${nf.properties.idthr}`;
           }
-          return f;
-        });
 
-        return [...acc, ...features];
-      },
-      [] as Feature<Geometry, AmdbProperties>[],
-    );
+          if (nf.properties.idrwy) {
+            nf.properties.idrwy = nf.properties.idrwy
+              .split('.')
+              .map((qfu) => (qfu.replace(/[^0-9]/g, '').length < 2 ? `0${qfu}` : qfu))
+              .join('.');
+          }
+
+          return nf;
+        }
+        return f;
+      });
+
+      return [...acc, ...features];
+    }, [] as AmdbFeature[]);
     const airportMap: AmdbFeatureCollection = featureCollection(features);
 
     const wgs84ReferencePoint = wgs84ArpDat.aerodromereferencepoint?.features[0];
@@ -892,7 +889,7 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
     }
   }
 
-  private generateAllLabels(data: FeatureCollection<Geometry, AmdbProperties>) {
+  private generateAllLabels(data: AmdbFeatureCollection) {
     for (const feature of data.features) {
       if (!LABEL_FEATURE_TYPES.includes(feature.properties.feattype)) {
         continue;

--- a/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
+++ b/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
@@ -18,6 +18,7 @@ import {
   VNode,
   Wait,
 } from '@microsoft/msfs-sdk';
+
 import {
   AmdbFeatureCollection,
   AmdbFeatureTypeStrings,
@@ -37,20 +38,9 @@ import {
   OansFmsDataStore,
   OansMapProjection,
 } from '@flybywiresim/fbw-sdk';
-import {
-  bbox,
-  bboxPolygon,
-  booleanPointInPolygon,
-  centroid,
-  Feature,
-  featureCollection,
-  FeatureCollection,
-  Geometry,
-  LineString,
-  Point,
-  Polygon,
-  Position,
-} from '@turf/turf';
+
+import { bbox, bboxPolygon, booleanPointInPolygon, centroid, featureCollection } from '@turf/turf';
+import { Feature, FeatureCollection, Geometry, LineString, Point, Polygon, Position } from 'geojson';
 import { bearingTo, clampAngle, Coordinates, distanceTo, placeBearingDistance } from 'msfs-geo';
 
 import { OansControlEvents } from './OansControlEventPublisher';

--- a/fbw-common/src/systems/instruments/src/OANC/OancAircraftIcon.tsx
+++ b/fbw-common/src/systems/instruments/src/OANC/OancAircraftIcon.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 // Copyright (c) 2023-2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 

--- a/fbw-common/src/systems/instruments/src/OANC/OancArcModeCompass.tsx
+++ b/fbw-common/src/systems/instruments/src/OANC/OancArcModeCompass.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 // Copyright (c) 2023-2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 

--- a/fbw-common/src/systems/instruments/src/OANC/OancLabelManager.ts
+++ b/fbw-common/src/systems/instruments/src/OANC/OancLabelManager.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { clampAngle } from 'msfs-geo';
-import { Feature, LineString } from '@turf/turf';
+import { Feature, LineString } from 'geojson';
 import { ArraySubject } from '@microsoft/msfs-sdk';
 import { MathUtils, OansFmsDataStore } from '@flybywiresim/fbw-sdk';
 import { filterLabel, labelStyle, OancLabelFilter } from './OancLabelFilter';

--- a/fbw-common/src/systems/instruments/src/OANC/OancMapUtils.ts
+++ b/fbw-common/src/systems/instruments/src/OANC/OancMapUtils.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { MathUtils } from '@flybywiresim/fbw-sdk';
-import { Position } from '@turf/turf';
+import { Position } from 'geojson';
 import { clampAngle } from 'msfs-geo';
 
 export function fractionalPointAlongLine(

--- a/fbw-common/src/systems/instruments/src/OANC/OancMarkerManager.ts
+++ b/fbw-common/src/systems/instruments/src/OANC/OancMarkerManager.ts
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { ArraySubject, EventBus } from '@microsoft/msfs-sdk';
-import { along, Feature, Geometry, length, LineString, Point, Position } from '@turf/turf';
+import { along, length } from '@turf/turf';
+import { LineString, Point, Position } from 'geojson';
 import { Label, LabelStyle, Oanc, OansControlEvents } from './';
 import { OancLabelManager } from './OancLabelManager';
-import { AmdbProperties, FeatureType } from '@flybywiresim/fbw-sdk';
+import { AmdbFeature, FeatureType } from '@flybywiresim/fbw-sdk';
 
 const MAX_SYMBOL_DIST_NEIGHBORHOOD_SEARCH = 20;
 const TAXIWAY_SYMBOL_SPACING = 250;
@@ -27,7 +28,7 @@ export class OancMarkerManager<T extends number> {
   private nextCrossId = 0;
   private nextFlagId = 0;
 
-  addCross(coords: Position, feature?: Feature<Geometry, AmdbProperties>) {
+  addCross(coords: Position, feature?: AmdbFeature) {
     const crossSymbolLabel: Label = {
       text: (this.nextCrossId++).toString(),
       style: LabelStyle.CrossSymbol,
@@ -40,7 +41,7 @@ export class OancMarkerManager<T extends number> {
     this.crosses.insert(crossSymbolLabel);
   }
 
-  addFlag(coords: Position, feature?: Feature<Geometry, AmdbProperties>) {
+  addFlag(coords: Position, feature?: AmdbFeature) {
     const flagSymbolLabel: Label = {
       text: (this.nextFlagId++).toString(),
       style: LabelStyle.FlagSymbol,
@@ -132,7 +133,7 @@ export class OancMarkerManager<T extends number> {
   addSymbolAtFeature(
     id: number,
     feattype: FeatureType,
-    addFunction: (coords: Position, feature?: Feature<Geometry, AmdbProperties>) => void,
+    addFunction: (coords: Position, feature?: AmdbFeature) => void,
   ) {
     // Find feature by id in loaded airport data
     const feature = this.oanc.data?.features.filter(

--- a/fbw-common/src/systems/instruments/src/OANC/OancMovingModeOverlay.tsx
+++ b/fbw-common/src/systems/instruments/src/OANC/OancMovingModeOverlay.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 // Copyright (c) 2023-2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 

--- a/fbw-common/src/systems/instruments/src/OANC/OancPlanModeCompass.tsx
+++ b/fbw-common/src/systems/instruments/src/OANC/OancPlanModeCompass.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 // Copyright (c) 2023-2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 

--- a/fbw-common/src/systems/instruments/src/OANC/OancPositionComputer.ts
+++ b/fbw-common/src/systems/instruments/src/OANC/OancPositionComputer.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { FeatureType } from '@flybywiresim/fbw-sdk';
-import { booleanPointInPolygon, Polygon } from '@turf/turf';
+
+import { booleanPointInPolygon } from '@turf/turf';
+import { Polygon } from 'geojson';
 import { Oanc } from './Oanc';
 
 const OANC_VALID_POSITION_INDICATION_FEATURE_TYPES = [

--- a/fbw-common/src/systems/instruments/src/OANC/OancRoseCompass.tsx
+++ b/fbw-common/src/systems/instruments/src/OANC/OancRoseCompass.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 // Copyright (c) 2023-2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 

--- a/fbw-common/src/systems/instruments/src/OANC/OansBrakeToVacateSelection.ts
+++ b/fbw-common/src/systems/instruments/src/OANC/OansBrakeToVacateSelection.ts
@@ -3,6 +3,7 @@
 
 import { ConsumerSubject, EventBus, MappedSubject, NodeReference, Subject, Subscribable } from '@microsoft/msfs-sdk';
 import {
+  AmdbFeature,
   AmdbProperties,
   Arinc429LocalVarConsumerSubject,
   BTV_MIN_TOUCHDOWN_ZONE_DISTANCE,
@@ -10,19 +11,8 @@ import {
   OansMapProjection,
   Runway,
 } from '@flybywiresim/fbw-sdk';
-import {
-  booleanContains,
-  booleanDisjoint,
-  Feature,
-  FeatureCollection,
-  Geometry,
-  lineOffset,
-  lineString,
-  point,
-  polygon,
-  Polygon,
-  Position,
-} from '@turf/turf';
+import { booleanContains, booleanDisjoint, lineOffset, lineString, point, polygon } from '@turf/turf';
+import { FeatureCollection, Geometry, Polygon, Position } from 'geojson';
 import { Arinc429Register, Arinc429SignStatusMatrix, MathUtils } from '@flybywiresim/fbw-sdk';
 import { Label, LabelStyle } from '.';
 import { BtvData } from '../../../shared/src/publishers/OansBtv/BtvPublisher';
@@ -170,12 +160,10 @@ export class OansBrakeToVacateSelection<T extends number> {
     this.fwsFlightPhase,
   );
 
-  selectRunwayFromOans(
-    runway: string,
-    centerlineFeature: Feature<Geometry, AmdbProperties>,
-    thresholdFeature: Feature<Geometry, AmdbProperties>,
-  ) {
+  selectRunwayFromOans(runway: string, centerlineFeature: AmdbFeature, thresholdFeature: AmdbFeature) {
     this.clearSelection();
+
+    // FIXME specify geometry in types instead of casting
 
     // Select opposite threshold location
     const thrLoc = thresholdFeature.geometry.coordinates as Position;
@@ -216,7 +204,7 @@ export class OansBrakeToVacateSelection<T extends number> {
     this.drawBtvLayer();
   }
 
-  selectExitFromOans(exit: string, feature: Feature<Geometry, AmdbProperties>) {
+  selectExitFromOans(exit: string, feature: AmdbFeature) {
     if (this.btvRunway.get() == null || !this.btvThresholdPosition || !this.btvOppositeThresholdPosition) {
       return;
     }

--- a/fbw-common/src/systems/instruments/src/OANC/OansControlEventPublisher.ts
+++ b/fbw-common/src/systems/instruments/src/OANC/OansControlEventPublisher.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { EfisSide, FeatureType } from '@flybywiresim/fbw-sdk';
-import { Position } from '@turf/turf';
+import { Position } from 'geojson';
 
 export interface OansControlEvents {
   nd_show_oans: { side: EfisSide; show: boolean };

--- a/fbw-common/src/systems/instruments/src/OANC/style-data.ts
+++ b/fbw-common/src/systems/instruments/src/OANC/style-data.ts
@@ -3,113 +3,172 @@
 
 import { FeatureType, PolygonalStructureType } from '@flybywiresim/fbw-sdk';
 
-export interface StyleRule {
-  forFeatureTypes?: FeatureType[];
+export interface LayerSpecification {
+  renderScale: number;
 
-  forPolygonStructureTypes?: PolygonalStructureType[];
+  zoomLevelVisibilities: [boolean, boolean, boolean, boolean, boolean];
 
-  dontFetchFromAmdb?: boolean;
-
-  styles: {
-    doStroke: boolean;
-
-    doFill: boolean;
-
-    strokeStyle?: string;
-
-    lineWidth?: number;
-
-    fillStyle?: string;
-  };
+  styleRules: StyleRule[];
 }
 
-export const STYLE_DATA: Record<number, StyleRule[]> = {
-  0: [
-    {
-      forFeatureTypes: [FeatureType.TaxiwayElement],
-      styles: { doStroke: false, doFill: true, fillStyle: '#8f8f8f' },
-    },
-    {
-      forFeatureTypes: [FeatureType.TaxiwayShoulder],
-      styles: { doStroke: false, doFill: true, fillStyle: '#85451d' },
-    },
-    {
-      forFeatureTypes: [FeatureType.ServiceRoad],
-      styles: { doStroke: false, doFill: true, fillStyle: '#b59824' },
-    },
-  ],
-  1: [
-    {
-      forFeatureTypes: [FeatureType.ApronElement],
-      styles: { doStroke: false, doFill: true, fillStyle: '#545454' },
-    },
-    {
-      forFeatureTypes: [FeatureType.ParkingStandArea],
-      styles: { doStroke: false, doFill: true, fillStyle: '#778585' },
-    },
-    {
-      forFeatureTypes: [FeatureType.VerticalPolygonalStructure],
-      forPolygonStructureTypes: [PolygonalStructureType.TerminalBuilding],
-      styles: { doStroke: false, doFill: true, fillStyle: '#00ffff' },
-    },
-    {
-      forFeatureTypes: [FeatureType.VerticalPolygonalStructure],
-      forPolygonStructureTypes: [PolygonalStructureType.NonTerminalBuilding],
-      styles: { doStroke: false, doFill: true, fillStyle: '#3286da' },
-    },
-  ],
-  2: [
-    {
-      forFeatureTypes: [
-        FeatureType.RunwayElement,
-        FeatureType.RunwayIntersection,
-        FeatureType.BlastPad,
-        FeatureType.RunwayDisplacedArea,
-        FeatureType.Stopway,
-      ],
-      styles: { doStroke: false, doFill: true, fillStyle: 'gray' },
-    },
-    {
-      forFeatureTypes: [FeatureType.RunwayMarking],
-      styles: { doStroke: false, doFill: true, fillStyle: '#ffffff' },
-    },
-    {
-      forFeatureTypes: [FeatureType.RunwayShoulder],
-      styles: { doStroke: false, doFill: true, fillStyle: '#85451d' },
-    },
-  ],
-  3: [
-    {
-      forFeatureTypes: [FeatureType.TaxiwayGuidanceLine, FeatureType.RunwayExitLine],
-      styles: { doStroke: true, doFill: false, strokeStyle: '#ffff00', lineWidth: 1.85 },
-    },
-    {
-      forFeatureTypes: [FeatureType.TaxiwayHoldingPosition],
-      styles: { doStroke: true, doFill: false, strokeStyle: '#ff2f00' },
-    },
-  ],
-  4: [
-    {
-      forFeatureTypes: [FeatureType.TaxiwayGuidanceLine, FeatureType.RunwayExitLine],
-      styles: { doStroke: true, doFill: false, strokeStyle: '#666666', lineWidth: 8 },
-    },
-  ],
-  5: [
-    {
-      forFeatureTypes: [
-        FeatureType.RunwayElement,
-        FeatureType.RunwayIntersection,
-        FeatureType.RunwayDisplacedArea,
-        FeatureType.Stopway,
-      ],
-      styles: { doStroke: false, doFill: true, fillStyle: '#ffffff' },
-    },
-  ],
-  6: [
-    {
-      forFeatureTypes: [FeatureType.StandGuidanceLine],
-      styles: { doStroke: true, doFill: false, strokeStyle: '#ffff00', lineWidth: 1.85 },
-    },
-  ],
-  7: [],
+export interface StyleRule {
+  /** An array of feature types that this rule applies to */
+  forFeatureTypes?: FeatureType[];
+
+  /** If {@link forFeatureTypes} is {@link FeatureType.VerticalPolygonalStructure}, an array that filters out which features to draw */
+  forPolygonStructureTypes?: PolygonalStructureType[];
+
+  /** If `true`, the feature won't be fetched from the AMDB */
+  dontFetchFromAmdb?: boolean;
+
+  /** The styles to apply */
+  styles: StyleData;
+}
+
+export interface StyleData {
+  /** Whether to stroke the feature */
+  doStroke: boolean;
+
+  /** Whether to fill the feature */
+  doFill: boolean;
+
+  /** The canvas style with which to stroke the feature */
+  strokeStyle?: string;
+
+  /** The line width to stroke the feature with */
+  lineWidth?: number;
+
+  /** The canvas style with which to fill the feature */
+  fillStyle?: string;
+}
+
+export const LAYER_SPECIFICATIONS: Record<number, LayerSpecification> = {
+  0: {
+    // Layer 0: TAXIWAY BG + TAXIWAY SHOULDER
+    renderScale: 1.0,
+    zoomLevelVisibilities: [true, true, false, false, false],
+    styleRules: [
+      {
+        forFeatureTypes: [FeatureType.TaxiwayElement],
+        styles: { doStroke: false, doFill: true, fillStyle: '#8f8f8f' },
+      },
+      {
+        forFeatureTypes: [FeatureType.TaxiwayShoulder],
+        styles: { doStroke: false, doFill: true, fillStyle: '#85451d' },
+      },
+      {
+        forFeatureTypes: [FeatureType.ServiceRoad],
+        styles: { doStroke: false, doFill: true, fillStyle: '#b59824' },
+      },
+    ],
+  },
+  1: {
+    // Layer 1: APRON + STAND BG + BUILDINGS (terminal only)
+    renderScale: 1.0,
+    zoomLevelVisibilities: [true, true, true, true, true],
+    styleRules: [
+      {
+        forFeatureTypes: [FeatureType.ApronElement],
+        styles: { doStroke: false, doFill: true, fillStyle: '#545454' },
+      },
+      {
+        forFeatureTypes: [FeatureType.ParkingStandArea],
+        styles: { doStroke: false, doFill: true, fillStyle: '#778585' },
+      },
+      {
+        forFeatureTypes: [FeatureType.VerticalPolygonalStructure],
+        forPolygonStructureTypes: [PolygonalStructureType.TerminalBuilding],
+        styles: { doStroke: false, doFill: true, fillStyle: '#00ffff' },
+      },
+      {
+        forFeatureTypes: [FeatureType.VerticalPolygonalStructure],
+        forPolygonStructureTypes: [PolygonalStructureType.NonTerminalBuilding],
+        styles: { doStroke: false, doFill: true, fillStyle: '#3286da' },
+      },
+    ],
+  },
+  2: {
+    // Layer 2: RUNWAY (with markings)
+    renderScale: 1.0,
+    zoomLevelVisibilities: [true, true, false, false, false],
+    styleRules: [
+      {
+        forFeatureTypes: [
+          FeatureType.RunwayElement,
+          FeatureType.RunwayIntersection,
+          FeatureType.BlastPad,
+          FeatureType.RunwayDisplacedArea,
+          FeatureType.Stopway,
+        ],
+        styles: { doStroke: false, doFill: true, fillStyle: 'gray' },
+      },
+      {
+        forFeatureTypes: [FeatureType.RunwayMarking],
+        styles: { doStroke: false, doFill: true, fillStyle: '#ffffff' },
+      },
+      {
+        forFeatureTypes: [FeatureType.RunwayShoulder],
+        styles: { doStroke: false, doFill: true, fillStyle: '#85451d' },
+      },
+    ],
+  },
+  3: {
+    // Layer 3: TAXIWAY GUIDANCE LINES (scaled width), HOLD SHORT LINES
+    renderScale: 1.0,
+    zoomLevelVisibilities: [true, true, false, false, false],
+    styleRules: [
+      {
+        forFeatureTypes: [FeatureType.TaxiwayGuidanceLine, FeatureType.RunwayExitLine],
+        styles: { doStroke: true, doFill: false, strokeStyle: '#ffff00', lineWidth: 1.85 },
+      },
+      {
+        forFeatureTypes: [FeatureType.TaxiwayHoldingPosition],
+        styles: { doStroke: true, doFill: false, strokeStyle: '#ff2f00' },
+      },
+    ],
+  },
+  4: {
+    // Layer 4: TAXIWAY GUIDANCE LINES (unscaled width)
+    renderScale: 0.25,
+    zoomLevelVisibilities: [false, false, true, true, true],
+    styleRules: [
+      {
+        forFeatureTypes: [FeatureType.TaxiwayGuidanceLine, FeatureType.RunwayExitLine],
+        styles: { doStroke: true, doFill: false, strokeStyle: '#666666', lineWidth: 8 },
+      },
+    ],
+  },
+  5: {
+    // Layer 5: RUNWAY (without markings)
+    renderScale: 0.25,
+    zoomLevelVisibilities: [false, false, true, true, true],
+    styleRules: [
+      {
+        forFeatureTypes: [
+          FeatureType.RunwayElement,
+          FeatureType.RunwayIntersection,
+          FeatureType.RunwayDisplacedArea,
+          FeatureType.Stopway,
+        ],
+        styles: { doStroke: false, doFill: true, fillStyle: '#ffffff' },
+      },
+    ],
+  },
+  6: {
+    // Layer 6: STAND GUIDANCE LINES (scaled width)
+    renderScale: 1.0,
+    zoomLevelVisibilities: [true, false, false, false, false],
+    styleRules: [
+      {
+        forFeatureTypes: [FeatureType.StandGuidanceLine],
+        styles: { doStroke: true, doFill: false, strokeStyle: '#ffff00', lineWidth: 1.85 },
+      },
+    ],
+  },
+  7: {
+    // Layer 7: DYNAMIC BTV CONTENT (BTV PATH, STOP LINES)
+    renderScale: 1.0,
+    zoomLevelVisibilities: [true, true, true, true, true],
+    styleRules: [],
+  },
 };

--- a/fbw-common/src/systems/instruments/src/OANC/style-data.ts
+++ b/fbw-common/src/systems/instruments/src/OANC/style-data.ts
@@ -1,13 +1,16 @@
 // Copyright (c) 2023-2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
-import { FeatureType, PolygonalStructureType } from '@flybywiresim/fbw-sdk';
+import { AmdbProperties, FeatureType, PolygonalStructureType } from '@flybywiresim/fbw-sdk';
 
 export interface LayerSpecification {
+  /** The scale at which to render this layer, as a multiple of the total size (in projected coordinates) of the entire airport map */
   renderScale: number;
 
+  /** The visibility of this layer at each OANS zoom level */
   zoomLevelVisibilities: [boolean, boolean, boolean, boolean, boolean];
 
+  /** The styling rules for this layer  */
   styleRules: StyleRule[];
 }
 
@@ -20,6 +23,12 @@ export interface StyleRule {
 
   /** If `true`, the feature won't be fetched from the AMDB */
   dontFetchFromAmdb?: boolean;
+
+  /** If applicable, how to union features this rule applies to. Only valid for polygons. */
+  unionBy?: keyof AmdbProperties | 'all';
+
+  /** If provided, the tolerance with which to simplify features. If not provided, the feature is not simplified. */
+  simplify?: number;
 
   /** The styles to apply */
   styles: StyleData;
@@ -131,12 +140,7 @@ export const LAYER_SPECIFICATIONS: Record<number, LayerSpecification> = {
     // Layer 4: TAXIWAY GUIDANCE LINES (unscaled width)
     renderScale: 0.25,
     zoomLevelVisibilities: [false, false, true, true, true],
-    styleRules: [
-      {
-        forFeatureTypes: [FeatureType.TaxiwayGuidanceLine, FeatureType.RunwayExitLine],
-        styles: { doStroke: true, doFill: false, strokeStyle: '#666666', lineWidth: 8 },
-      },
-    ],
+    styleRules: [],
   },
   5: {
     // Layer 5: RUNWAY (without markings)
@@ -144,12 +148,18 @@ export const LAYER_SPECIFICATIONS: Record<number, LayerSpecification> = {
     zoomLevelVisibilities: [false, false, true, true, true],
     styleRules: [
       {
+        forFeatureTypes: [FeatureType.TaxiwayGuidanceLine, FeatureType.RunwayExitLine],
+        styles: { doStroke: true, doFill: false, strokeStyle: '#666666', lineWidth: 8 },
+      },
+      {
         forFeatureTypes: [
           FeatureType.RunwayElement,
           FeatureType.RunwayIntersection,
           FeatureType.RunwayDisplacedArea,
           FeatureType.Stopway,
         ],
+        unionBy: 'all',
+        simplify: 0.1,
         styles: { doStroke: false, doFill: true, fillStyle: '#ffffff' },
       },
     ],

--- a/fbw-common/src/systems/instruments/src/OANC/style-data.ts
+++ b/fbw-common/src/systems/instruments/src/OANC/style-data.ts
@@ -53,7 +53,7 @@ export interface StyleData {
 
 export const LAYER_SPECIFICATIONS: Record<number, LayerSpecification> = {
   0: {
-    // Layer 0: TAXIWAY BG + TAXIWAY SHOULDER
+    // Layer 0: TAXIWAYS (scaled), SERVICE ROADS, RUNWAYS (with markings), TAXI LINES, HOLD SHORT LINES
     renderScale: 1.0,
     zoomLevelVisibilities: [true, true, false, false, false],
     styleRules: [
@@ -68,6 +68,32 @@ export const LAYER_SPECIFICATIONS: Record<number, LayerSpecification> = {
       {
         forFeatureTypes: [FeatureType.ServiceRoad],
         styles: { doStroke: false, doFill: true, fillStyle: '#b59824' },
+      },
+      {
+        forFeatureTypes: [
+          FeatureType.RunwayElement,
+          FeatureType.RunwayIntersection,
+          FeatureType.BlastPad,
+          FeatureType.RunwayDisplacedArea,
+          FeatureType.Stopway,
+        ],
+        styles: { doStroke: false, doFill: true, fillStyle: 'gray' },
+      },
+      {
+        forFeatureTypes: [FeatureType.RunwayMarking],
+        styles: { doStroke: false, doFill: true, fillStyle: '#ffffff' },
+      },
+      {
+        forFeatureTypes: [FeatureType.RunwayShoulder],
+        styles: { doStroke: false, doFill: true, fillStyle: '#85451d' },
+      },
+      {
+        forFeatureTypes: [FeatureType.TaxiwayGuidanceLine, FeatureType.RunwayExitLine],
+        styles: { doStroke: true, doFill: false, strokeStyle: '#ffff00', lineWidth: 1.85 },
+      },
+      {
+        forFeatureTypes: [FeatureType.TaxiwayHoldingPosition],
+        styles: { doStroke: true, doFill: false, strokeStyle: '#ff2f00' },
       },
     ],
   },
@@ -97,53 +123,7 @@ export const LAYER_SPECIFICATIONS: Record<number, LayerSpecification> = {
     ],
   },
   2: {
-    // Layer 2: RUNWAY (with markings)
-    renderScale: 1.0,
-    zoomLevelVisibilities: [true, true, false, false, false],
-    styleRules: [
-      {
-        forFeatureTypes: [
-          FeatureType.RunwayElement,
-          FeatureType.RunwayIntersection,
-          FeatureType.BlastPad,
-          FeatureType.RunwayDisplacedArea,
-          FeatureType.Stopway,
-        ],
-        styles: { doStroke: false, doFill: true, fillStyle: 'gray' },
-      },
-      {
-        forFeatureTypes: [FeatureType.RunwayMarking],
-        styles: { doStroke: false, doFill: true, fillStyle: '#ffffff' },
-      },
-      {
-        forFeatureTypes: [FeatureType.RunwayShoulder],
-        styles: { doStroke: false, doFill: true, fillStyle: '#85451d' },
-      },
-    ],
-  },
-  3: {
-    // Layer 3: TAXIWAY GUIDANCE LINES (scaled width), HOLD SHORT LINES
-    renderScale: 1.0,
-    zoomLevelVisibilities: [true, true, false, false, false],
-    styleRules: [
-      {
-        forFeatureTypes: [FeatureType.TaxiwayGuidanceLine, FeatureType.RunwayExitLine],
-        styles: { doStroke: true, doFill: false, strokeStyle: '#ffff00', lineWidth: 1.85 },
-      },
-      {
-        forFeatureTypes: [FeatureType.TaxiwayHoldingPosition],
-        styles: { doStroke: true, doFill: false, strokeStyle: '#ff2f00' },
-      },
-    ],
-  },
-  4: {
-    // Layer 4: TAXIWAY GUIDANCE LINES (unscaled width)
-    renderScale: 0.25,
-    zoomLevelVisibilities: [false, false, true, true, true],
-    styleRules: [],
-  },
-  5: {
-    // Layer 5: RUNWAY (without markings)
+    // Layer 2: RUNWAYS (without markings)
     renderScale: 0.25,
     zoomLevelVisibilities: [false, false, true, true, true],
     styleRules: [
@@ -164,8 +144,8 @@ export const LAYER_SPECIFICATIONS: Record<number, LayerSpecification> = {
       },
     ],
   },
-  6: {
-    // Layer 6: STAND GUIDANCE LINES (scaled width)
+  3: {
+    // Layer 3: STAND GUIDANCE LINES (scaled)
     renderScale: 1.0,
     zoomLevelVisibilities: [true, false, false, false, false],
     styleRules: [
@@ -175,8 +155,8 @@ export const LAYER_SPECIFICATIONS: Record<number, LayerSpecification> = {
       },
     ],
   },
-  7: {
-    // Layer 7: DYNAMIC BTV CONTENT (BTV PATH, STOP LINES)
+  4: {
+    // Layer 4: DYNAMIC BTV CONTENT (BTV PATH, STOP LINES)
     renderScale: 1.0,
     zoomLevelVisibilities: [true, true, true, true, true],
     styleRules: [],

--- a/fbw-common/src/systems/instruments/src/OANC/style-data.ts
+++ b/fbw-common/src/systems/instruments/src/OANC/style-data.ts
@@ -27,7 +27,7 @@ export interface StyleRule {
   /** If applicable, how to union features this rule applies to. Only valid for polygons. */
   unionBy?: keyof AmdbProperties | 'all';
 
-  /** If provided, the tolerance with which to simplify features. If not provided, the feature is not simplified. */
+  /** If provided, the tolerance with which to simplify features, in units of projected coordinates. If not provided, the feature is not simplified. */
   simplify?: number;
 
   /** The styles to apply */

--- a/fbw-common/src/systems/oans/OansMapProjection.ts
+++ b/fbw-common/src/systems/oans/OansMapProjection.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
-import { Position } from '@turf/turf';
+import { Position } from 'geojson';
 import { bearingTo, Coordinates, distanceTo } from 'msfs-geo';
 import { MathUtils } from '../shared/src/MathUtils';
 

--- a/fbw-common/src/systems/shared/src/amdb.ts
+++ b/fbw-common/src/systems/shared/src/amdb.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2021-2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
-import { FeatureCollection, Geometry, Point } from '@turf/turf';
+import { FeatureCollection, Geometry, Point } from 'geojson';
 import { LatLonInterface } from '@microsoft/msfs-sdk';
 
 export enum AmdbProjection {

--- a/fbw-common/src/systems/shared/src/amdb.ts
+++ b/fbw-common/src/systems/shared/src/amdb.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2021-2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
-import { Feature, FeatureCollection, Geometry, Point } from 'geojson';
+import { Feature, FeatureCollection, Geometry, GeometryCollection, Point } from 'geojson';
 import { LatLonInterface } from '@microsoft/msfs-sdk';
 
 export enum AmdbProjection {
@@ -187,9 +187,11 @@ export interface AmdbProperties {
   midpoint?: Point;
 }
 
-export type AmdbFeature<GeometryType extends Geometry = Geometry> = Feature<GeometryType, AmdbProperties>;
+export type AmdbGeometry = Exclude<Geometry, GeometryCollection>;
 
-export type AmdbFeatureCollection = FeatureCollection<Geometry, AmdbProperties>;
+export type AmdbFeature<GeometryType extends Geometry = AmdbGeometry> = Feature<GeometryType, AmdbProperties>;
+
+export type AmdbFeatureCollection = FeatureCollection<AmdbGeometry, AmdbProperties>;
 
 export type AmdbResponse = Partial<Record<FeatureTypeString, AmdbFeatureCollection>>;
 

--- a/fbw-common/src/systems/shared/src/amdb.ts
+++ b/fbw-common/src/systems/shared/src/amdb.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2021-2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
-import { FeatureCollection, Geometry, Point } from 'geojson';
+import { Feature, FeatureCollection, Geometry, Point } from 'geojson';
 import { LatLonInterface } from '@microsoft/msfs-sdk';
 
 export enum AmdbProjection {
@@ -186,6 +186,8 @@ export interface AmdbProperties {
 
   midpoint?: Point;
 }
+
+export type AmdbFeature<GeometryType extends Geometry = Geometry> = Feature<GeometryType, AmdbProperties>;
 
 export type AmdbFeatureCollection = FeatureCollection<Geometry, AmdbProperties>;
 

--- a/fbw-common/src/systems/shared/src/publishers/OansBtv/FmsOansPublisher.ts
+++ b/fbw-common/src/systems/shared/src/publishers/OansBtv/FmsOansPublisher.ts
@@ -3,7 +3,7 @@
 
 import { ArincEventBus } from '@flybywiresim/fbw-sdk';
 import { SimVarPublisher, SimVarDefinition, SimVarValueType } from '@microsoft/msfs-sdk';
-import { Position } from '@turf/turf';
+import { Position } from 'geojson';
 
 /**
  * Transmitted from FMS to OANS

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "@sentry/integrations": "^6.17.7",
     "@sentry/tracing": "^6.17.7",
     "@tabler/icons": "^1.41.2",
-    "@turf/turf": "^6.5.0",
+    "@turf/turf": "^7.2.0",
     "@types/react-canvas-draw": "^1.1.1",
     "byte-data": "^19.0.1",
     "classnames": "^2.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^1.41.2
         version: 1.119.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@turf/turf':
-        specifier: ^6.5.0
-        version: 6.5.0
+        specifier: ^7.2.0
+        version: 7.2.0
       '@types/react-canvas-draw':
         specifier: ^1.1.1
         version: 1.2.3
@@ -1807,326 +1807,353 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
-  '@turf/along@6.5.0':
-    resolution: {integrity: sha512-LLyWQ0AARqJCmMcIEAXF4GEu8usmd4Kbz3qk1Oy5HoRNpZX47+i5exQtmIWKdqJ1MMhW26fCTXgpsEs5zgJ5gw==}
+  '@turf/along@7.2.0':
+    resolution: {integrity: sha512-Cf+d2LozABdb0TJoIcJwFKB+qisJY4nMUW9z6PAuZ9UCH7AR//hy2Z06vwYCKFZKP4a7DRPkOMBadQABCyoYuw==}
 
-  '@turf/angle@6.5.0':
-    resolution: {integrity: sha512-4pXMbWhFofJJAOvTMCns6N4C8CMd5Ih4O2jSAG9b3dDHakj3O4yN1+Zbm+NUei+eVEZ9gFeVp9svE3aMDenIkw==}
+  '@turf/angle@7.2.0':
+    resolution: {integrity: sha512-b28rs1NO8Dt/MXadFhnpqH7GnEWRsl+xF5JeFtg9+eM/+l/zGrdliPYMZtAj12xn33w22J1X4TRprAI0rruvVQ==}
 
-  '@turf/area@6.5.0':
-    resolution: {integrity: sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==}
+  '@turf/area@7.2.0':
+    resolution: {integrity: sha512-zuTTdQ4eoTI9nSSjerIy4QwgvxqwJVciQJ8tOPuMHbXJ9N/dNjI7bU8tasjhxas/Cx3NE9NxVHtNpYHL0FSzoA==}
 
-  '@turf/bbox-clip@6.5.0':
-    resolution: {integrity: sha512-F6PaIRF8WMp8EmgU/Ke5B1Y6/pia14UAYB5TiBC668w5rVVjy5L8rTm/m2lEkkDMHlzoP9vNY4pxpNthE7rLcQ==}
+  '@turf/bbox-clip@7.2.0':
+    resolution: {integrity: sha512-q6RXTpqeUQAYLAieUL1n3J6ukRGsNVDOqcYtfzaJbPW+0VsAf+1cI16sN700t0sekbeU1DH/RRVAHhpf8+36wA==}
 
-  '@turf/bbox-polygon@6.5.0':
-    resolution: {integrity: sha512-+/r0NyL1lOG3zKZmmf6L8ommU07HliP4dgYToMoTxqzsWzyLjaj/OzgQ8rBmv703WJX+aS6yCmLuIhYqyufyuw==}
+  '@turf/bbox-polygon@7.2.0':
+    resolution: {integrity: sha512-Aj4G1GAAy26fmOqMjUk0Z+Lcax5VQ9g1xYDbHLQWXvfTsaueBT+RzdH6XPnZ/seEEnZkio2IxE8V5af/osupgA==}
 
-  '@turf/bbox@6.5.0':
-    resolution: {integrity: sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==}
+  '@turf/bbox@7.2.0':
+    resolution: {integrity: sha512-wzHEjCXlYZiDludDbXkpBSmv8Zu6tPGLmJ1sXQ6qDwpLE1Ew3mcWqt8AaxfTP5QwDNQa3sf2vvgTEzNbPQkCiA==}
 
-  '@turf/bearing@6.5.0':
-    resolution: {integrity: sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==}
+  '@turf/bearing@7.2.0':
+    resolution: {integrity: sha512-Jm0Xt3GgHjRrWvBtAGvgfnADLm+4exud2pRlmCYx8zfiKuNXQFkrcTZcOiJOgTfG20Agq28iSh15uta47jSIbg==}
 
-  '@turf/bezier-spline@6.5.0':
-    resolution: {integrity: sha512-vokPaurTd4PF96rRgGVm6zYYC5r1u98ZsG+wZEv9y3kJTuJRX/O3xIY2QnTGTdbVmAJN1ouOsD0RoZYaVoXORQ==}
+  '@turf/bezier-spline@7.2.0':
+    resolution: {integrity: sha512-7BPkc3ufYB9KLvcaTpTsnpXzh9DZoENxCS0Ms9XUwuRXw45TpevwUpOsa3atO76iKQ5puHntqFO4zs8IUxBaaA==}
 
-  '@turf/boolean-clockwise@6.5.0':
-    resolution: {integrity: sha512-45+C7LC5RMbRWrxh3Z0Eihsc8db1VGBO5d9BLTOAwU4jR6SgsunTfRWR16X7JUwIDYlCVEmnjcXJNi/kIU3VIw==}
+  '@turf/boolean-clockwise@7.2.0':
+    resolution: {integrity: sha512-0fJeFSARxy6ealGBM4Gmgpa1o8msQF87p2Dx5V6uSqzT8VPDegX1NSWl4b7QgXczYa9qv7IAABttdWP0K7Q7eQ==}
 
-  '@turf/boolean-contains@6.5.0':
-    resolution: {integrity: sha512-4m8cJpbw+YQcKVGi8y0cHhBUnYT+QRfx6wzM4GI1IdtYH3p4oh/DOBJKrepQyiDzFDaNIjxuWXBh0ai1zVwOQQ==}
+  '@turf/boolean-concave@7.2.0':
+    resolution: {integrity: sha512-v3dTN04dfO6VqctQj1a+pjDHb6+/Ev90oAR2QjJuAntY4ubhhr7vKeJdk/w+tWNSMKULnYwfe65Du3EOu3/TeA==}
 
-  '@turf/boolean-crosses@6.5.0':
-    resolution: {integrity: sha512-gvshbTPhAHporTlQwBJqyfW+2yV8q/mOTxG6PzRVl6ARsqNoqYQWkd4MLug7OmAqVyBzLK3201uAeBjxbGw0Ng==}
+  '@turf/boolean-contains@7.2.0':
+    resolution: {integrity: sha512-dgRQm4uVO5XuLee4PLVH7CFQZKdefUBMIXTPITm2oRIDmPLJKHDOFKQTNkGJ73mDKKBR2lmt6eVH3br6OYrEYg==}
 
-  '@turf/boolean-disjoint@6.5.0':
-    resolution: {integrity: sha512-rZ2ozlrRLIAGo2bjQ/ZUu4oZ/+ZjGvLkN5CKXSKBcu6xFO6k2bgqeM8a1836tAW+Pqp/ZFsTA5fZHsJZvP2D5g==}
+  '@turf/boolean-crosses@7.2.0':
+    resolution: {integrity: sha512-9GyM4UUWFKQOoNhHVSfJBf5XbPy8Fxfz9djjJNAnm/IOl8NmFUSwFPAjKlpiMcr6yuaAoc9R/1KokS9/eLqPvA==}
 
-  '@turf/boolean-equal@6.5.0':
-    resolution: {integrity: sha512-cY0M3yoLC26mhAnjv1gyYNQjn7wxIXmL2hBmI/qs8g5uKuC2hRWi13ydufE3k4x0aNRjFGlg41fjoYLwaVF+9Q==}
+  '@turf/boolean-disjoint@7.2.0':
+    resolution: {integrity: sha512-xdz+pYKkLMuqkNeJ6EF/3OdAiJdiHhcHCV0ykX33NIuALKIEpKik0+NdxxNsZsivOW6keKwr61SI+gcVtHYcnQ==}
 
-  '@turf/boolean-intersects@6.5.0':
-    resolution: {integrity: sha512-nIxkizjRdjKCYFQMnml6cjPsDOBCThrt+nkqtSEcxkKMhAQj5OO7o2CecioNTaX8EayqwMGVKcsz27oP4mKPTw==}
+  '@turf/boolean-equal@7.2.0':
+    resolution: {integrity: sha512-TmjKYLsxXqEmdDtFq3QgX4aSogiISp3/doeEtDOs3NNSR8susOtBEZkmvwO6DLW+g/rgoQJIBR6iVoWiRqkBxw==}
 
-  '@turf/boolean-overlap@6.5.0':
-    resolution: {integrity: sha512-8btMIdnbXVWUa1M7D4shyaSGxLRw6NjMcqKBcsTXcZdnaixl22k7ar7BvIzkaRYN3SFECk9VGXfLncNS3ckQUw==}
+  '@turf/boolean-intersects@7.2.0':
+    resolution: {integrity: sha512-GLRyLQgK3F14drkK5Qi9Mv7Z9VT1bgQUd9a3DB3DACTZWDSwfh8YZUFn/HBwRkK8dDdgNEXaavggQHcPi1k9ow==}
 
-  '@turf/boolean-parallel@6.5.0':
-    resolution: {integrity: sha512-aSHJsr1nq9e5TthZGZ9CZYeXklJyRgR5kCLm5X4urz7+MotMOp/LsGOsvKvK9NeUl9+8OUmfMn8EFTT8LkcvIQ==}
+  '@turf/boolean-overlap@7.2.0':
+    resolution: {integrity: sha512-ieM5qIE4anO+gUHIOvEN7CjyowF+kQ6v20/oNYJCp63TVS6eGMkwgd+I4uMzBXfVW66nVHIXjODdUelU+Xyctw==}
 
-  '@turf/boolean-point-in-polygon@6.5.0':
-    resolution: {integrity: sha512-DtSuVFB26SI+hj0SjrvXowGTUCHlgevPAIsukssW6BG5MlNSBQAo70wpICBNJL6RjukXg8d2eXaAWuD/CqL00A==}
+  '@turf/boolean-parallel@7.2.0':
+    resolution: {integrity: sha512-iOtuzzff8nmwv05ROkSvyeGLMrfdGkIi+3hyQ+DH4IVyV37vQbqR5oOJ0Nt3Qq1Tjrq9fvF8G3OMdAv3W2kY9w==}
 
-  '@turf/boolean-point-on-line@6.5.0':
-    resolution: {integrity: sha512-A1BbuQ0LceLHvq7F/P7w3QvfpmZqbmViIUPHdNLvZimFNLo4e6IQunmzbe+8aSStH9QRZm3VOflyvNeXvvpZEQ==}
+  '@turf/boolean-point-in-polygon@7.2.0':
+    resolution: {integrity: sha512-lvEOjxeXIp+wPXgl9kJA97dqzMfNexjqHou+XHVcfxQgolctoJiRYmcVCWGpiZ9CBf/CJha1KmD1qQoRIsjLaA==}
 
-  '@turf/boolean-within@6.5.0':
-    resolution: {integrity: sha512-YQB3oU18Inx35C/LU930D36RAVe7LDXk1kWsQ8mLmuqYn9YdPsDQTMTkLJMhoQ8EbN7QTdy333xRQ4MYgToteQ==}
+  '@turf/boolean-point-on-line@7.2.0':
+    resolution: {integrity: sha512-H/bXX8+2VYeSyH8JWrOsu8OGmeA9KVZfM7M6U5/fSqGsRHXo9MyYJ94k39A9kcKSwI0aWiMXVD2UFmiWy8423Q==}
 
-  '@turf/buffer@6.5.0':
-    resolution: {integrity: sha512-qeX4N6+PPWbKqp1AVkBVWFerGjMYMUyencwfnkCesoznU6qvfugFHNAngNqIBVnJjZ5n8IFyOf+akcxnrt9sNg==}
+  '@turf/boolean-touches@7.2.0':
+    resolution: {integrity: sha512-8qb1CO+cwFATGRGFgTRjzL9aibfsbI91pdiRl7KIEkVdeN/H9k8FDrUA1neY7Yq48IaciuwqjbbojQ16FD9b0w==}
 
-  '@turf/center-mean@6.5.0':
-    resolution: {integrity: sha512-AAX6f4bVn12pTVrMUiB9KrnV94BgeBKpyg3YpfnEbBpkN/znfVhL8dG8IxMAxAoSZ61Zt9WLY34HfENveuOZ7Q==}
+  '@turf/boolean-valid@7.2.0':
+    resolution: {integrity: sha512-xb7gdHN8VV6ivPJh6rPpgxmAEGReiRxqY+QZoEZVGpW2dXcmU1BdY6FA6G/cwvggXAXxJBREoANtEDgp/0ySbA==}
 
-  '@turf/center-median@6.5.0':
-    resolution: {integrity: sha512-dT8Ndu5CiZkPrj15PBvslpuf01ky41DEYEPxS01LOxp5HOUHXp1oJxsPxvc+i/wK4BwccPNzU1vzJ0S4emd1KQ==}
+  '@turf/boolean-within@7.2.0':
+    resolution: {integrity: sha512-zB3AiF59zQZ27Dp1iyhp9mVAKOFHat8RDH45TZhLY8EaqdEPdmLGvwMFCKfLryQcUDQvmzP8xWbtUR82QM5C4g==}
 
-  '@turf/center-of-mass@6.5.0':
-    resolution: {integrity: sha512-EWrriU6LraOfPN7m1jZi+1NLTKNkuIsGLZc2+Y8zbGruvUW+QV7K0nhf7iZWutlxHXTBqEXHbKue/o79IumAsQ==}
+  '@turf/buffer@7.2.0':
+    resolution: {integrity: sha512-QH1FTr5Mk4z1kpQNztMD8XBOZfpOXPOtlsxaSAj2kDIf5+LquA6HtJjZrjUngnGtzG5+XwcfyRL4ImvLnFjm5Q==}
 
-  '@turf/center@6.5.0':
-    resolution: {integrity: sha512-T8KtMTfSATWcAX088rEDKjyvQCBkUsLnK/Txb6/8WUXIeOZyHu42G7MkdkHRoHtwieLdduDdmPLFyTdG5/e7ZQ==}
+  '@turf/center-mean@7.2.0':
+    resolution: {integrity: sha512-NaW6IowAooTJ35O198Jw3U4diZ6UZCCeJY+4E+WMLpks3FCxMDSHEfO2QjyOXQMGWZnVxVelqI5x9DdniDbQ+A==}
 
-  '@turf/centroid@6.5.0':
-    resolution: {integrity: sha512-MwE1oq5E3isewPprEClbfU5pXljIK/GUOMbn22UM3IFPDJX0KeoyLNwghszkdmFp/qMGL/M13MMWvU+GNLXP/A==}
+  '@turf/center-median@7.2.0':
+    resolution: {integrity: sha512-/CgVyHNG4zAoZpvkl7qBCe4w7giWNVtLyTU5PoIfg1vWM4VpYw+N7kcBBH46bbzvVBn0vhmZr586r543EwdC/A==}
 
-  '@turf/circle@6.5.0':
-    resolution: {integrity: sha512-oU1+Kq9DgRnoSbWFHKnnUdTmtcRUMmHoV9DjTXu9vOLNV5OWtAAh1VZ+mzsioGGzoDNT/V5igbFOkMfBQc0B6A==}
+  '@turf/center-of-mass@7.2.0':
+    resolution: {integrity: sha512-ij3pmG61WQPHGTQvOziPOdIgwTMegkYTwIc71Gl7xn4C0vWH6KLDSshCphds9xdWSXt2GbHpUs3tr4XGntHkEQ==}
 
-  '@turf/clean-coords@6.5.0':
-    resolution: {integrity: sha512-EMX7gyZz0WTH/ET7xV8MyrExywfm9qUi0/MY89yNffzGIEHuFfqwhcCqZ8O00rZIPZHUTxpmsxQSTfzJJA1CPw==}
+  '@turf/center@7.2.0':
+    resolution: {integrity: sha512-UTNp9abQ2kuyRg5gCIGDNwwEQeF3NbpYsd1Q0KW9lwWuzbLVNn0sOwbxjpNF4J2HtMOs5YVOcqNvYyuoa2XrXw==}
 
-  '@turf/clone@6.5.0':
-    resolution: {integrity: sha512-mzVtTFj/QycXOn6ig+annKrM6ZlimreKYz6f/GSERytOpgzodbQyOgkfwru100O1KQhhjSudKK4DsQ0oyi9cTw==}
+  '@turf/centroid@7.2.0':
+    resolution: {integrity: sha512-yJqDSw25T7P48au5KjvYqbDVZ7qVnipziVfZ9aSo7P2/jTE7d4BP21w0/XLi3T/9bry/t9PR1GDDDQljN4KfDw==}
 
-  '@turf/clusters-dbscan@6.5.0':
-    resolution: {integrity: sha512-SxZEE4kADU9DqLRiT53QZBBhu8EP9skviSyl+FGj08Y01xfICM/RR9ACUdM0aEQimhpu+ZpRVcUK+2jtiCGrYQ==}
+  '@turf/circle@7.2.0':
+    resolution: {integrity: sha512-1AbqBYtXhstrHmnW6jhLwsv7TtmT0mW58Hvl1uZXEDM1NCVXIR50yDipIeQPjrCuJ/Zdg/91gU8+4GuDCAxBGA==}
 
-  '@turf/clusters-kmeans@6.5.0':
-    resolution: {integrity: sha512-DwacD5+YO8kwDPKaXwT9DV46tMBVNsbi1IzdajZu1JDSWoN7yc7N9Qt88oi+p30583O0UPVkAK+A10WAQv4mUw==}
+  '@turf/clean-coords@7.2.0':
+    resolution: {integrity: sha512-+5+J1+D7wW7O/RDXn46IfCHuX1gIV1pIAQNSA7lcDbr3HQITZj334C4mOGZLEcGbsiXtlHWZiBtm785Vg8i+QQ==}
 
-  '@turf/clusters@6.5.0':
-    resolution: {integrity: sha512-Y6gfnTJzQ1hdLfCsyd5zApNbfLIxYEpmDibHUqR5z03Lpe02pa78JtgrgUNt1seeO/aJ4TG1NLN8V5gOrHk04g==}
+  '@turf/clone@7.2.0':
+    resolution: {integrity: sha512-JlGUT+/5qoU5jqZmf6NMFIoLDY3O7jKd53Up+zbpJ2vzUp6QdwdNzwrsCeONhynWM13F0MVtPXH4AtdkrgFk4g==}
 
-  '@turf/collect@6.5.0':
-    resolution: {integrity: sha512-4dN/T6LNnRg099m97BJeOcTA5fSI8cu87Ydgfibewd2KQwBexO69AnjEFqfPX3Wj+Zvisj1uAVIZbPmSSrZkjg==}
+  '@turf/clusters-dbscan@7.2.0':
+    resolution: {integrity: sha512-VWVUuDreev56g3/BMlnq/81yzczqaz+NVTypN5CigGgP67e+u/CnijphiuhKjtjDd/MzGjXgEWBJc26Y6LYKAw==}
 
-  '@turf/combine@6.5.0':
-    resolution: {integrity: sha512-Q8EIC4OtAcHiJB3C4R+FpB4LANiT90t17uOd851qkM2/o6m39bfN5Mv0PWqMZIHWrrosZqRqoY9dJnzz/rJxYQ==}
+  '@turf/clusters-kmeans@7.2.0':
+    resolution: {integrity: sha512-BxQdK8jc8Mwm9yoClCYkktm4W004uiQGqb/i/6Y7a8xqgJITWDgTu/cy//wOxAWPk4xfe6MThjnqkszWW8JdyQ==}
 
-  '@turf/concave@6.5.0':
-    resolution: {integrity: sha512-I/sUmUC8TC5h/E2vPwxVht+nRt+TnXIPRoztDFvS8/Y0+cBDple9inLSo9nnPXMXidrBlGXZ9vQx/BjZUJgsRQ==}
+  '@turf/clusters@7.2.0':
+    resolution: {integrity: sha512-sKOrIKHHtXAuTKNm2USnEct+6/MrgyzMW42deZ2YG2RRKWGaaxHMFU2Yw71Yk4DqStOqTIBQpIOdrRuSOwbuQw==}
 
-  '@turf/convex@6.5.0':
-    resolution: {integrity: sha512-x7ZwC5z7PJB0SBwNh7JCeCNx7Iu+QSrH7fYgK0RhhNop13TqUlvHMirMLRgf2db1DqUetrAO2qHJeIuasquUWg==}
+  '@turf/collect@7.2.0':
+    resolution: {integrity: sha512-zRVGDlYS8Bx/Zz4vnEUyRg4dmqHhkDbW/nIUIJh657YqaMj1SFi4Iv2i9NbcurlUBDJFkpuOhCvvEvAdskJ8UA==}
 
-  '@turf/destination@6.5.0':
-    resolution: {integrity: sha512-4cnWQlNC8d1tItOz9B4pmJdWpXqS0vEvv65bI/Pj/genJnsL7evI0/Xw42RvEGROS481MPiU80xzvwxEvhQiMQ==}
+  '@turf/combine@7.2.0':
+    resolution: {integrity: sha512-VEjm3IvnbMt3IgeRIhCDhhQDbLqCU1/5uN1+j1u6fyA095pCizPThGp4f/COSzC3t1s/iiV+fHuDsB6DihHffQ==}
 
-  '@turf/difference@6.5.0':
-    resolution: {integrity: sha512-l8iR5uJqvI+5Fs6leNbhPY5t/a3vipUF/3AeVLpwPQcgmedNXyheYuy07PcMGH5Jdpi5gItOiTqwiU/bUH4b3A==}
+  '@turf/concave@7.2.0':
+    resolution: {integrity: sha512-cpaDDlumK762kdadexw5ZAB6g/h2pJdihZ+e65lbQVe3WukJHAANnIEeKsdFCuIyNKrwTz2gWu5ws+OpjP48Yw==}
 
-  '@turf/dissolve@6.5.0':
-    resolution: {integrity: sha512-WBVbpm9zLTp0Bl9CE35NomTaOL1c4TQCtEoO43YaAhNEWJOOIhZMFJyr8mbvYruKl817KinT3x7aYjjCMjTAsQ==}
+  '@turf/convex@7.2.0':
+    resolution: {integrity: sha512-HsgHm+zHRE8yPCE/jBUtWFyaaBmpXcSlyHd5/xsMhSZRImFzRzBibaONWQo7xbKZMISC3Nc6BtUjDi/jEVbqyA==}
 
-  '@turf/distance-weight@6.5.0':
-    resolution: {integrity: sha512-a8qBKkgVNvPKBfZfEJZnC3DV7dfIsC3UIdpRci/iap/wZLH41EmS90nM+BokAJflUHYy8PqE44wySGWHN1FXrQ==}
+  '@turf/destination@7.2.0':
+    resolution: {integrity: sha512-8DUxtOO0Fvrh1xclIUj3d9C5WS20D21F5E+j+X9Q+ju6fcM4huOqTg5ckV1DN2Pg8caABEc5HEZJnGch/5YnYQ==}
 
-  '@turf/distance@6.5.0':
-    resolution: {integrity: sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==}
+  '@turf/difference@7.2.0':
+    resolution: {integrity: sha512-NHKD1v3s8RX+9lOpvHJg6xRuJOKiY3qxHhz5/FmE0VgGqnCkE7OObqWZ5SsXG+Ckh0aafs5qKhmDdDV/gGi6JA==}
 
-  '@turf/ellipse@6.5.0':
-    resolution: {integrity: sha512-kuXtwFviw/JqnyJXF1mrR/cb496zDTSbGKtSiolWMNImYzGGkbsAsFTjwJYgD7+4FixHjp0uQPzo70KDf3AIBw==}
+  '@turf/dissolve@7.2.0':
+    resolution: {integrity: sha512-gPG5TE3mAYuZqBut8tPYCKwi4hhx5Cq0ALoQMB9X0hrVtFIKrihrsj98XQM/5pL/UIpAxQfwisQvy6XaOFaoPA==}
 
-  '@turf/envelope@6.5.0':
-    resolution: {integrity: sha512-9Z+FnBWvOGOU4X+fMZxYFs1HjFlkKqsddLuMknRaqcJd6t+NIv5DWvPtDL8ATD2GEExYDiFLwMdckfr1yqJgHA==}
+  '@turf/distance-weight@7.2.0':
+    resolution: {integrity: sha512-NeoyV0fXDH+7nIoNtLjAoH9XL0AS1pmTIyDxEE6LryoDTsqjnuR0YQxIkLCCWDqECoqaOmmBqpeWONjX5BwWCg==}
 
-  '@turf/explode@6.5.0':
-    resolution: {integrity: sha512-6cSvMrnHm2qAsace6pw9cDmK2buAlw8+tjeJVXMfMyY+w7ZUi1rprWMsY92J7s2Dar63Bv09n56/1V7+tcj52Q==}
+  '@turf/distance@7.2.0':
+    resolution: {integrity: sha512-HBjjXIgEcD/wJYjv7/6OZj5yoky2oUvTtVeIAqO3lL80XRvoYmVg6vkOIu6NswkerwLDDNT9kl7+BFLJoHbh6Q==}
 
-  '@turf/flatten@6.5.0':
-    resolution: {integrity: sha512-IBZVwoNLVNT6U/bcUUllubgElzpMsNoCw8tLqBw6dfYg9ObGmpEjf9BIYLr7a2Yn5ZR4l7YIj2T7kD5uJjZADQ==}
+  '@turf/ellipse@7.2.0':
+    resolution: {integrity: sha512-/Y75S5hE2+xjnTw4dXpQ5r/Y2HPM4xrwkPRCCQRpuuboKdEvm42azYmh7isPnMnBTVcmGb9UmGKj0HHAbiwt1g==}
 
-  '@turf/flip@6.5.0':
-    resolution: {integrity: sha512-oyikJFNjt2LmIXQqgOGLvt70RgE2lyzPMloYWM7OR5oIFGRiBvqVD2hA6MNw6JewIm30fWZ8DQJw1NHXJTJPbg==}
+  '@turf/envelope@7.2.0':
+    resolution: {integrity: sha512-xOMtDeNKHwUuDfzQeoSNmdabsP0/IgVDeyzitDe/8j9wTeW+MrKzVbGz7627PT3h6gsO+2nUv5asfKtUbmTyHA==}
 
-  '@turf/great-circle@6.5.0':
-    resolution: {integrity: sha512-7ovyi3HaKOXdFyN7yy1yOMa8IyOvV46RC1QOQTT+RYUN8ke10eyqExwBpL9RFUPvlpoTzoYbM/+lWPogQlFncg==}
+  '@turf/explode@7.2.0':
+    resolution: {integrity: sha512-jyMXg93J1OI7/65SsLE1k9dfQD3JbcPNMi4/O3QR2Qb3BAs2039oFaSjtW+YqhMqVC4V3ZeKebMcJ8h9sK1n+A==}
 
-  '@turf/helpers@6.5.0':
-    resolution: {integrity: sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==}
+  '@turf/flatten@7.2.0':
+    resolution: {integrity: sha512-q38Qsqr4l7mxp780zSdn0gp/WLBX+sa+gV6qIbDQ1HKCrrPK8QQJmNx7gk1xxEXVot6tq/WyAPysCQdX+kLmMA==}
 
-  '@turf/hex-grid@6.5.0':
-    resolution: {integrity: sha512-Ln3tc2tgZT8etDOldgc6e741Smg1CsMKAz1/Mlel+MEL5Ynv2mhx3m0q4J9IB1F3a4MNjDeVvm8drAaf9SF33g==}
+  '@turf/flip@7.2.0':
+    resolution: {integrity: sha512-X0TQ0U/UYh4tyXdLO5itP1sO2HOvfrZC0fYSWmTfLDM14jEPkEK8PblofznfBygL+pIFtOS2is8FuVcp5XxYpQ==}
 
-  '@turf/interpolate@6.5.0':
-    resolution: {integrity: sha512-LSH5fMeiGyuDZ4WrDJNgh81d2DnNDUVJtuFryJFup8PV8jbs46lQGfI3r1DJ2p1IlEJIz3pmAZYeTfMMoeeohw==}
+  '@turf/geojson-rbush@7.2.0':
+    resolution: {integrity: sha512-ST8fLv+EwxVkDgsmhHggM0sPk2SfOHTZJkdgMXVFT7gB9o4lF8qk4y4lwvCCGIfFQAp2yv/PN5EaGMEKutk6xw==}
 
-  '@turf/intersect@6.5.0':
-    resolution: {integrity: sha512-2legGJeKrfFkzntcd4GouPugoqPUjexPZnOvfez+3SfIMrHvulw8qV8u7pfVyn2Yqs53yoVCEjS5sEpvQ5YRQg==}
+  '@turf/great-circle@7.2.0':
+    resolution: {integrity: sha512-n30OiADyOKHhor0aXNgYfXQYXO3UtsOKmhQsY1D89/Oh1nCIXG/1ZPlLL9ZoaRXXBTUBjh99a+K8029NQbGDhw==}
 
-  '@turf/invariant@6.5.0':
-    resolution: {integrity: sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==}
+  '@turf/helpers@7.2.0':
+    resolution: {integrity: sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==}
 
-  '@turf/isobands@6.5.0':
-    resolution: {integrity: sha512-4h6sjBPhRwMVuFaVBv70YB7eGz+iw0bhPRnp+8JBdX1UPJSXhoi/ZF2rACemRUr0HkdVB/a1r9gC32vn5IAEkw==}
+  '@turf/hex-grid@7.2.0':
+    resolution: {integrity: sha512-Yo2yUGxrTCQfmcVsSjDt0G3Veg8YD26WRd7etVPD9eirNNgXrIyZkbYA7zVV/qLeRWVmYIKRXg1USWl7ORQOGA==}
 
-  '@turf/isolines@6.5.0':
-    resolution: {integrity: sha512-6ElhiLCopxWlv4tPoxiCzASWt/jMRvmp6mRYrpzOm3EUl75OhHKa/Pu6Y9nWtCMmVC/RcWtiiweUocbPLZLm0A==}
+  '@turf/interpolate@7.2.0':
+    resolution: {integrity: sha512-Ifgjm1SEo6XujuSAU6lpRMvoJ1SYTreil1Rf5WsaXj16BQJCedht/4FtWCTNhSWTwEz2motQ1WNrjTCuPG94xA==}
 
-  '@turf/kinks@6.5.0':
-    resolution: {integrity: sha512-ViCngdPt1eEL7hYUHR2eHR662GvCgTc35ZJFaNR6kRtr6D8plLaDju0FILeFFWSc+o8e3fwxZEJKmFj9IzPiIQ==}
+  '@turf/intersect@7.2.0':
+    resolution: {integrity: sha512-81GMzKS9pKqLPa61qSlFxLFeAC8XbwyCQ9Qv4z6o5skWk1qmMUbEHeMqaGUTEzk+q2XyhZ0sju1FV4iLevQ/aw==}
 
-  '@turf/length@6.5.0':
-    resolution: {integrity: sha512-5pL5/pnw52fck3oRsHDcSGrj9HibvtlrZ0QNy2OcW8qBFDNgZ4jtl6U7eATVoyWPKBHszW3dWETW+iLV7UARig==}
+  '@turf/invariant@7.2.0':
+    resolution: {integrity: sha512-kV4u8e7Gkpq+kPbAKNC21CmyrXzlbBgFjO1PhrHPgEdNqXqDawoZ3i6ivE3ULJj2rSesCjduUaC/wyvH/sNr2Q==}
 
-  '@turf/line-arc@6.5.0':
-    resolution: {integrity: sha512-I6c+V6mIyEwbtg9P9zSFF89T7QPe1DPTG3MJJ6Cm1MrAY0MdejwQKOpsvNl8LDU2ekHOlz2kHpPVR7VJsoMllA==}
+  '@turf/isobands@7.2.0':
+    resolution: {integrity: sha512-lYoHeRieFzpBp29Jh19QcDIb0E+dzo/K5uwZuNga4wxr6heNU0AfkD4ByAHYIXHtvmp4m/JpSKq/2N6h/zvBkg==}
 
-  '@turf/line-chunk@6.5.0':
-    resolution: {integrity: sha512-i1FGE6YJaaYa+IJesTfyRRQZP31QouS+wh/pa6O3CC0q4T7LtHigyBSYjrbjSLfn2EVPYGlPCMFEqNWCOkC6zg==}
+  '@turf/isolines@7.2.0':
+    resolution: {integrity: sha512-4ZXKxvA/JKkxAXixXhN3UVza5FABsdYgOWXyYm3L5ryTPJVOYTVSSd9A+CAVlv9dZc3YdlsqMqLTXNOOre/kwg==}
 
-  '@turf/line-intersect@6.5.0':
-    resolution: {integrity: sha512-CS6R1tZvVQD390G9Ea4pmpM6mJGPWoL82jD46y0q1KSor9s6HupMIo1kY4Ny+AEYQl9jd21V3Scz20eldpbTVA==}
+  '@turf/jsts@2.7.2':
+    resolution: {integrity: sha512-zAezGlwWHPyU0zxwcX2wQY3RkRpwuoBmhhNE9HY9kWhFDkCxZ3aWK5URKwa/SWKJbj9aztO+8vtdiBA28KVJFg==}
 
-  '@turf/line-offset@6.5.0':
-    resolution: {integrity: sha512-CEXZbKgyz8r72qRvPchK0dxqsq8IQBdH275FE6o4MrBkzMcoZsfSjghtXzKaz9vvro+HfIXal0sTk2mqV1lQTw==}
+  '@turf/kinks@7.2.0':
+    resolution: {integrity: sha512-BtxDxGewJR0Q5WR9HKBSxZhirFX+GEH1rD7/EvgDsHS8e1Y5/vNQQUmXdURjdPa4StzaUBsWRU5T3A356gLbPA==}
 
-  '@turf/line-overlap@6.5.0':
-    resolution: {integrity: sha512-xHOaWLd0hkaC/1OLcStCpfq55lPHpPNadZySDXYiYjEz5HXr1oKmtMYpn0wGizsLwrOixRdEp+j7bL8dPt4ojQ==}
+  '@turf/length@7.2.0':
+    resolution: {integrity: sha512-LBmYN+iCgVtWNLsckVnpQIJENqIIPO63mogazMp23lrDGfWXu07zZQ9ZinJVO5xYurXNhc/QI2xxoqt2Xw90Ig==}
 
-  '@turf/line-segment@6.5.0':
-    resolution: {integrity: sha512-jI625Ho4jSuJESNq66Mmi290ZJ5pPZiQZruPVpmHkUw257Pew0alMmb6YrqYNnLUuiVVONxAAKXUVeeUGtycfw==}
+  '@turf/line-arc@7.2.0':
+    resolution: {integrity: sha512-kfWzA5oYrTpslTg5fN50G04zSypiYQzjZv3FLjbZkk6kta5fo4JkERKjTeA8x4XNojb+pfmjMBB0yIh2w2dDRw==}
 
-  '@turf/line-slice-along@6.5.0':
-    resolution: {integrity: sha512-KHJRU6KpHrAj+BTgTNqby6VCTnDzG6a1sJx/I3hNvqMBLvWVA2IrkR9L9DtsQsVY63IBwVdQDqiwCuZLDQh4Ng==}
+  '@turf/line-chunk@7.2.0':
+    resolution: {integrity: sha512-1ODyL5gETtWSL85MPI0lgp/78vl95M39gpeBxePXyDIqx8geDP9kXfAzctuKdxBoR4JmOVM3NT7Fz7h+IEkC+g==}
 
-  '@turf/line-slice@6.5.0':
-    resolution: {integrity: sha512-vDqJxve9tBHhOaVVFXqVjF5qDzGtKWviyjbyi2QnSnxyFAmLlLnBfMX8TLQCAf2GxHibB95RO5FBE6I2KVPRuw==}
+  '@turf/line-intersect@7.2.0':
+    resolution: {integrity: sha512-GhCJVEkc8EmggNi85EuVLoXF5T5jNVxmhIetwppiVyJzMrwkYAkZSYB3IBFYGUUB9qiNFnTwungVSsBV/S8ZiA==}
 
-  '@turf/line-split@6.5.0':
-    resolution: {integrity: sha512-/rwUMVr9OI2ccJjw7/6eTN53URtGThNSD5I0GgxyFXMtxWiloRJ9MTff8jBbtPWrRka/Sh2GkwucVRAEakx9Sw==}
+  '@turf/line-offset@7.2.0':
+    resolution: {integrity: sha512-1+OkYueDCbnEWzbfBh3taVr+3SyM2bal5jfnSEuDiLA6jnlScgr8tn3INo+zwrUkPFZPPAejL1swVyO5TjUahw==}
 
-  '@turf/line-to-polygon@6.5.0':
-    resolution: {integrity: sha512-qYBuRCJJL8Gx27OwCD1TMijM/9XjRgXH/m/TyuND4OXedBpIWlK5VbTIO2gJ8OCfznBBddpjiObLBrkuxTpN4Q==}
+  '@turf/line-overlap@7.2.0':
+    resolution: {integrity: sha512-NNn7/jg53+N10q2Kyt66bEDqN3101iW/1zA5FW7J6UbKApDFkByh+18YZq1of71kS6oUYplP86WkDp16LFpqqw==}
 
-  '@turf/mask@6.5.0':
-    resolution: {integrity: sha512-RQha4aU8LpBrmrkH8CPaaoAfk0Egj5OuXtv6HuCQnHeGNOQt3TQVibTA3Sh4iduq4EPxnZfDjgsOeKtrCA19lg==}
+  '@turf/line-segment@7.2.0':
+    resolution: {integrity: sha512-E162rmTF9XjVN4rINJCd15AdQGCBlNqeWN3V0YI1vOUpZFNT2ii4SqEMCcH2d+5EheHLL8BWVwZoOsvHZbvaWA==}
 
-  '@turf/meta@6.5.0':
-    resolution: {integrity: sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==}
+  '@turf/line-slice-along@7.2.0':
+    resolution: {integrity: sha512-4/gPgP0j5Rp+1prbhXqn7kIH/uZTmSgiubUnn67F8nb9zE+MhbRglhSlRYEZxAVkB7VrGwjyolCwvrROhjHp2A==}
 
-  '@turf/midpoint@6.5.0':
-    resolution: {integrity: sha512-MyTzV44IwmVI6ec9fB2OgZ53JGNlgOpaYl9ArKoF49rXpL84F9rNATndbe0+MQIhdkw8IlzA6xVP4lZzfMNVCw==}
+  '@turf/line-slice@7.2.0':
+    resolution: {integrity: sha512-bHotzZIaU1GPV3RMwttYpDrmcvb3X2i1g/WUttPZWtKrEo2VVAkoYdeZ2aFwtogERYS4quFdJ/TDzAtquBC8WQ==}
 
-  '@turf/moran-index@6.5.0':
-    resolution: {integrity: sha512-ItsnhrU2XYtTtTudrM8so4afBCYWNaB0Mfy28NZwLjB5jWuAsvyV+YW+J88+neK/ougKMTawkmjQqodNJaBeLQ==}
+  '@turf/line-split@7.2.0':
+    resolution: {integrity: sha512-yJTZR+c8CwoKqdW/aIs+iLbuFwAa3Yan+EOADFQuXXIUGps3bJUXx/38rmowNoZbHyP1np1+OtrotyHu5uBsfQ==}
 
-  '@turf/nearest-point-on-line@6.5.0':
-    resolution: {integrity: sha512-WthrvddddvmymnC+Vf7BrkHGbDOUu6Z3/6bFYUGv1kxw8tiZ6n83/VG6kHz4poHOfS0RaNflzXSkmCi64fLBlg==}
+  '@turf/line-to-polygon@7.2.0':
+    resolution: {integrity: sha512-iKpJqc7EYc5NvlD4KaqrKKO6mXR7YWO/YwtW60E2FnsF/blnsy9OfAOcilYHgH3S/V/TT0VedC7DW7Kgjy2EIA==}
 
-  '@turf/nearest-point-to-line@6.5.0':
-    resolution: {integrity: sha512-PXV7cN0BVzUZdjj6oeb/ESnzXSfWmEMrsfZSDRgqyZ9ytdiIj/eRsnOXLR13LkTdXVOJYDBuf7xt1mLhM4p6+Q==}
+  '@turf/mask@7.2.0':
+    resolution: {integrity: sha512-ulJ6dQqXC0wrjIoqFViXuMUdIPX5Q6GPViZ3kGfeVijvlLM7kTFBsZiPQwALSr5nTQg4Ppf3FD0Jmg8IErPrgA==}
 
-  '@turf/nearest-point@6.5.0':
-    resolution: {integrity: sha512-fguV09QxilZv/p94s8SMsXILIAMiaXI5PATq9d7YWijLxWUj6Q/r43kxyoi78Zmwwh1Zfqz9w+bCYUAxZ5+euA==}
+  '@turf/meta@7.2.0':
+    resolution: {integrity: sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==}
 
-  '@turf/planepoint@6.5.0':
-    resolution: {integrity: sha512-R3AahA6DUvtFbka1kcJHqZ7DMHmPXDEQpbU5WaglNn7NaCQg9HB0XM0ZfqWcd5u92YXV+Gg8QhC8x5XojfcM4Q==}
+  '@turf/midpoint@7.2.0':
+    resolution: {integrity: sha512-AMn5S9aSrbXdE+Q4Rj+T5nLdpfpn+mfzqIaEKkYI021HC0vb22HyhQHsQbSeX+AWcS4CjD1hFsYVcgKI+5qCfw==}
 
-  '@turf/point-grid@6.5.0':
-    resolution: {integrity: sha512-Iq38lFokNNtQJnOj/RBKmyt6dlof0yhaHEDELaWHuECm1lIZLY3ZbVMwbs+nXkwTAHjKfS/OtMheUBkw+ee49w==}
+  '@turf/moran-index@7.2.0':
+    resolution: {integrity: sha512-Aexh1EmXVPJhApr9grrd120vbalIthcIsQ3OAN2Tqwf+eExHXArJEJqGBo9IZiQbIpFJeftt/OvUvlI8BeO1bA==}
 
-  '@turf/point-on-feature@6.5.0':
-    resolution: {integrity: sha512-bDpuIlvugJhfcF/0awAQ+QI6Om1Y1FFYE8Y/YdxGRongivix850dTeXCo0mDylFdWFPGDo7Mmh9Vo4VxNwW/TA==}
+  '@turf/nearest-neighbor-analysis@7.2.0':
+    resolution: {integrity: sha512-LmP/crXb7gilgsL0wL9hsygqc537W/a1W5r9XBKJT4SKdqjoXX5APJatJfd3nwXbRIqwDH0cDA9/YyFjBPlKnA==}
 
-  '@turf/point-to-line-distance@6.5.0':
-    resolution: {integrity: sha512-opHVQ4vjUhNBly1bob6RWy+F+hsZDH9SA0UW36pIRzfpu27qipU18xup0XXEePfY6+wvhF6yL/WgCO2IbrLqEA==}
+  '@turf/nearest-point-on-line@7.2.0':
+    resolution: {integrity: sha512-UOhAeoDPVewBQV+PWg1YTMQcYpJsIqfW5+EuZ5vJl60XwUa0+kqB/eVfSLNXmHENjKKIlEt9Oy9HIDF4VeWmXA==}
 
-  '@turf/points-within-polygon@6.5.0':
-    resolution: {integrity: sha512-YyuheKqjliDsBDt3Ho73QVZk1VXX1+zIA2gwWvuz8bR1HXOkcuwk/1J76HuFMOQI3WK78wyAi+xbkx268PkQzQ==}
+  '@turf/nearest-point-to-line@7.2.0':
+    resolution: {integrity: sha512-EorU7Qj30A7nAjh++KF/eTPDlzwuuV4neBz7tmSTB21HKuXZAR0upJsx6M2X1CSyGEgNsbFB0ivNKIvymRTKBw==}
 
-  '@turf/polygon-smooth@6.5.0':
-    resolution: {integrity: sha512-LO/X/5hfh/Rk4EfkDBpLlVwt3i6IXdtQccDT9rMjXEP32tRgy0VMFmdkNaXoGlSSKf/1mGqLl4y4wHd86DqKbg==}
+  '@turf/nearest-point@7.2.0':
+    resolution: {integrity: sha512-0wmsqXZ8CGw4QKeZmS+NdjYTqCMC+HXZvM3XAQIU6k6laNLqjad2oS4nDrtcRs/nWDvcj1CR+Io7OiQ6sbpn5Q==}
 
-  '@turf/polygon-tangents@6.5.0':
-    resolution: {integrity: sha512-sB4/IUqJMYRQH9jVBwqS/XDitkEfbyqRy+EH/cMRJURTg78eHunvJ708x5r6umXsbiUyQU4eqgPzEylWEQiunw==}
+  '@turf/planepoint@7.2.0':
+    resolution: {integrity: sha512-8Vno01tvi5gThUEKBQ46CmlEKDAwVpkl7stOPFvJYlA1oywjAL4PsmgwjXgleZuFtXQUPBNgv5a42Pf438XP4g==}
 
-  '@turf/polygon-to-line@6.5.0':
-    resolution: {integrity: sha512-5p4n/ij97EIttAq+ewSnKt0ruvuM+LIDzuczSzuHTpq4oS7Oq8yqg5TQ4nzMVuK41r/tALCk7nAoBuw3Su4Gcw==}
+  '@turf/point-grid@7.2.0':
+    resolution: {integrity: sha512-ai7lwBV2FREPW3XiUNohT4opC1hd6+F56qZe20xYhCTkTD9diWjXHiNudQPSmVAUjgMzQGasblQQqvOdL+bJ3Q==}
 
-  '@turf/polygonize@6.5.0':
-    resolution: {integrity: sha512-a/3GzHRaCyzg7tVYHo43QUChCspa99oK4yPqooVIwTC61npFzdrmnywMv0S+WZjHZwK37BrFJGFrZGf6ocmY5w==}
+  '@turf/point-on-feature@7.2.0':
+    resolution: {integrity: sha512-ksoYoLO9WtJ/qI8VI9ltF+2ZjLWrAjZNsCsu8F7nyGeCh4I8opjf4qVLytFG44XA2qI5yc6iXDpyv0sshvP82Q==}
 
-  '@turf/projection@6.5.0':
-    resolution: {integrity: sha512-/Pgh9mDvQWWu8HRxqpM+tKz8OzgauV+DiOcr3FCjD6ubDnrrmMJlsf6fFJmggw93mtVPrZRL6yyi9aYCQBOIvg==}
+  '@turf/point-to-line-distance@7.2.0':
+    resolution: {integrity: sha512-fB9Rdnb5w5+t76Gho2dYDkGe20eRrFk8CXi4v1+l1PC8YyLXO+x+l3TrtT8HzL/dVaZeepO6WUIsIw3ditTOPg==}
 
-  '@turf/random@6.5.0':
-    resolution: {integrity: sha512-8Q25gQ/XbA7HJAe+eXp4UhcXM9aOOJFaxZ02+XSNwMvY8gtWSCBLVqRcW4OhqilgZ8PeuQDWgBxeo+BIqqFWFQ==}
+  '@turf/point-to-polygon-distance@7.2.0':
+    resolution: {integrity: sha512-w+WYuINgTiFjoZemQwOaQSje/8Kq+uqJOynvx7+gleQPHyWQ3VtTodtV4LwzVzXz8Sf7Mngx1Jcp2SNai5CJYA==}
 
-  '@turf/rectangle-grid@6.5.0':
-    resolution: {integrity: sha512-yQZ/1vbW68O2KsSB3OZYK+72aWz/Adnf7m2CMKcC+aq6TwjxZjAvlbCOsNUnMAuldRUVN1ph6RXMG4e9KEvKvg==}
+  '@turf/points-within-polygon@7.2.0':
+    resolution: {integrity: sha512-jRKp8/mWNMzA+hKlQhxci97H5nOio9tp14R2SzpvkOt+cswxl+NqTEi1hDd2XetA7tjU0TSoNjEgVY8FfA0S6w==}
 
-  '@turf/rewind@6.5.0':
-    resolution: {integrity: sha512-IoUAMcHWotBWYwSYuYypw/LlqZmO+wcBpn8ysrBNbazkFNkLf3btSDZMkKJO/bvOzl55imr/Xj4fi3DdsLsbzQ==}
+  '@turf/polygon-smooth@7.2.0':
+    resolution: {integrity: sha512-KCp9wF2IEynvGXVhySR8oQ2razKP0zwg99K+fuClP21pSKCFjAPaihPEYq6e8uI/1J7ibjL5++6EMl+LrUTrLg==}
 
-  '@turf/rhumb-bearing@6.5.0':
-    resolution: {integrity: sha512-jMyqiMRK4hzREjQmnLXmkJ+VTNTx1ii8vuqRwJPcTlKbNWfjDz/5JqJlb5NaFDcdMpftWovkW5GevfnuzHnOYA==}
+  '@turf/polygon-tangents@7.2.0':
+    resolution: {integrity: sha512-AHUUPmOjiQDrtP/ODXukHBlUG0C/9I1je7zz50OTfl2ZDOdEqFJQC3RyNELwq07grTXZvg5TS5wYx/Y7nsm47g==}
 
-  '@turf/rhumb-destination@6.5.0':
-    resolution: {integrity: sha512-RHNP1Oy+7xTTdRrTt375jOZeHceFbjwohPHlr9Hf68VdHHPMAWgAKqiX2YgSWDcvECVmiGaBKWus1Df+N7eE4Q==}
+  '@turf/polygon-to-line@7.2.0':
+    resolution: {integrity: sha512-9jeTN3LiJ933I5sd4K0kwkcivOYXXm1emk0dHorwXeSFSHF+nlYesEW3Hd889wb9lZd7/SVLMUeX/h39mX+vCA==}
 
-  '@turf/rhumb-distance@6.5.0':
-    resolution: {integrity: sha512-oKp8KFE8E4huC2Z1a1KNcFwjVOqa99isxNOwfo4g3SUABQ6NezjKDDrnvC4yI5YZ3/huDjULLBvhed45xdCrzg==}
+  '@turf/polygonize@7.2.0':
+    resolution: {integrity: sha512-U9v+lBhUPDv+nsg/VcScdiqCB59afO6CHDGrwIl2+5i6Ve+/KQKjpTV/R+NqoC1iMXAEq3brY6HY8Ukp/pUWng==}
 
-  '@turf/sample@6.5.0':
-    resolution: {integrity: sha512-kSdCwY7el15xQjnXYW520heKUrHwRvnzx8ka4eYxX9NFeOxaFITLW2G7UtXb6LJK8mmPXI8Aexv23F2ERqzGFg==}
+  '@turf/projection@7.2.0':
+    resolution: {integrity: sha512-/qke5vJScv8Mu7a+fU3RSChBRijE6EVuFHU3RYihMuYm04Vw8dBMIs0enEpoq0ke/IjSbleIrGQNZIMRX9EwZQ==}
 
-  '@turf/sector@6.5.0':
-    resolution: {integrity: sha512-cYUOkgCTWqa23SOJBqxoFAc/yGCUsPRdn/ovbRTn1zNTm/Spmk6hVB84LCKOgHqvSF25i0d2kWqpZDzLDdAPbw==}
+  '@turf/quadrat-analysis@7.2.0':
+    resolution: {integrity: sha512-fDQh3+ldYNxUqS6QYlvJ7GZLlCeDZR6tD3ikdYtOsSemwW1n/4gm2xcgWJqy3Y0uszBwxc13IGGY7NGEjHA+0w==}
 
-  '@turf/shortest-path@6.5.0':
-    resolution: {integrity: sha512-4de5+G7+P4hgSoPwn+SO9QSi9HY5NEV/xRJ+cmoFVRwv2CDsuOPDheHKeuIAhKyeKDvPvPt04XYWbac4insJMg==}
+  '@turf/random@7.2.0':
+    resolution: {integrity: sha512-fNXs5mOeXsrirliw84S8UCNkpm4RMNbefPNsuCTfZEXhcr1MuHMzq4JWKb4FweMdN1Yx2l/xcytkO0s71cJ50w==}
 
-  '@turf/simplify@6.5.0':
-    resolution: {integrity: sha512-USas3QqffPHUY184dwQdP8qsvcVH/PWBYdXY5am7YTBACaQOMAlf6AKJs9FT8jiO6fQpxfgxuEtwmox+pBtlOg==}
+  '@turf/rectangle-grid@7.2.0':
+    resolution: {integrity: sha512-f0o5ifvy0Ml/nHDJzMNcuSk4h11aa3BfvQNnYQhLpuTQu03j/ICZNlzKTLxwjcUqvxADUifty7Z9CX5W6zky4A==}
 
-  '@turf/square-grid@6.5.0':
-    resolution: {integrity: sha512-mlR0ayUdA+L4c9h7p4k3pX6gPWHNGuZkt2c5II1TJRmhLkW2557d6b/Vjfd1z9OVaajb1HinIs1FMSAPXuuUrA==}
+  '@turf/rewind@7.2.0':
+    resolution: {integrity: sha512-SZpRAZiZsE22+HVz6pEID+ST25vOdpAMGk5NO1JeqzhpMALIkIGnkG+xnun2CfYHz7wv8/Z0ADiAvei9rkcQYA==}
 
-  '@turf/square@6.5.0':
-    resolution: {integrity: sha512-BM2UyWDmiuHCadVhHXKIx5CQQbNCpOxB6S/aCNOCLbhCeypKX5Q0Aosc5YcmCJgkwO5BERCC6Ee7NMbNB2vHmQ==}
+  '@turf/rhumb-bearing@7.2.0':
+    resolution: {integrity: sha512-jbdexlrR8X2ZauUciHx3tRwG+BXoMXke4B8p8/IgDlAfIrVdzAxSQN89FMzIKnjJ/kdLjo9bFGvb92bu31Etug==}
 
-  '@turf/standard-deviational-ellipse@6.5.0':
-    resolution: {integrity: sha512-02CAlz8POvGPFK2BKK8uHGUk/LXb0MK459JVjKxLC2yJYieOBTqEbjP0qaWhiBhGzIxSMaqe8WxZ0KvqdnstHA==}
+  '@turf/rhumb-destination@7.2.0':
+    resolution: {integrity: sha512-U9OLgLAHlH4Wfx3fBZf3jvnkDjdTcfRan5eI7VPV1+fQWkOteATpzkiRjCvSYK575GljVwWBjkKca8LziGWitQ==}
 
-  '@turf/tag@6.5.0':
-    resolution: {integrity: sha512-XwlBvrOV38CQsrNfrxvBaAPBQgXMljeU0DV8ExOyGM7/hvuGHJw3y8kKnQ4lmEQcmcrycjDQhP7JqoRv8vFssg==}
+  '@turf/rhumb-distance@7.2.0':
+    resolution: {integrity: sha512-NsijTPON1yOc9tirRPEQQuJ5aQi7pREsqchQquaYKbHNWsexZjcDi4wnw2kM3Si4XjmgynT+2f7aXH7FHarHzw==}
 
-  '@turf/tesselate@6.5.0':
-    resolution: {integrity: sha512-M1HXuyZFCfEIIKkglh/r5L9H3c5QTEsnMBoZOFQiRnGPGmJWcaBissGb7mTFX2+DKE7FNWXh4TDnZlaLABB0dQ==}
+  '@turf/sample@7.2.0':
+    resolution: {integrity: sha512-f+ZbcbQJ9glQ/F26re8LadxO0ORafy298EJZe6XtbctRTJrNus6UNAsl8+GYXFqMnXM22tbTAznnJX3ZiWNorA==}
 
-  '@turf/tin@6.5.0':
-    resolution: {integrity: sha512-YLYikRzKisfwj7+F+Tmyy/LE3d2H7D4kajajIfc9mlik2+esG7IolsX/+oUz1biguDYsG0DUA8kVYXDkobukfg==}
+  '@turf/sector@7.2.0':
+    resolution: {integrity: sha512-zL06MjbbMG4DdpiNz+Q9Ax8jsCekt3R76uxeWShulAGkyDB5smdBOUDoRwxn05UX7l4kKv4Ucq2imQXhxKFd1w==}
 
-  '@turf/transform-rotate@6.5.0':
-    resolution: {integrity: sha512-A2Ip1v4246ZmpssxpcL0hhiVBEf4L8lGnSPWTgSv5bWBEoya2fa/0SnFX9xJgP40rMP+ZzRaCN37vLHbv1Guag==}
+  '@turf/shortest-path@7.2.0':
+    resolution: {integrity: sha512-6fpx8feZ2jMSaeRaFdqFShGWkNb+veUOeyLFSHA/aRD9n/e9F2pWZoRbQWKbKTpcKFJ2FnDEqCZnh/GrcAsqWA==}
 
-  '@turf/transform-scale@6.5.0':
-    resolution: {integrity: sha512-VsATGXC9rYM8qTjbQJ/P7BswKWXHdnSJ35JlV4OsZyHBMxJQHftvmZJsFbOqVtQnIQIzf2OAly6rfzVV9QLr7g==}
+  '@turf/simplify@7.2.0':
+    resolution: {integrity: sha512-9YHIfSc8BXQfi5IvEMbCeQYqNch0UawIGwbboJaoV8rodhtk6kKV2wrpXdGqk/6Thg6/RWvChJFKVVTjVrULyQ==}
 
-  '@turf/transform-translate@6.5.0':
-    resolution: {integrity: sha512-NABLw5VdtJt/9vSstChp93pc6oel4qXEos56RBMsPlYB8hzNTEKYtC146XJvyF4twJeeYS8RVe1u7KhoFwEM5w==}
+  '@turf/square-grid@7.2.0':
+    resolution: {integrity: sha512-EmzGXa90hz+tiCOs9wX+Lak6pH0Vghb7QuX6KZej+pmWi3Yz7vdvQLmy/wuN048+wSkD5c8WUo/kTeNDe7GnmA==}
 
-  '@turf/triangle-grid@6.5.0':
-    resolution: {integrity: sha512-2jToUSAS1R1htq4TyLQYPTIsoy6wg3e3BQXjm2rANzw4wPQCXGOxrur1Fy9RtzwqwljlC7DF4tg0OnWr8RjmfA==}
+  '@turf/square@7.2.0':
+    resolution: {integrity: sha512-9pMoAGFvqzCDOlO9IRSSBCGXKbl8EwMx6xRRBMKdZgpS0mZgfm9xiptMmx/t1m4qqHIlb/N+3MUF7iMBx6upcA==}
 
-  '@turf/truncate@6.5.0':
-    resolution: {integrity: sha512-pFxg71pLk+eJj134Z9yUoRhIi8vqnnKvCYwdT4x/DQl/19RVdq1tV3yqOT3gcTQNfniteylL5qV1uTBDV5sgrg==}
+  '@turf/standard-deviational-ellipse@7.2.0':
+    resolution: {integrity: sha512-+uC0pR2nRjm90JvMXe/2xOCZsYV2II1ZZ2zmWcBWv6bcFXBspcxk2QfCC3k0bj6jDapELzoQgnn3cG5lbdQV2w==}
 
-  '@turf/turf@6.5.0':
-    resolution: {integrity: sha512-ipMCPnhu59bh92MNt8+pr1VZQhHVuTMHklciQURo54heoxRzt1neNYZOBR6jdL+hNsbDGAECMuIpAutX+a3Y+w==}
+  '@turf/tag@7.2.0':
+    resolution: {integrity: sha512-TAFvsbp5TCBqXue8ui+CtcLsPZ6NPC88L8Ad6Hb/R6VAi21qe0U42WJHQYXzWmtThoTNwxi+oKSeFbRDsr0FIA==}
 
-  '@turf/union@6.5.0':
-    resolution: {integrity: sha512-igYWCwP/f0RFHIlC2c0SKDuM/ObBaqSljI3IdV/x71805QbIvY/BYGcJdyNcgEA6cylIGl/0VSlIbpJHZ9ldhw==}
+  '@turf/tesselate@7.2.0':
+    resolution: {integrity: sha512-zHGcG85aOJJu1seCm+CYTJ3UempX4Xtyt669vFG6Hbr/Hc7ii6STQ2ysFr7lJwFtU9uyYhphVrrgwIqwglvI/Q==}
 
-  '@turf/unkink-polygon@6.5.0':
-    resolution: {integrity: sha512-8QswkzC0UqKmN1DT6HpA9upfa1HdAA5n6bbuzHy8NJOX8oVizVAqfEPY0wqqTgboDjmBR4yyImsdPGUl3gZ8JQ==}
+  '@turf/tin@7.2.0':
+    resolution: {integrity: sha512-y24Vt3oeE6ZXvyLJamP0Ke02rPlDGE9gF7OFADnR0mT+2uectb0UTIBC3kKzON80TEAlA3GXpKFkCW5Fo/O/Kg==}
 
-  '@turf/voronoi@6.5.0':
-    resolution: {integrity: sha512-C/xUsywYX+7h1UyNqnydHXiun4UPjK88VDghtoRypR9cLlb7qozkiLRphQxxsCM0KxyxpVPHBVQXdAL3+Yurow==}
+  '@turf/transform-rotate@7.2.0':
+    resolution: {integrity: sha512-EMCj0Zqy3cF9d3mGRqDlYnX2ZBXe3LgT+piDR0EuF5c5sjuKErcFcaBIsn/lg1gp4xCNZFinkZ3dsFfgGHf6fw==}
+
+  '@turf/transform-scale@7.2.0':
+    resolution: {integrity: sha512-HYB+pw938eeI8s1/zSWFy6hq+t38fuUaBb0jJsZB1K9zQ1WjEYpPvKF/0//80zNPlyxLv3cOkeBucso3hzI07A==}
+
+  '@turf/transform-translate@7.2.0':
+    resolution: {integrity: sha512-zAglR8MKCqkzDTjGMIQgbg/f+Q3XcKVzr9cELw5l9CrS1a0VTSDtBZLDm0kWx0ankwtam7ZmI2jXyuQWT8Gbug==}
+
+  '@turf/triangle-grid@7.2.0':
+    resolution: {integrity: sha512-4gcAqWKh9hg6PC5nNSb9VWyLgl821cwf9yR9yEzQhEFfwYL/pZONBWCO1cwVF23vSYMSMm+/TwqxH4emxaArfw==}
+
+  '@turf/truncate@7.2.0':
+    resolution: {integrity: sha512-jyFzxYbPugK4XjV5V/k6Xr3taBjjvo210IbPHJXw0Zh7Y6sF+hGxeRVtSuZ9VP/6oRyqAOHKUrze+OOkPqBgUg==}
+
+  '@turf/turf@7.2.0':
+    resolution: {integrity: sha512-G1kKBu4hYgoNoRJgnpJohNuS7bLnoWHZ2G/4wUMym5xOSiYah6carzdTEsMoTsauyi7ilByWHx5UHwbjjCVcBw==}
+
+  '@turf/union@7.2.0':
+    resolution: {integrity: sha512-Xex/cfKSmH0RZRWSJl4RLlhSmEALVewywiEXcu0aIxNbuZGTcpNoI0h4oLFrE/fUd0iBGFg/EGLXRL3zTfpg6g==}
+
+  '@turf/unkink-polygon@7.2.0':
+    resolution: {integrity: sha512-dFPfzlIgkEr15z6oXVxTSWshWi51HeITGVFtl1GAKGMtiXJx1uMqnfRsvljqEjaQu/4AzG1QAp3b+EkSklQSiQ==}
+
+  '@turf/voronoi@7.2.0':
+    resolution: {integrity: sha512-3K6N0LtJsWTXxPb/5N2qD9e8f4q8+tjTbGV3lE3v8x06iCnNlnuJnqM5NZNPpvgvCatecBkhClO3/3RndE61Fw==}
+
+  '@types/d3-voronoi@1.1.12':
+    resolution: {integrity: sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==}
 
   '@types/estree@0.0.39':
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
@@ -2140,8 +2167,8 @@ packages:
   '@types/fs-extra@8.1.5':
     resolution: {integrity: sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==}
 
-  '@types/geojson@7946.0.8':
-    resolution: {integrity: sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==}
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
@@ -2523,6 +2550,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
@@ -2575,10 +2605,6 @@ packages:
 
   call-bind@1.0.5:
     resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
-
-  call-bind@1.0.7:
-    resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
-    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -2823,10 +2849,6 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
-  deep-equal@1.1.2:
-    resolution: {integrity: sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==}
-    engines: {node: '>= 0.4'}
-
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2841,10 +2863,6 @@ packages:
     resolution: {integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==}
     engines: {node: '>= 0.4'}
 
-  define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
-
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
@@ -2852,9 +2870,6 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-
-  density-clustering@1.3.0:
-    resolution: {integrity: sha512-icpmBubVTwLnsaor9qH/4tG5+7+f61VcqMN3V3pm9sxxSCt2Jcs0zWOgwZW9ARJYaKD3FumIgHiMOcIMRRAzFQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2936,10 +2951,6 @@ packages:
 
   es-abstract@1.22.3:
     resolution: {integrity: sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==}
-    engines: {node: '>= 0.4'}
-
-  es-define-property@1.0.0:
-    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
     engines: {node: '>= 0.4'}
 
   es-define-property@1.0.1:
@@ -3441,11 +3452,11 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
-  geojson-equality@0.1.6:
-    resolution: {integrity: sha512-TqG8YbqizP3EfwP5Uw4aLu6pKkg6JQK9uq/XZ1lXQntvTHD1BBKJWhNpJ2M0ax6TuWMP3oyx6Oq7FCIfznrgpQ==}
+  geojson-equality-ts@1.0.2:
+    resolution: {integrity: sha512-h3Ryq+0mCSN/7yLs0eDgrZhvc9af23o/QuC4aTiuuzP/MRCtd6mf5rLsLRY44jX0RPUfM8c4GqERQmlUxPGPoQ==}
 
-  geojson-rbush@3.2.0:
-    resolution: {integrity: sha512-oVltQTXolxvsz1sZnutlSuLDEcQAKYC/uXt9zDzJJ6bu0W+baTI8LZBaTup5afzibEH4N3jlq2p+a152wlBJ7w==}
+  geojson-polygon-self-intersections@1.2.1:
+    resolution: {integrity: sha512-/QM1b5u2d172qQVO//9CGRa49jEmclKEsYOQmWP9ooEjj63tBM51m2805xsbxkzlEELQ2REgTf700gUhhlegxA==}
 
   geolib@3.3.4:
     resolution: {integrity: sha512-EicrlLLL3S42gE9/wde+11uiaYAaeSVDwCUIv2uMIoRBfNJCn8EsSI+6nS3r4TCKDO6+RQNM9ayLq2at+oZQWQ==}
@@ -3547,9 +3558,6 @@ packages:
 
   has-property-descriptors@1.0.1:
     resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
-
-  has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   has-proto@1.0.1:
     resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
@@ -3668,10 +3676,6 @@ packages:
 
   internal-slot@1.0.6:
     resolution: {integrity: sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==}
-    engines: {node: '>= 0.4'}
-
-  is-arguments@1.1.1:
-    resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
     engines: {node: '>= 0.4'}
 
   is-array-buffer@3.0.2:
@@ -3879,6 +3883,10 @@ packages:
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
+  jsts@2.7.1:
+    resolution: {integrity: sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==}
+    engines: {node: '>= 12'}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -3986,6 +3994,9 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  marchingsquares@1.3.3:
+    resolution: {integrity: sha512-gz6nNQoVK7Lkh2pZulrT4qd4347S/toG9RXH2pyzhLgkL5mLkBoqgv4EvAGXcV0ikDW72n/OQb3Xe8bGagQZCg==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -4141,10 +4152,6 @@ packages:
 
   object-inspect@1.13.1:
     resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
-
-  object-is@1.1.6:
-    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
-    engines: {node: '>= 0.4'}
 
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -4314,11 +4321,14 @@ packages:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
 
+  point-in-polygon-hao@1.2.4:
+    resolution: {integrity: sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==}
+
   point-in-polygon@1.1.0:
     resolution: {integrity: sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==}
 
-  polygon-clipping@0.15.7:
-    resolution: {integrity: sha512-nhfdr83ECBg6xtqOAJab1tbksbBAOMUltN60bU+llHVOL0e5Onm1WpAXXWXVB39L8AJFssoIhEVuy/S90MmotA==}
+  polyclip-ts@0.16.8:
+    resolution: {integrity: sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==}
 
   postcss-calc@8.2.4:
     resolution: {integrity: sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==}
@@ -4974,10 +4984,6 @@ packages:
     resolution: {integrity: sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==}
     engines: {node: '>= 0.4'}
 
-  set-function-length@1.2.2:
-    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
-    engines: {node: '>= 0.4'}
-
   set-function-name@2.0.1:
     resolution: {integrity: sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==}
     engines: {node: '>= 0.4'}
@@ -5048,8 +5054,8 @@ packages:
   spdx-license-ids@3.0.20:
     resolution: {integrity: sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==}
 
-  splaytree@3.1.2:
-    resolution: {integrity: sha512-4OM2BJgC5UzrhVnnJA4BkHKGtjXNzzUfpQjCO8I05xYPsfS/VuQDwjCGGMi8rYQilHEV4j8NBqTFbls/PZEE7A==}
+  splaytree-ts@1.0.2:
+    resolution: {integrity: sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==}
 
   split-file@2.3.0:
     resolution: {integrity: sha512-dc/0SDKvjtSjUI999vkclWQAk5xhD86pKEWWL2ULR6WrHI9/euIEMG/JSUbwbNW8IC+gYLJqynSGHwlOVmSwGA==}
@@ -5142,6 +5148,9 @@ packages:
     resolution: {integrity: sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  sweepline-intersections@1.5.0:
+    resolution: {integrity: sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -5270,14 +5279,14 @@ packages:
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsutils@3.21.0:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-
-  turf-jsts@1.2.3:
-    resolution: {integrity: sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -7072,821 +7081,1117 @@ snapshots:
 
   '@trysound/sax@0.2.0': {}
 
-  '@turf/along@6.5.0':
+  '@turf/along@7.2.0':
     dependencies:
-      '@turf/bearing': 6.5.0
-      '@turf/destination': 6.5.0
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/bearing': 7.2.0
+      '@turf/destination': 7.2.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/angle@6.5.0':
+  '@turf/angle@7.2.0':
     dependencies:
-      '@turf/bearing': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/rhumb-bearing': 6.5.0
+      '@turf/bearing': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/rhumb-bearing': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/area@6.5.0':
+  '@turf/area@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/bbox-clip@6.5.0':
+  '@turf/bbox-clip@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/bbox-polygon@6.5.0':
+  '@turf/bbox-polygon@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/bbox@6.5.0':
+  '@turf/bbox@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/bearing@6.5.0':
+  '@turf/bearing@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/bezier-spline@6.5.0':
+  '@turf/bezier-spline@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/boolean-clockwise@6.5.0':
+  '@turf/boolean-clockwise@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/boolean-contains@6.5.0':
+  '@turf/boolean-concave@7.2.0':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/boolean-point-in-polygon': 6.5.0
-      '@turf/boolean-point-on-line': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/boolean-crosses@6.5.0':
+  '@turf/boolean-contains@7.2.0':
     dependencies:
-      '@turf/boolean-point-in-polygon': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/line-intersect': 6.5.0
-      '@turf/polygon-to-line': 6.5.0
+      '@turf/bbox': 7.2.0
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/boolean-point-on-line': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/boolean-disjoint@6.5.0':
+  '@turf/boolean-crosses@7.2.0':
     dependencies:
-      '@turf/boolean-point-in-polygon': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/line-intersect': 6.5.0
-      '@turf/meta': 6.5.0
-      '@turf/polygon-to-line': 6.5.0
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/line-intersect': 7.2.0
+      '@turf/polygon-to-line': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/boolean-equal@6.5.0':
+  '@turf/boolean-disjoint@7.2.0':
     dependencies:
-      '@turf/clean-coords': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      geojson-equality: 0.1.6
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/line-intersect': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/polygon-to-line': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/boolean-intersects@6.5.0':
+  '@turf/boolean-equal@7.2.0':
     dependencies:
-      '@turf/boolean-disjoint': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/clean-coords': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      geojson-equality-ts: 1.0.2
+      tslib: 2.8.1
 
-  '@turf/boolean-overlap@6.5.0':
+  '@turf/boolean-intersects@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/line-intersect': 6.5.0
-      '@turf/line-overlap': 6.5.0
-      '@turf/meta': 6.5.0
-      geojson-equality: 0.1.6
+      '@turf/boolean-disjoint': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/boolean-parallel@6.5.0':
+  '@turf/boolean-overlap@7.2.0':
     dependencies:
-      '@turf/clean-coords': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/line-segment': 6.5.0
-      '@turf/rhumb-bearing': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/line-intersect': 7.2.0
+      '@turf/line-overlap': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      geojson-equality-ts: 1.0.2
+      tslib: 2.8.1
 
-  '@turf/boolean-point-in-polygon@6.5.0':
+  '@turf/boolean-parallel@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/clean-coords': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/line-segment': 7.2.0
+      '@turf/rhumb-bearing': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/boolean-point-on-line@6.5.0':
+  '@turf/boolean-point-in-polygon@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      point-in-polygon-hao: 1.2.4
+      tslib: 2.8.1
 
-  '@turf/boolean-within@6.5.0':
+  '@turf/boolean-point-on-line@7.2.0':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/boolean-point-in-polygon': 6.5.0
-      '@turf/boolean-point-on-line': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/buffer@6.5.0':
+  '@turf/boolean-touches@7.2.0':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/center': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
-      '@turf/projection': 6.5.0
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/boolean-point-on-line': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/boolean-valid@7.2.0':
+    dependencies:
+      '@turf/bbox': 7.2.0
+      '@turf/boolean-crosses': 7.2.0
+      '@turf/boolean-disjoint': 7.2.0
+      '@turf/boolean-overlap': 7.2.0
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/boolean-point-on-line': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/line-intersect': 7.2.0
+      '@types/geojson': 7946.0.16
+      geojson-polygon-self-intersections: 1.2.1
+      tslib: 2.8.1
+
+  '@turf/boolean-within@7.2.0':
+    dependencies:
+      '@turf/bbox': 7.2.0
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/boolean-point-on-line': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/buffer@7.2.0':
+    dependencies:
+      '@turf/bbox': 7.2.0
+      '@turf/center': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/jsts': 2.7.2
+      '@turf/meta': 7.2.0
+      '@turf/projection': 7.2.0
+      '@types/geojson': 7946.0.16
       d3-geo: 1.7.1
-      turf-jsts: 1.2.3
 
-  '@turf/center-mean@6.5.0':
+  '@turf/center-mean@7.2.0':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/bbox': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/center-median@6.5.0':
+  '@turf/center-median@7.2.0':
     dependencies:
-      '@turf/center-mean': 6.5.0
-      '@turf/centroid': 6.5.0
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/center-mean': 7.2.0
+      '@turf/centroid': 7.2.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/center-of-mass@6.5.0':
+  '@turf/center-of-mass@7.2.0':
     dependencies:
-      '@turf/centroid': 6.5.0
-      '@turf/convex': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/centroid': 7.2.0
+      '@turf/convex': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/center@6.5.0':
+  '@turf/center@7.2.0':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/helpers': 6.5.0
+      '@turf/bbox': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/centroid@6.5.0':
+  '@turf/centroid@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/circle@6.5.0':
+  '@turf/circle@7.2.0':
     dependencies:
-      '@turf/destination': 6.5.0
-      '@turf/helpers': 6.5.0
+      '@turf/destination': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/clean-coords@6.5.0':
+  '@turf/clean-coords@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/clone@6.5.0':
+  '@turf/clone@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/clusters-dbscan@6.5.0':
+  '@turf/clusters-dbscan@7.2.0':
     dependencies:
-      '@turf/clone': 6.5.0
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
-      density-clustering: 1.3.0
+      '@turf/clone': 7.2.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      rbush: 3.0.1
+      tslib: 2.8.1
 
-  '@turf/clusters-kmeans@6.5.0':
+  '@turf/clusters-kmeans@7.2.0':
     dependencies:
-      '@turf/clone': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/clone': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
       skmeans: 0.9.7
+      tslib: 2.8.1
 
-  '@turf/clusters@6.5.0':
+  '@turf/clusters@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/collect@6.5.0':
+  '@turf/collect@7.2.0':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/boolean-point-in-polygon': 6.5.0
-      '@turf/helpers': 6.5.0
-      rbush: 2.0.2
+      '@turf/bbox': 7.2.0
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      rbush: 3.0.1
+      tslib: 2.8.1
 
-  '@turf/combine@6.5.0':
+  '@turf/combine@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/concave@6.5.0':
+  '@turf/concave@7.2.0':
     dependencies:
-      '@turf/clone': 6.5.0
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
-      '@turf/tin': 6.5.0
+      '@turf/clone': 7.2.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/tin': 7.2.0
+      '@types/geojson': 7946.0.16
       topojson-client: 3.1.0
       topojson-server: 3.0.1
+      tslib: 2.8.1
 
-  '@turf/convex@6.5.0':
+  '@turf/convex@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
       concaveman: 1.2.1
+      tslib: 2.8.1
 
-  '@turf/destination@6.5.0':
+  '@turf/destination@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/difference@6.5.0':
+  '@turf/difference@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      polygon-clipping: 0.15.7
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      polyclip-ts: 0.16.8
+      tslib: 2.8.1
 
-  '@turf/dissolve@6.5.0':
+  '@turf/dissolve@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
-      polygon-clipping: 0.15.7
+      '@turf/flatten': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      polyclip-ts: 0.16.8
+      tslib: 2.8.1
 
-  '@turf/distance-weight@6.5.0':
+  '@turf/distance-weight@7.2.0':
     dependencies:
-      '@turf/centroid': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/centroid': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/distance@6.5.0':
+  '@turf/distance@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/ellipse@6.5.0':
+  '@turf/ellipse@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/rhumb-destination': 6.5.0
-      '@turf/transform-rotate': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/rhumb-destination': 7.2.0
+      '@turf/transform-rotate': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/envelope@6.5.0':
+  '@turf/envelope@7.2.0':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/bbox-polygon': 6.5.0
-      '@turf/helpers': 6.5.0
+      '@turf/bbox': 7.2.0
+      '@turf/bbox-polygon': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/explode@6.5.0':
+  '@turf/explode@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/flatten@6.5.0':
+  '@turf/flatten@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/flip@6.5.0':
+  '@turf/flip@7.2.0':
     dependencies:
-      '@turf/clone': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/clone': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/great-circle@6.5.0':
+  '@turf/geojson-rbush@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/bbox': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      rbush: 3.0.1
 
-  '@turf/helpers@6.5.0': {}
-
-  '@turf/hex-grid@6.5.0':
+  '@turf/great-circle@7.2.0':
     dependencies:
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/intersect': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
 
-  '@turf/interpolate@6.5.0':
+  '@turf/helpers@7.2.0':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/centroid': 6.5.0
-      '@turf/clone': 6.5.0
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/hex-grid': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
-      '@turf/point-grid': 6.5.0
-      '@turf/square-grid': 6.5.0
-      '@turf/triangle-grid': 6.5.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/intersect@6.5.0':
+  '@turf/hex-grid@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      polygon-clipping: 0.15.7
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/intersect': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/invariant@6.5.0':
+  '@turf/interpolate@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
+      '@turf/bbox': 7.2.0
+      '@turf/centroid': 7.2.0
+      '@turf/clone': 7.2.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/hex-grid': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/point-grid': 7.2.0
+      '@turf/square-grid': 7.2.0
+      '@turf/triangle-grid': 7.2.0
+      '@types/geojson': 7946.0.16
 
-  '@turf/isobands@6.5.0':
+  '@turf/intersect@7.2.0':
     dependencies:
-      '@turf/area': 6.5.0
-      '@turf/bbox': 6.5.0
-      '@turf/boolean-point-in-polygon': 6.5.0
-      '@turf/explode': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
-      object-assign: 4.1.1
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      polyclip-ts: 0.16.8
+      tslib: 2.8.1
 
-  '@turf/isolines@6.5.0':
+  '@turf/invariant@7.2.0':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
-      object-assign: 4.1.1
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/kinks@6.5.0':
+  '@turf/isobands@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
+      '@turf/area': 7.2.0
+      '@turf/bbox': 7.2.0
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/explode': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      marchingsquares: 1.3.3
+      tslib: 2.8.1
 
-  '@turf/length@6.5.0':
+  '@turf/isolines@7.2.0':
     dependencies:
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/bbox': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      marchingsquares: 1.3.3
+      tslib: 2.8.1
 
-  '@turf/line-arc@6.5.0':
+  '@turf/jsts@2.7.2':
     dependencies:
-      '@turf/circle': 6.5.0
-      '@turf/destination': 6.5.0
-      '@turf/helpers': 6.5.0
+      jsts: 2.7.1
 
-  '@turf/line-chunk@6.5.0':
+  '@turf/kinks@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/length': 6.5.0
-      '@turf/line-slice-along': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/line-intersect@6.5.0':
+  '@turf/length@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/line-segment': 6.5.0
-      '@turf/meta': 6.5.0
-      geojson-rbush: 3.2.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/line-offset@6.5.0':
+  '@turf/line-arc@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/circle': 7.2.0
+      '@turf/destination': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/line-overlap@6.5.0':
+  '@turf/line-chunk@7.2.0':
     dependencies:
-      '@turf/boolean-point-on-line': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/line-segment': 6.5.0
-      '@turf/meta': 6.5.0
-      '@turf/nearest-point-on-line': 6.5.0
-      deep-equal: 1.1.2
-      geojson-rbush: 3.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/length': 7.2.0
+      '@turf/line-slice-along': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
 
-  '@turf/line-segment@6.5.0':
+  '@turf/line-intersect@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      sweepline-intersections: 1.5.0
+      tslib: 2.8.1
 
-  '@turf/line-slice-along@6.5.0':
+  '@turf/line-offset@7.2.0':
     dependencies:
-      '@turf/bearing': 6.5.0
-      '@turf/destination': 6.5.0
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
 
-  '@turf/line-slice@6.5.0':
+  '@turf/line-overlap@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/nearest-point-on-line': 6.5.0
+      '@turf/boolean-point-on-line': 7.2.0
+      '@turf/geojson-rbush': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/line-segment': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/nearest-point-on-line': 7.2.0
+      '@types/geojson': 7946.0.16
+      fast-deep-equal: 3.1.3
+      tslib: 2.8.1
 
-  '@turf/line-split@6.5.0':
+  '@turf/line-segment@7.2.0':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/line-intersect': 6.5.0
-      '@turf/line-segment': 6.5.0
-      '@turf/meta': 6.5.0
-      '@turf/nearest-point-on-line': 6.5.0
-      '@turf/square': 6.5.0
-      '@turf/truncate': 6.5.0
-      geojson-rbush: 3.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/line-to-polygon@6.5.0':
+  '@turf/line-slice-along@7.2.0':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/clone': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/bearing': 7.2.0
+      '@turf/destination': 7.2.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
 
-  '@turf/mask@6.5.0':
+  '@turf/line-slice@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      polygon-clipping: 0.15.7
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/nearest-point-on-line': 7.2.0
+      '@types/geojson': 7946.0.16
 
-  '@turf/meta@6.5.0':
+  '@turf/line-split@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
+      '@turf/bbox': 7.2.0
+      '@turf/geojson-rbush': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/line-intersect': 7.2.0
+      '@turf/line-segment': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/nearest-point-on-line': 7.2.0
+      '@turf/square': 7.2.0
+      '@turf/truncate': 7.2.0
+      '@types/geojson': 7946.0.16
 
-  '@turf/midpoint@6.5.0':
+  '@turf/line-to-polygon@7.2.0':
     dependencies:
-      '@turf/bearing': 6.5.0
-      '@turf/destination': 6.5.0
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
+      '@turf/bbox': 7.2.0
+      '@turf/clone': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/moran-index@6.5.0':
+  '@turf/mask@7.2.0':
     dependencies:
-      '@turf/distance-weight': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/clone': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      polyclip-ts: 0.16.8
+      tslib: 2.8.1
 
-  '@turf/nearest-point-on-line@6.5.0':
+  '@turf/meta@7.2.0':
     dependencies:
-      '@turf/bearing': 6.5.0
-      '@turf/destination': 6.5.0
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/line-intersect': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
 
-  '@turf/nearest-point-to-line@6.5.0':
+  '@turf/midpoint@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
-      '@turf/point-to-line-distance': 6.5.0
-      object-assign: 4.1.1
+      '@turf/bearing': 7.2.0
+      '@turf/destination': 7.2.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/nearest-point@6.5.0':
+  '@turf/moran-index@7.2.0':
     dependencies:
-      '@turf/clone': 6.5.0
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/distance-weight': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/planepoint@6.5.0':
+  '@turf/nearest-neighbor-analysis@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/area': 7.2.0
+      '@turf/bbox': 7.2.0
+      '@turf/bbox-polygon': 7.2.0
+      '@turf/centroid': 7.2.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/nearest-point': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/point-grid@6.5.0':
+  '@turf/nearest-point-on-line@7.2.0':
     dependencies:
-      '@turf/boolean-within': 6.5.0
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/point-on-feature@6.5.0':
+  '@turf/nearest-point-to-line@7.2.0':
     dependencies:
-      '@turf/boolean-point-in-polygon': 6.5.0
-      '@turf/center': 6.5.0
-      '@turf/explode': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/nearest-point': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/point-to-line-distance': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/point-to-line-distance@6.5.0':
+  '@turf/nearest-point@7.2.0':
     dependencies:
-      '@turf/bearing': 6.5.0
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
-      '@turf/projection': 6.5.0
-      '@turf/rhumb-bearing': 6.5.0
-      '@turf/rhumb-distance': 6.5.0
+      '@turf/clone': 7.2.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/points-within-polygon@6.5.0':
+  '@turf/planepoint@7.2.0':
     dependencies:
-      '@turf/boolean-point-in-polygon': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/polygon-smooth@6.5.0':
+  '@turf/point-grid@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/boolean-within': 7.2.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/polygon-tangents@6.5.0':
+  '@turf/point-on-feature@7.2.0':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/boolean-within': 6.5.0
-      '@turf/explode': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/nearest-point': 6.5.0
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/center': 7.2.0
+      '@turf/explode': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/nearest-point': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/polygon-to-line@6.5.0':
+  '@turf/point-to-line-distance@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/bearing': 7.2.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/nearest-point-on-line': 7.2.0
+      '@turf/projection': 7.2.0
+      '@turf/rhumb-bearing': 7.2.0
+      '@turf/rhumb-distance': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/polygonize@6.5.0':
+  '@turf/point-to-polygon-distance@7.2.0':
     dependencies:
-      '@turf/boolean-point-in-polygon': 6.5.0
-      '@turf/envelope': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/point-to-line-distance': 7.2.0
+      '@turf/polygon-to-line': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/projection@6.5.0':
+  '@turf/points-within-polygon@7.2.0':
     dependencies:
-      '@turf/clone': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/random@6.5.0':
+  '@turf/polygon-smooth@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/rectangle-grid@6.5.0':
+  '@turf/polygon-tangents@7.2.0':
     dependencies:
-      '@turf/boolean-intersects': 6.5.0
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
+      '@turf/bbox': 7.2.0
+      '@turf/boolean-within': 7.2.0
+      '@turf/explode': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/nearest-point': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/rewind@6.5.0':
+  '@turf/polygon-to-line@7.2.0':
     dependencies:
-      '@turf/boolean-clockwise': 6.5.0
-      '@turf/clone': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/rhumb-bearing@6.5.0':
+  '@turf/polygonize@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/envelope': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/rhumb-destination@6.5.0':
+  '@turf/projection@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/clone': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/rhumb-distance@6.5.0':
+  '@turf/quadrat-analysis@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/area': 7.2.0
+      '@turf/bbox': 7.2.0
+      '@turf/bbox-polygon': 7.2.0
+      '@turf/centroid': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/point-grid': 7.2.0
+      '@turf/random': 7.2.0
+      '@turf/square-grid': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/sample@6.5.0':
+  '@turf/random@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/sector@6.5.0':
+  '@turf/rectangle-grid@7.2.0':
     dependencies:
-      '@turf/circle': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/line-arc': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/boolean-intersects': 7.2.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/shortest-path@6.5.0':
+  '@turf/rewind@7.2.0':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/bbox-polygon': 6.5.0
-      '@turf/boolean-point-in-polygon': 6.5.0
-      '@turf/clean-coords': 6.5.0
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
-      '@turf/transform-scale': 6.5.0
+      '@turf/boolean-clockwise': 7.2.0
+      '@turf/clone': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/simplify@6.5.0':
+  '@turf/rhumb-bearing@7.2.0':
     dependencies:
-      '@turf/clean-coords': 6.5.0
-      '@turf/clone': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/square-grid@6.5.0':
+  '@turf/rhumb-destination@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/rectangle-grid': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/square@6.5.0':
+  '@turf/rhumb-distance@7.2.0':
     dependencies:
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/standard-deviational-ellipse@6.5.0':
+  '@turf/sample@7.2.0':
     dependencies:
-      '@turf/center-mean': 6.5.0
-      '@turf/ellipse': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
-      '@turf/points-within-polygon': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/tag@6.5.0':
+  '@turf/sector@7.2.0':
     dependencies:
-      '@turf/boolean-point-in-polygon': 6.5.0
-      '@turf/clone': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/circle': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/line-arc': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/tesselate@6.5.0':
+  '@turf/shortest-path@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
+      '@turf/bbox': 7.2.0
+      '@turf/bbox-polygon': 7.2.0
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/clean-coords': 7.2.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/transform-scale': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/simplify@7.2.0':
+    dependencies:
+      '@turf/clean-coords': 7.2.0
+      '@turf/clone': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/square-grid@7.2.0':
+    dependencies:
+      '@turf/helpers': 7.2.0
+      '@turf/rectangle-grid': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/square@7.2.0':
+    dependencies:
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/standard-deviational-ellipse@7.2.0':
+    dependencies:
+      '@turf/center-mean': 7.2.0
+      '@turf/ellipse': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/points-within-polygon': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/tag@7.2.0':
+    dependencies:
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/clone': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/tesselate@7.2.0':
+    dependencies:
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
       earcut: 2.2.4
+      tslib: 2.8.1
 
-  '@turf/tin@6.5.0':
+  '@turf/tin@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/transform-rotate@6.5.0':
+  '@turf/transform-rotate@7.2.0':
     dependencies:
-      '@turf/centroid': 6.5.0
-      '@turf/clone': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
-      '@turf/rhumb-bearing': 6.5.0
-      '@turf/rhumb-destination': 6.5.0
-      '@turf/rhumb-distance': 6.5.0
+      '@turf/centroid': 7.2.0
+      '@turf/clone': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/rhumb-bearing': 7.2.0
+      '@turf/rhumb-destination': 7.2.0
+      '@turf/rhumb-distance': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/transform-scale@6.5.0':
+  '@turf/transform-scale@7.2.0':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/center': 6.5.0
-      '@turf/centroid': 6.5.0
-      '@turf/clone': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
-      '@turf/rhumb-bearing': 6.5.0
-      '@turf/rhumb-destination': 6.5.0
-      '@turf/rhumb-distance': 6.5.0
+      '@turf/bbox': 7.2.0
+      '@turf/center': 7.2.0
+      '@turf/centroid': 7.2.0
+      '@turf/clone': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/rhumb-bearing': 7.2.0
+      '@turf/rhumb-destination': 7.2.0
+      '@turf/rhumb-distance': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/transform-translate@6.5.0':
+  '@turf/transform-translate@7.2.0':
     dependencies:
-      '@turf/clone': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/meta': 6.5.0
-      '@turf/rhumb-destination': 6.5.0
+      '@turf/clone': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/rhumb-destination': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/triangle-grid@6.5.0':
+  '@turf/triangle-grid@7.2.0':
     dependencies:
-      '@turf/distance': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/intersect': 6.5.0
+      '@turf/distance': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/intersect': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/truncate@6.5.0':
+  '@turf/truncate@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/turf@6.5.0':
+  '@turf/turf@7.2.0':
     dependencies:
-      '@turf/along': 6.5.0
-      '@turf/angle': 6.5.0
-      '@turf/area': 6.5.0
-      '@turf/bbox': 6.5.0
-      '@turf/bbox-clip': 6.5.0
-      '@turf/bbox-polygon': 6.5.0
-      '@turf/bearing': 6.5.0
-      '@turf/bezier-spline': 6.5.0
-      '@turf/boolean-clockwise': 6.5.0
-      '@turf/boolean-contains': 6.5.0
-      '@turf/boolean-crosses': 6.5.0
-      '@turf/boolean-disjoint': 6.5.0
-      '@turf/boolean-equal': 6.5.0
-      '@turf/boolean-intersects': 6.5.0
-      '@turf/boolean-overlap': 6.5.0
-      '@turf/boolean-parallel': 6.5.0
-      '@turf/boolean-point-in-polygon': 6.5.0
-      '@turf/boolean-point-on-line': 6.5.0
-      '@turf/boolean-within': 6.5.0
-      '@turf/buffer': 6.5.0
-      '@turf/center': 6.5.0
-      '@turf/center-mean': 6.5.0
-      '@turf/center-median': 6.5.0
-      '@turf/center-of-mass': 6.5.0
-      '@turf/centroid': 6.5.0
-      '@turf/circle': 6.5.0
-      '@turf/clean-coords': 6.5.0
-      '@turf/clone': 6.5.0
-      '@turf/clusters': 6.5.0
-      '@turf/clusters-dbscan': 6.5.0
-      '@turf/clusters-kmeans': 6.5.0
-      '@turf/collect': 6.5.0
-      '@turf/combine': 6.5.0
-      '@turf/concave': 6.5.0
-      '@turf/convex': 6.5.0
-      '@turf/destination': 6.5.0
-      '@turf/difference': 6.5.0
-      '@turf/dissolve': 6.5.0
-      '@turf/distance': 6.5.0
-      '@turf/distance-weight': 6.5.0
-      '@turf/ellipse': 6.5.0
-      '@turf/envelope': 6.5.0
-      '@turf/explode': 6.5.0
-      '@turf/flatten': 6.5.0
-      '@turf/flip': 6.5.0
-      '@turf/great-circle': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/hex-grid': 6.5.0
-      '@turf/interpolate': 6.5.0
-      '@turf/intersect': 6.5.0
-      '@turf/invariant': 6.5.0
-      '@turf/isobands': 6.5.0
-      '@turf/isolines': 6.5.0
-      '@turf/kinks': 6.5.0
-      '@turf/length': 6.5.0
-      '@turf/line-arc': 6.5.0
-      '@turf/line-chunk': 6.5.0
-      '@turf/line-intersect': 6.5.0
-      '@turf/line-offset': 6.5.0
-      '@turf/line-overlap': 6.5.0
-      '@turf/line-segment': 6.5.0
-      '@turf/line-slice': 6.5.0
-      '@turf/line-slice-along': 6.5.0
-      '@turf/line-split': 6.5.0
-      '@turf/line-to-polygon': 6.5.0
-      '@turf/mask': 6.5.0
-      '@turf/meta': 6.5.0
-      '@turf/midpoint': 6.5.0
-      '@turf/moran-index': 6.5.0
-      '@turf/nearest-point': 6.5.0
-      '@turf/nearest-point-on-line': 6.5.0
-      '@turf/nearest-point-to-line': 6.5.0
-      '@turf/planepoint': 6.5.0
-      '@turf/point-grid': 6.5.0
-      '@turf/point-on-feature': 6.5.0
-      '@turf/point-to-line-distance': 6.5.0
-      '@turf/points-within-polygon': 6.5.0
-      '@turf/polygon-smooth': 6.5.0
-      '@turf/polygon-tangents': 6.5.0
-      '@turf/polygon-to-line': 6.5.0
-      '@turf/polygonize': 6.5.0
-      '@turf/projection': 6.5.0
-      '@turf/random': 6.5.0
-      '@turf/rewind': 6.5.0
-      '@turf/rhumb-bearing': 6.5.0
-      '@turf/rhumb-destination': 6.5.0
-      '@turf/rhumb-distance': 6.5.0
-      '@turf/sample': 6.5.0
-      '@turf/sector': 6.5.0
-      '@turf/shortest-path': 6.5.0
-      '@turf/simplify': 6.5.0
-      '@turf/square': 6.5.0
-      '@turf/square-grid': 6.5.0
-      '@turf/standard-deviational-ellipse': 6.5.0
-      '@turf/tag': 6.5.0
-      '@turf/tesselate': 6.5.0
-      '@turf/tin': 6.5.0
-      '@turf/transform-rotate': 6.5.0
-      '@turf/transform-scale': 6.5.0
-      '@turf/transform-translate': 6.5.0
-      '@turf/triangle-grid': 6.5.0
-      '@turf/truncate': 6.5.0
-      '@turf/union': 6.5.0
-      '@turf/unkink-polygon': 6.5.0
-      '@turf/voronoi': 6.5.0
+      '@turf/along': 7.2.0
+      '@turf/angle': 7.2.0
+      '@turf/area': 7.2.0
+      '@turf/bbox': 7.2.0
+      '@turf/bbox-clip': 7.2.0
+      '@turf/bbox-polygon': 7.2.0
+      '@turf/bearing': 7.2.0
+      '@turf/bezier-spline': 7.2.0
+      '@turf/boolean-clockwise': 7.2.0
+      '@turf/boolean-concave': 7.2.0
+      '@turf/boolean-contains': 7.2.0
+      '@turf/boolean-crosses': 7.2.0
+      '@turf/boolean-disjoint': 7.2.0
+      '@turf/boolean-equal': 7.2.0
+      '@turf/boolean-intersects': 7.2.0
+      '@turf/boolean-overlap': 7.2.0
+      '@turf/boolean-parallel': 7.2.0
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/boolean-point-on-line': 7.2.0
+      '@turf/boolean-touches': 7.2.0
+      '@turf/boolean-valid': 7.2.0
+      '@turf/boolean-within': 7.2.0
+      '@turf/buffer': 7.2.0
+      '@turf/center': 7.2.0
+      '@turf/center-mean': 7.2.0
+      '@turf/center-median': 7.2.0
+      '@turf/center-of-mass': 7.2.0
+      '@turf/centroid': 7.2.0
+      '@turf/circle': 7.2.0
+      '@turf/clean-coords': 7.2.0
+      '@turf/clone': 7.2.0
+      '@turf/clusters': 7.2.0
+      '@turf/clusters-dbscan': 7.2.0
+      '@turf/clusters-kmeans': 7.2.0
+      '@turf/collect': 7.2.0
+      '@turf/combine': 7.2.0
+      '@turf/concave': 7.2.0
+      '@turf/convex': 7.2.0
+      '@turf/destination': 7.2.0
+      '@turf/difference': 7.2.0
+      '@turf/dissolve': 7.2.0
+      '@turf/distance': 7.2.0
+      '@turf/distance-weight': 7.2.0
+      '@turf/ellipse': 7.2.0
+      '@turf/envelope': 7.2.0
+      '@turf/explode': 7.2.0
+      '@turf/flatten': 7.2.0
+      '@turf/flip': 7.2.0
+      '@turf/geojson-rbush': 7.2.0
+      '@turf/great-circle': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/hex-grid': 7.2.0
+      '@turf/interpolate': 7.2.0
+      '@turf/intersect': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/isobands': 7.2.0
+      '@turf/isolines': 7.2.0
+      '@turf/kinks': 7.2.0
+      '@turf/length': 7.2.0
+      '@turf/line-arc': 7.2.0
+      '@turf/line-chunk': 7.2.0
+      '@turf/line-intersect': 7.2.0
+      '@turf/line-offset': 7.2.0
+      '@turf/line-overlap': 7.2.0
+      '@turf/line-segment': 7.2.0
+      '@turf/line-slice': 7.2.0
+      '@turf/line-slice-along': 7.2.0
+      '@turf/line-split': 7.2.0
+      '@turf/line-to-polygon': 7.2.0
+      '@turf/mask': 7.2.0
+      '@turf/meta': 7.2.0
+      '@turf/midpoint': 7.2.0
+      '@turf/moran-index': 7.2.0
+      '@turf/nearest-neighbor-analysis': 7.2.0
+      '@turf/nearest-point': 7.2.0
+      '@turf/nearest-point-on-line': 7.2.0
+      '@turf/nearest-point-to-line': 7.2.0
+      '@turf/planepoint': 7.2.0
+      '@turf/point-grid': 7.2.0
+      '@turf/point-on-feature': 7.2.0
+      '@turf/point-to-line-distance': 7.2.0
+      '@turf/point-to-polygon-distance': 7.2.0
+      '@turf/points-within-polygon': 7.2.0
+      '@turf/polygon-smooth': 7.2.0
+      '@turf/polygon-tangents': 7.2.0
+      '@turf/polygon-to-line': 7.2.0
+      '@turf/polygonize': 7.2.0
+      '@turf/projection': 7.2.0
+      '@turf/quadrat-analysis': 7.2.0
+      '@turf/random': 7.2.0
+      '@turf/rectangle-grid': 7.2.0
+      '@turf/rewind': 7.2.0
+      '@turf/rhumb-bearing': 7.2.0
+      '@turf/rhumb-destination': 7.2.0
+      '@turf/rhumb-distance': 7.2.0
+      '@turf/sample': 7.2.0
+      '@turf/sector': 7.2.0
+      '@turf/shortest-path': 7.2.0
+      '@turf/simplify': 7.2.0
+      '@turf/square': 7.2.0
+      '@turf/square-grid': 7.2.0
+      '@turf/standard-deviational-ellipse': 7.2.0
+      '@turf/tag': 7.2.0
+      '@turf/tesselate': 7.2.0
+      '@turf/tin': 7.2.0
+      '@turf/transform-rotate': 7.2.0
+      '@turf/transform-scale': 7.2.0
+      '@turf/transform-translate': 7.2.0
+      '@turf/triangle-grid': 7.2.0
+      '@turf/truncate': 7.2.0
+      '@turf/union': 7.2.0
+      '@turf/unkink-polygon': 7.2.0
+      '@turf/voronoi': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/union@6.5.0':
+  '@turf/union@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-      polygon-clipping: 0.15.7
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      polyclip-ts: 0.16.8
+      tslib: 2.8.1
 
-  '@turf/unkink-polygon@6.5.0':
+  '@turf/unkink-polygon@7.2.0':
     dependencies:
-      '@turf/area': 6.5.0
-      '@turf/boolean-point-in-polygon': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
-      rbush: 2.0.2
+      '@turf/area': 7.2.0
+      '@turf/boolean-point-in-polygon': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      rbush: 3.0.1
+      tslib: 2.8.1
 
-  '@turf/voronoi@6.5.0':
+  '@turf/voronoi@7.2.0':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@turf/clone': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/d3-voronoi': 1.1.12
+      '@types/geojson': 7946.0.16
       d3-voronoi: 1.1.2
+      tslib: 2.8.1
+
+  '@types/d3-voronoi@1.1.12': {}
 
   '@types/estree@0.0.39': {}
 
@@ -7898,7 +8203,7 @@ snapshots:
     dependencies:
       '@types/node': 20.10.4
 
-  '@types/geojson@7946.0.8': {}
+  '@types/geojson@7946.0.16': {}
 
   '@types/glob@7.2.0':
     dependencies:
@@ -8387,6 +8692,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  bignumber.js@9.3.1: {}
+
   binary-extensions@2.2.0: {}
 
   bl@4.1.0:
@@ -8442,14 +8749,6 @@ snapshots:
       function-bind: 1.1.2
       get-intrinsic: 1.2.4
       set-function-length: 1.1.1
-
-  call-bind@1.0.7:
-    dependencies:
-      es-define-property: 1.0.0
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.2.4
-      set-function-length: 1.2.2
 
   callsites@3.1.0: {}
 
@@ -8696,15 +8995,6 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
-  deep-equal@1.1.2:
-    dependencies:
-      is-arguments: 1.1.1
-      is-date-object: 1.0.5
-      is-regex: 1.1.4
-      object-is: 1.1.6
-      object-keys: 1.1.1
-      regexp.prototype.flags: 1.5.1
-
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -8719,12 +9009,6 @@ snapshots:
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
 
-  define-data-property@1.1.4:
-    dependencies:
-      es-define-property: 1.0.0
-      es-errors: 1.3.0
-      gopd: 1.0.1
-
   define-properties@1.2.1:
     dependencies:
       define-data-property: 1.1.1
@@ -8732,8 +9016,6 @@ snapshots:
       object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
-
-  density-clustering@1.3.0: {}
 
   dequal@2.0.3: {}
 
@@ -8846,10 +9128,6 @@ snapshots:
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
       which-typed-array: 1.1.13
-
-  es-define-property@1.0.0:
-    dependencies:
-      get-intrinsic: 1.2.4
 
   es-define-property@1.0.1: {}
 
@@ -9468,17 +9746,13 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
-  geojson-equality@0.1.6:
+  geojson-equality-ts@1.0.2:
     dependencies:
-      deep-equal: 1.1.2
+      '@types/geojson': 7946.0.16
 
-  geojson-rbush@3.2.0:
+  geojson-polygon-self-intersections@1.2.1:
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
-      '@types/geojson': 7946.0.8
-      rbush: 3.0.1
+      rbush: 2.0.2
 
   geolib@3.3.4: {}
 
@@ -9607,10 +9881,6 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.4
 
-  has-property-descriptors@1.0.2:
-    dependencies:
-      es-define-property: 1.0.0
-
   has-proto@1.0.1: {}
 
   has-symbols@1.0.3: {}
@@ -9729,11 +9999,6 @@ snapshots:
       get-intrinsic: 1.2.4
       hasown: 2.0.0
       side-channel: 1.0.4
-
-  is-arguments@1.1.1:
-    dependencies:
-      call-bind: 1.0.5
-      has-tostringtag: 1.0.0
 
   is-array-buffer@3.0.2:
     dependencies:
@@ -9936,6 +10201,8 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsts@2.7.1: {}
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.7
@@ -10044,6 +10311,8 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  marchingsquares@1.3.3: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -10181,11 +10450,6 @@ snapshots:
   object-hash@3.0.0: {}
 
   object-inspect@1.13.1: {}
-
-  object-is@1.1.6:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
@@ -10356,12 +10620,16 @@ snapshots:
       find-up: 2.1.0
       load-json-file: 4.0.0
 
-  point-in-polygon@1.1.0: {}
-
-  polygon-clipping@0.15.7:
+  point-in-polygon-hao@1.2.4:
     dependencies:
       robust-predicates: 3.0.2
-      splaytree: 3.1.2
+
+  point-in-polygon@1.1.0: {}
+
+  polyclip-ts@0.16.8:
+    dependencies:
+      bignumber.js: 9.3.1
+      splaytree-ts: 1.0.2
 
   postcss-calc@8.2.4(postcss@8.4.32):
     dependencies:
@@ -11065,15 +11333,6 @@ snapshots:
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
 
-  set-function-length@1.2.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.2.4
-      gopd: 1.0.1
-      has-property-descriptors: 1.0.2
-
   set-function-name@2.0.1:
     dependencies:
       define-data-property: 1.1.1
@@ -11131,7 +11390,7 @@ snapshots:
 
   spdx-license-ids@3.0.20: {}
 
-  splaytree@3.1.2: {}
+  splaytree-ts@1.0.2: {}
 
   split-file@2.3.0:
     dependencies:
@@ -11242,6 +11501,10 @@ snapshots:
       csso: 4.2.0
       picocolors: 1.0.0
       stable: 0.1.8
+
+  sweepline-intersections@1.5.0:
+    dependencies:
+      tinyqueue: 2.0.3
 
   symbol-tree@3.2.4: {}
 
@@ -11370,12 +11633,12 @@ snapshots:
 
   tslib@2.6.2: {}
 
+  tslib@2.8.1: {}
+
   tsutils@3.21.0(typescript@5.5.2):
     dependencies:
       tslib: 1.14.1
       typescript: 5.5.2
-
-  turf-jsts@1.2.3: {}
 
   type-check@0.4.0:
     dependencies:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,7 +47,7 @@ else
   if [ "${USE_4K_TEXTURES}" == "true" ]; then
     time npx igniter -r "^(?!.*ci-build)(?!.*8K).*" "${args[@]}"
   else
-    FBW_TYPECHECK=1 time npx igniter -r "^(?!.*ci-build)(?!.*4K).*" "${args[@]}"
+    time npx igniter -r "^(?!.*ci-build)(?!.*4K).*" "${args[@]}"
   fi
 fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,6 +32,8 @@ for arg in "$@"; do
   fi
 done
 
+
+
 #use ci config if github action
 if [ "${GITHUB_ACTIONS}" == "true" ]; then
   # select build tasks for assigned texture resolution
@@ -45,7 +47,7 @@ else
   if [ "${USE_4K_TEXTURES}" == "true" ]; then
     time npx igniter -r "^(?!.*ci-build)(?!.*8K).*" "${args[@]}"
   else
-    time npx igniter -r "^(?!.*ci-build)(?!.*4K).*" "${args[@]}"
+    FBW_TYPECHECK=1 time npx igniter -r "^(?!.*ci-build)(?!.*4K).*" "${args[@]}"
   fi
 fi
 


### PR DESCRIPTION
Combine and scale down render size of certain layers to save ~50% of VRAM with very little visual impact.

## Summary of Changes
- Upgraded `turf.js` to v7.
- Refactored some OANS code to keep layer data in one place and preserve order of features according to order of style rules in each layer.
- Combine layers so that we have 5 total layers instead of 8.
- Allow individual layers to render at a different scale to save on VRAM. This is used to render layers that are only visible at higher ranges at a lower resolution.
- Add optional union-ing and simplifying of features per style rule. In this case, this allowed fixing some visual artifacts caused by the topology of runway features that were made worse by a lower render scale..

Possible future work: make the BTV layer be a fixed 786x786 layer instead of making it draw on an airport map-sized layer. Could yield an additional ~25% savings.

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

- Ensure all OANS features behaves and look as they did before.
- Ensure all BTV features behave and look as they did before.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
