### PR TITLE
chore: Remove "Instruments" from manifest title 

### DIFF
--- a/fbw-a380x/src/base/manifest-base.json
+++ b/fbw-a380x/src/base/manifest-base.json
@@ -6,7 +6,7 @@
       "OlderHistory": ""
     }
   },
-  "title": "A380X Instruments",
+  "title": "A380X",
   "dependencies": [
     {
       "package_version": "0.1.129",


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Removes the "Instruments" word from the manifest so the package title/manifest matches the A32NX.


## Additional context
<!-- Add any other context about the pull request here. -->
Artifact from pre-release when there were two packages (1st instruments, 2nd model) 

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): alepouna

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
QA Not required

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
