### PR TITLE
fix(fmgc): use both LGCIU for self test condition

### DIFF
--- a/fbw-a32nx/src/wasm/fbw_a320/src/fmgc/Fmgc.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/fmgc/Fmgc.cpp
@@ -16,7 +16,7 @@ void Fmgc::initSelfTests() {
     return;
 
   clearMemory();
-  if (modelInputs.in.discrete_inputs.nose_gear_pressed_opp && modelInputs.in.discrete_inputs.nose_gear_pressed_opp) {
+  if (modelInputs.in.discrete_inputs.nose_gear_pressed_opp && modelInputs.in.discrete_inputs.nose_gear_pressed_own) {
     selfTestTimer = selfTestDuration;
   }
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Tiny little fix for the FMGC self test that became apparent after #10369 was merged:
The FMGC now checks nose gear on ground discretes from both LGCIUs instead of one twice for the self test initiation

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
