### PR TITLE
fix(fms): fix both hold legs and course reversal symbol showing

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/FlightPlanUtils.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/FlightPlanUtils.ts
@@ -5,6 +5,7 @@
 import { PathVector } from '@flybywiresim/fbw-sdk';
 import { ReadonlyFlightPlan } from './plans/ReadonlyFlightPlan';
 import { ReadonlyFlightPlanElement } from './legs/ReadonlyFlightPlanLeg';
+import { LnavConfig } from '../guidance/LnavConfig';
 
 export class FlightPlanUtils {
   public static getAllPathVectorsInFlightPlan(
@@ -19,10 +20,18 @@ export class FlightPlanUtils {
       : plan.activeLegIndex;
     const end = missedApproach ? plan.legCount : plan.firstMissedApproachLegIndex;
 
-    for (let i = start; i < end; i++) {
-      const element = plan.elementAt(i);
+    for (let index = start; index < end; index++) {
+      const element = plan.elementAt(index);
 
       if (element.isDiscontinuity === true) {
+        continue;
+      }
+
+      const transmitCourseReversal =
+        LnavConfig.DEBUG_FORCE_INCLUDE_COURSE_REVERSAL_VECTORS ||
+        (activeLegIndex !== undefined && (index === activeLegIndex || index === activeLegIndex + 1));
+
+      if (element.isCourseReversal() && !transmitCourseReversal) {
         continue;
       }
 

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/legs/FlightPlanLeg.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/legs/FlightPlanLeg.ts
@@ -253,6 +253,10 @@ export class FlightPlanLeg implements ReadonlyFlightPlanLeg {
     return this.definition.waypointDescriptor === WaypointDescriptor.Runway;
   }
 
+  isCourseReversal(): boolean {
+    return this.isHX() || this.type === LegType.PI;
+  }
+
   /**
    * Returns the termination waypoint is this is an XF leg, `null` otherwise
    */

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/legs/ReadonlyFlightPlanLeg.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/legs/ReadonlyFlightPlanLeg.ts
@@ -43,6 +43,20 @@ export interface ReadonlyFlightPlanLeg {
   readonly pilotEnteredSpeedConstraint: SpeedConstraint | undefined;
 
   readonly calculated: LegCalculations | undefined;
+
+  isCourseReversal(): boolean;
+
+  isXF(): boolean;
+
+  isFX(): boolean;
+
+  isHX(): boolean;
+
+  isXI(): boolean;
+
+  isXA(): boolean;
+
+  isVectors(): boolean;
 }
 
 export interface ReadonlyDiscontinuity {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes an issue where hold legs were displayed on the ND despite not being within 2 legs of the hold

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before:
<img width="703" height="697" alt="image" src="https://github.com/user-attachments/assets/0800b066-0dc2-439a-9fdc-e0cd908e0640" />

After: 
<img width="1061" height="1008" alt="Screenshot 2025-12-16 130208" src="https://github.com/user-attachments/assets/e3837ef8-8b3b-41f9-81a6-d3932f505d40" />


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Insert a hold into the flight plan, either active or secondary both should work the same. The hold is shown as a course reversal if the hold is not on the currently active leg.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
