### PR TITLE
fix(a32nx/fms): Fix double negative sign on RAD NAV page

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -27,7 +27,6 @@
 1. [A32NX/MCDU] Fix managed speed units in IAS/MACH on perf climb page - @Lucas-IQ21 (Lucas)
 1. [A32NX/FMS] Implement ability to create, modify, activate and swap a secondary flight plan - @Benjozork (Benjamin Dupont), @BlueberyKing (BlueberryKing)
 1. [A380X] Fix PFD F RELIEF indication and SD status area ISA visibility - @flogross89 (floridude)
-1. [A380X/FMS] Add - sign to LS slope value - @Jonny23787 (Jonathan)
 1. [A380X/MFD] Implement Position Monitor page - @BravoMike99 (bruno_pt99)
 1. [A380X/MFD] Only show "RETURN" button on PERF & POS NAVAIDS if acessed via INIT page keys - @BravoMike99 (bruno_pt99)
 1. [A32NX/FWS] Make master caution from autobrake off trigger for 3 seconds - @BravoMike99 (bruno_pt99)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -34,7 +34,6 @@
 1. [A380X/FWS] Add FCDC, SLAT/FLAP SYS, FWS+FCDC, FWS+CPIOM faults - @flogross89 (floridude)
 1. [A32NX/FMS] Removed required leading zeros for acceleration, thrust reduction, and transition altitudes - @Jonny23787 (Jonathan)
 1. [A32NX/FMS] Adjusted TRANS ALT allowed entry range - @Jonny23787 (Jonathan)
-1. [A32NX/FMS] Add - sign to slope value on RAD NAV page - @Jonny23787 (Jonathan)
 1. [A32NX/FMS] Fix "NOT ALLOWED IN NAV" when sequencing TO waypoint while in LOC mode - @BravoMike99 (bruno_pt99)
 1. [A380X/SD] Improve STS page: Add deferred procedures, page switching, MORE page, improve performance - @flogross89 (floridude)
 1. [A32NX/FMS] Adjusted position of flight phase and flight number on PROG page  - @Jonny23787 (Jonathan)
@@ -47,6 +46,7 @@
 1. [A380X/FWS] Add ENG THRUST LOCKED & AUTO FLT A/THR LIMITED abnornmal sensed procedures - @BravoMike99 (bruno_pt99)
 1. [ATSU] Fix certain aerodromes ATIS letter not being retrieved correctly - @clc0609 (Coby)
 1. [A380X/FUEL SYSTEM] Fuel system update - @donstim (donbikes) & @Maximilian-Reuter (\_chaoz_)
+1. [FMS] Fix incorrect sign on glideslope angle (FS2020 only) - @tracernz (Mike)
 
 ## 0.14.0
 

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_NavRadioPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_NavRadioPage.ts
@@ -328,7 +328,7 @@ export class CDUNavRadioPage {
     const mmr = mcdu.getMmrTuningData(1);
     const showSlope = CDUNavRadioPage.showSlope(mcdu, mmr);
     const slope =
-      mmr.slope !== null ? `\xa0\xa0{small}{green}-${mmr.slope.toFixed(1)}{end}{end}` : '{white}\xa0\xa0\xa0-.-{end}';
+      mmr.slope !== null ? `\xa0\xa0{small}{green}${mmr.slope.toFixed(1)}{end}{end}` : '{white}\xa0\xa0\xa0-.-{end}';
     if (mmr.course !== null) {
       return `{${mmr.courseManual ? 'big' : 'small'}}{cyan}${mmr.backcourse ? 'B' : 'F'}${mmr.course.toFixed(0).padStart(3, '0')}{end}{end}${showSlope ? slope : ''}`;
     }

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/POSITION/MfdFmsPositionNavaids.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/POSITION/MfdFmsPositionNavaids.tsx
@@ -160,7 +160,7 @@ export class MfdFmsPositionNavaids extends FmsPage<MfdFmsPositionNavaidsProps> {
     this.lsIdent.set(mmr.ident ?? null);
     this.lsFreq.set(mmr.frequency ?? null);
     this.lsCourse.set(mmr.course ?? null);
-    this.lsSlope.set(mmr.slope ? `-${mmr.slope.toFixed(1)}` : '---');
+    this.lsSlope.set(mmr.slope ? mmr.slope.toFixed(1) : '---');
     this.lsClass.set(mmr.ident ? 'ILS/DME' : '');
     this.lsIdentEnteredByPilot.set(MfdFmsPositionNavaids.isNavRadioIdentManual(mmr));
     this.lsFrequencyEnteredByPilot.set(MfdFmsPositionNavaids.isNavRadioFreqManual(mmr));

--- a/fbw-common/src/systems/navdata/client/backends/Msfs/Mapping.ts
+++ b/fbw-common/src/systems/navdata/client/backends/Msfs/Mapping.ts
@@ -516,7 +516,7 @@ export class MsfsMapping {
           category = this.mapIlsCatString(nameMatch[1]);
         }
         locBearing = jsFrequency.localizerCourse;
-        gsSlope = jsFrequency.hasGlideslope ? jsFrequency.glideslopeAngle : undefined;
+        gsSlope = jsFrequency.hasGlideslope ? -jsFrequency.glideslopeAngle : undefined;
       } else if (approach) {
         gsSlope = this.approachHasGlideslope(approach)
           ? approach.finalLegs[approach.finalLegs.length - 1].verticalAngle - 360


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
Removes - sign from rad nav page which was causing double negative signs to appear on FS2024 or in FS2020 on runways with no ILS link in the navdata.
Fixes the issue that caused the glideslope sign to be inverted on FS2020 when there was an ILS link in the navdata.

<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
jonny_23

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
