### PR TITLE
feat(a380x): add animation for thrust reverser levers

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -52,6 +52,7 @@
 1. [FMS] Fixed pseudo waypoints symbols being offset after a direct to - @BlueberryKing (BlueberryKing)
 1. [A32NX/SFCC] Added implementation of slat baulk and slat alpha lock functions in SFCC - @Eagle941 (Joe)
 1. [ATSU] Add support for BeyondATC and SayIntentions AI ACARS - @saschl
+1. [A380X/MODEL] Add animation for thrust reverser levers - @heclak (Heclak)
 
 
 ## 0.14.0

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/legacy/generated/A32NX_Interior_Engine.xml
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/legacy/generated/A32NX_Interior_Engine.xml
@@ -58,12 +58,12 @@
         <Component ID="#NODE_ID#" Node="#NODE_ID#">
             <UseTemplate Name="ASOBO_GT_Anim_Code">
                 <ANIM_CODE>
-                    (#POSITION_TYPE#:#POSITION_VAR#) 1 &lt; 100 *
+                    (#POSITION_TYPE#:#POSITION_VAR#) 1 min -1 * 1 + 100 *
                 </ANIM_CODE>
-                <ANIM_NAME>#ANIM_NAME_REVERSE_LOCK#</ANIM_NAME>
+                <ANIM_NAME>#ANIM_NAME_REVERSER_LEVER#</ANIM_NAME>
             </UseTemplate>
             <UseTemplate Name="ASOBO_GT_AnimTriggers_2SoundEvents">
-                <ANIM_NAME>#ANIM_NAME_REVERSE_LOCK#</ANIM_NAME>
+                <ANIM_NAME>#ANIM_NAME_REVERSER_LEVER#</ANIM_NAME>
                 <WWISE_EVENT_1>detent</WWISE_EVENT_1>
                 <WWISE_EVENT_2>detent</WWISE_EVENT_2>
             </UseTemplate>

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/pedestal/pedestal.xml
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/behaviour/pedestal/pedestal.xml
@@ -36,6 +36,7 @@
             <UseTemplate Name="FBW_ENGINE_Lever_Throttle_Template">
                 <NODE_ID>LEVER_THROTTLE_2</NODE_ID>
                 <ANIM_NAME>throttle_lever_2</ANIM_NAME>
+                <ANIM_NAME_REVERSER_LEVER>LEVER_THROTTLE_2_REVERSE</ANIM_NAME_REVERSER_LEVER>
                 <ID>2</ID>
                 <DRAG_SPEED>-10</DRAG_SPEED>
                 <POSITION_TYPE>L</POSITION_TYPE>
@@ -47,6 +48,7 @@
             <UseTemplate Name="FBW_ENGINE_Lever_Throttle_Template">
                 <NODE_ID>LEVER_THROTTLE_3</NODE_ID>
                 <ANIM_NAME>throttle_lever_3</ANIM_NAME>
+                <ANIM_NAME_REVERSER_LEVER>LEVER_THROTTLE_3_REVERSE</ANIM_NAME_REVERSER_LEVER>
                 <ID>3</ID>
                 <DRAG_SPEED>-10</DRAG_SPEED>
                 <POSITION_TYPE>L</POSITION_TYPE>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #9281 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Add animation to thrust reverser levers

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

https://github.com/user-attachments/assets/12933603-272b-4e7b-a1ea-18ec79ee651f

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Heclak

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Ensure throttle levers are mapped to your physical controllers and exercise your throttle levers. Levers are not draggable in the virtual cockpit using the mouse so physical controllers/bindings must be used.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
