### PR TITLE
fix: ACARS SayIntentions API KEY Validation

### DIFF
--- a/fbw-common/src/systems/datalink/router/src/webinterfaces/AcarsClient.ts
+++ b/fbw-common/src/systems/datalink/router/src/webinterfaces/AcarsClient.ts
@@ -9,8 +9,15 @@ const ACARS_PROVIDER_ENDPOINTS: Record<string, string> = {
   SAI: 'https://acars.sayintentions.ai/acars/system/connect.html',
 };
 
-const PROVIDER_LOGON_CONFIG: Record<string, { legacyKey: string; missingMessage: string, validationUrl?: (key: string) => string }> = {
-  SAI: { legacyKey: 'CONFIG_SAI_LOGON_KEY', missingMessage: 'Missing SAI logon key', validationUrl: (key: string) => `https://portal.sayintentions.ai/api/mep/validateKey?key=${key}` },
+const PROVIDER_LOGON_CONFIG: Record<
+  string,
+  { legacyKey: string; missingMessage: string; validationUrl?: (key: string) => string }
+> = {
+  SAI: {
+    legacyKey: 'CONFIG_SAI_LOGON_KEY',
+    missingMessage: 'Missing SAI logon key',
+    validationUrl: (key: string) => `https://portal.sayintentions.ai/api/mep/validateKey?key=${key}`,
+  },
   HOPPIE: { legacyKey: 'CONFIG_HOPPIE_USERID', missingMessage: 'Missing Hoppie user ID' },
 };
 
@@ -29,7 +36,7 @@ export class AcarsClient {
       }
 
       if (acarsProvider === 'SAI' && logonConfig.validationUrl) {
-          await AcarsClient.validateSayIntentionsKey(logonConfig.validationUrl(logon));
+        await AcarsClient.validateSayIntentionsKey(logonConfig.validationUrl(logon));
       }
       params.append('logon', logon);
     }
@@ -57,7 +64,7 @@ export class AcarsClient {
           throw AcarsClient.generateNotAvailableException('Empty response');
         }
         if (data.includes('error {invalid logon code}')) {
-             throw AcarsClient.generateNotAvailableException('Invalid Hoppie User ID');
+          throw AcarsClient.generateNotAvailableException('Invalid Hoppie User ID');
         }
         return { response: data };
       })
@@ -68,18 +75,18 @@ export class AcarsClient {
 
   private static async validateSayIntentionsKey(url: string): Promise<void> {
     try {
-        const response = await fetch(url);
-        if (!response.ok) {
-            throw AcarsClient.generateNotAvailableException(`Validation server returned ${response.status}`);
-        }
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw AcarsClient.generateNotAvailableException(`Validation server returned ${response.status}`);
+      }
 
-        const result = await response.json() as { is_valid: number; flight_id: number };
+      const result = (await response.json()) as { is_valid: number; flight_id: number };
 
-        if (!result.is_valid) {
-            throw AcarsClient.generateNotAvailableException('Invalid SAI API Key');
-        }
+      if (!result.is_valid) {
+        throw AcarsClient.generateNotAvailableException('Invalid SAI API Key');
+      }
     } catch (err) {
-        throw AcarsClient.generateNotAvailableException(`Validation failed: ${err}`);
+      throw AcarsClient.generateNotAvailableException(`Validation failed: ${err}`);
     }
   }
 

--- a/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/AtsuAocPage.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Settings/Pages/AtsuAocPage.tsx
@@ -43,22 +43,22 @@ export const AtsuAocPage = () => {
 
   const getAcarsResponse = async (value: string): Promise<string> => {
     if (!value || value === '') {
-        return value;
+      return value;
     }
 
     try {
-        const body: CpdlcMessageDto = {
-            from: `FBW${aircraftProjectPrefix}`,
-            to: 'SERVER',
-            type: 'ping',
-        };
+      const body: CpdlcMessageDto = {
+        from: `FBW${aircraftProjectPrefix}`,
+        to: 'SERVER',
+        type: 'ping',
+      };
 
-        await AcarsClient.getData(body);
-        return value;
+      await AcarsClient.getData(body);
+      return value;
     } catch (err: any) {
-        throw new Error(`Error: Unknown user ID: ${err.message || err}`);
+      throw new Error(`Error: Unknown user ID: ${err.message || err}`);
     }
-  }
+  };
 
   const formatAcarsMessage = (messageKey: string) =>
     t(messageKey).replace(


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #10465

## Summary of Changes
This PR introduces a validation mechanism for ACARS providers, specifically adding support for the SayIntentions (SAI) validation endpoint. It also refactors the ACARS initialization flow to prevent "false-positive" connection states.

- SAI Key Validation: Integrated the https://portal.sayintentions.ai/api/mep/validateKey endpoint to verify keys before attempting a connection.

- ACARS is now explicitly deactivated upon new ID input. This prevents a misleading "Connected" state when a user enters an invalid key while previously authenticated.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
1. SayIntentions (SAI) Validation

- Setup: Set ACARS Provider to SAI in settings.
- Test (Valid Key): Enter a known valid SAI key.
  - Expected: The UI should show a "Validated" success toast and the ACARS status should turn green/active.

 - Test (Invalid Key): Enter 12345 or an incorrect key.
   - Expected: The UI should show an error toast: "Validation failed: Invalid logon key". The ACARS connection should remain inactive/disconnected.
2. Hoppie Validation (Legacy)

 - Setup: Set ACARS Provider to HOPPIE.
 - Test (Valid Key): Enter a known valid Hoppie Logon Code.
   - Expected: The UI should show a "Validated" success toast and the ACARS status should turn green/active.
 - Test (Invalid ID): Enter an invalid Logon Code (e.g., 999999).
   - Expected: The system should catch the text response error {invalid logon code} and display "Invalid Hoppie User ID" in the toast.

3. State Management & "False Positives"
 - Test: Connect successfully with a valid key. Then, modify the key field to an invalid one.
   - Expected: The ACARS connection should immediately reset/deactivate. It should not remain "Connected" while the user is actively changing credentials.

4. Empty Inputs
 - Test: Clear the ACARS ID field entirely.
   - Expected: The UI should display the "Acars ID has been removed" success toast and the connection should be deactivated.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
