### PR TITLE
fix: usage of setting subject map

### DIFF
--- a/fbw-common/src/typings/types.d.ts
+++ b/fbw-common/src/typings/types.d.ts
@@ -55,6 +55,11 @@ declare global {
 
     interface Window {
         /**
+         * Setting subject map for `NXDataStore`
+         */
+        NXDATASTORE_SUBJECT_MAP: Map<string, Subject<any>> | undefined;
+
+        /**
          * Present if the instrument is running in [ACE](https://github.com/flybywiresim/ace)
          */
         ACE_ENGINE_HANDLE: object | undefined


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

- Fixes an issue where subjects would be incessantly created when getting a typed setting from NXDataStore
- Additionally, stores the subject map on the window so settings are synced between instruments running in the same VCockpit instance

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

- N/A

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
