### PR TITLE
feat(A380X/mfd): improved compute lrc

### DIFF
--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
@@ -45,6 +45,7 @@ import {
 import { ApproachType } from '@flybywiresim/fbw-sdk';
 import { FlapConf } from '@fmgc/guidance/vnav/common';
 import { MfdFmsFplnVertRev } from 'instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnVertRev';
+import { Lrc } from '../../shared/Lrc';
 
 interface MfdFmsPerfProps extends AbstractMfdPageProps {}
 
@@ -437,6 +438,8 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
   private crzTableMachLine3 = Subject.create<string | null>(null);
 
   private crzTablePredLine3 = Subject.create<string | null>(null);
+
+  private crzTableLrcMachSpeed = Subject.create<string | null>(null);
 
   private destAirportIdent = Subject.create<string>('');
 
@@ -987,6 +990,37 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                 : '.--',
             );
             this.crzTablePredLine2.set(null);
+          }
+
+          // Compute LRC
+          const pd = this.loadedFlightPlan?.performanceData;
+          const crzFL = pd?.cruiseFlightLevel?.get();
+          const grossWeightKg = SimVar.GetSimVarValue('TOTAL WEIGHT', 'pounds') * 0.453592;
+          const isaDev =
+            SimVar.GetSimVarValue('AMBIENT TEMPERATURE', 'celsius') -
+            SimVar.GetSimVarValue('STANDARD ATM TEMPERATURE', 'celsius');
+          if (this.activeFlightPhase.get() >= FmgcFlightPhase.Cruise && crzFL > 0) {
+            const lrc = new Lrc({
+              GW: grossWeightKg,
+              FL: crzFL * 100,
+              ISA_dev: isaDev,
+              S: 845,
+              CD0: 0.022,
+              k: 0.045,
+              TSFC_base: 1.9e-5,
+              machMin: 0.75,
+              machMax: 0.88,
+              machStep: 0.002,
+            });
+
+            const lrcComputed = lrc.computeLRC();
+            if (Number.isFinite(lrcComputed.M_lrc) && lrcComputed.M_lrc > 0) {
+              this.crzTableLrcMachSpeed.set(lrcComputed.M_lrc.toFixed(2).replace('0.', '.'));
+            } else {
+              this.crzTableLrcMachSpeed.set('-.--');
+            }
+          } else {
+            this.crzTableLrcMachSpeed.set('-.--');
           }
 
           // Update CRZ DEST predictions
@@ -2278,7 +2312,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                     <div class="mfd-label">LRC</div>
                   </div>
                   <div class="mfd-fms-perf-speed-table-cell" style="border-bottom: none; padding: 5px;">
-                    <span class="mfd-value">.84</span>
+                    <span class="mfd-value">{this.crzTableLrcMachSpeed}</span>
                   </div>
                   <div class="mfd-fms-perf-speed-table-cell" style="border-bottom: none; padding: 5px;">
                     <div class="mfd-label-value-container">

--- a/fbw-a380x/src/systems/instruments/src/MFD/shared/Lrc.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/shared/Lrc.ts
@@ -1,0 +1,124 @@
+export class Lrc {
+  GW: number; // Gross weight (kg)
+  FL: number; // Flight level (ft)
+  ISA_dev: number; // ISA deviation (°C)
+  S: number; // Wing area (m^2)
+  CD0: number;
+  k: number;
+  TSFC_base: number; // Base TSFC (kg / (N * s))
+  machMin: number;
+  machMax: number;
+  machStep: number;
+  private g = 9.80665;
+  private R = 287.05287;
+  private gamma = 1.4;
+
+  constructor(opts: {
+    GW: number;
+    FL: number;
+    ISA_dev: number;
+    S: number;
+    CD0: number;
+    k: number;
+    TSFC_base: number;
+    machMin: number;
+    machMax: number;
+    machStep: number;
+  }) {
+    this.GW = opts.GW;
+    this.FL = opts.FL;
+    this.ISA_dev = opts.ISA_dev;
+    this.S = opts.S;
+    this.CD0 = opts.CD0;
+    this.k = opts.k;
+    this.TSFC_base = opts.TSFC_base;
+    this.machMin = opts.machMin;
+    this.machMax = opts.machMax;
+    this.machStep = opts.machStep;
+  }
+
+  private isaAtmosphere(alt_m: number) {
+    const T0 = 288.15;
+    const p0 = 101325;
+    let T: number, p: number;
+
+    if (alt_m <= 11000) {
+      const lapse = -0.0065;
+      T = T0 + lapse * alt_m + this.ISA_dev;
+      p = p0 * Math.pow(T / T0, -this.g / (this.R * lapse));
+    } else {
+      T = 216.65 + this.ISA_dev;
+      p = p0 * 0.223361 * Math.exp((-this.g * (alt_m - 11000)) / (this.R * T));
+    }
+    return {
+      T,
+      rho: p / (this.R * T),
+      a: Math.sqrt(this.gamma * this.R * T),
+    };
+  }
+
+  private tsfcModel(M: number, alt_m: number): number {
+    const altPenalty = 1 + 0.03 * Math.max(0, (alt_m - 11000) / 10000);
+    const machPenalty = 1 + 1.5 * Math.pow(Math.max(0, M - 0.82), 2);
+    return this.TSFC_base * altPenalty * machPenalty;
+  }
+
+  computeSRforMach(M: number): number {
+    const alt_m = this.FL * 0.3048;
+    const { rho, a } = this.isaAtmosphere(alt_m);
+    const V = M * a;
+    const W = this.GW * this.g;
+    const CL = (2 * W) / (rho * V * V * this.S);
+    const CL_buffet = 0.62;
+
+    if (CL > CL_buffet) return 0;
+    const M_buffet = 0.88 - 0.00000025 * (this.GW - 300000);
+    if (M > M_buffet) return 0;
+    const Mcrit = 0.82;
+    let CD_comp = 1.0;
+    if (M > Mcrit) {
+      CD_comp += 12 * Math.pow(M - Mcrit, 2) * (1 + 2 * CL);
+    }
+    const CD = (this.CD0 + this.k * CL * CL) * CD_comp;
+    const D = 0.5 * rho * V * V * this.S * CD;
+    const tsfc = this.tsfcModel(M, alt_m);
+    const mdot = tsfc * D;
+    if (mdot <= 0) return 0;
+    return V / mdot / 1852;
+  }
+
+  computeSRcurve(): { machs: number[]; srs: number[] } {
+    const machs: number[] = [];
+    const srs: number[] = [];
+    for (let m = this.machMin; m <= this.machMax + 1e-9; m += this.machStep) {
+      machs.push(Number(m.toFixed(6)));
+      srs.push(this.computeSRforMach(m));
+    }
+    return { machs, srs };
+  }
+
+  computeLRC() {
+    let bestSR = 0;
+    let M_mrc = this.machMin;
+
+    for (let M = this.machMin; M <= this.machMax; M += this.machStep) {
+      const SR = this.computeSRforMach(M);
+      if (SR > bestSR) {
+        bestSR = SR;
+        M_mrc = M;
+      }
+    }
+    const SR_target = 0.99 * bestSR;
+    let M_lrc = M_mrc;
+    for (let M = M_mrc; M <= this.machMax; M += this.machStep) {
+      if (this.computeSRforMach(M) >= SR_target) {
+        M_lrc = M;
+      }
+    }
+    return {
+      M_mrc: Number(M_mrc.toFixed(3)),
+      M_lrc: Number(M_lrc.toFixed(3)),
+      SR_max: bestSR,
+    };
+  }
+}


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes

<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Improved LRC compute FMS perf cuize page.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
<img width="1302" height="1390" alt="image" src="https://github.com/user-attachments/assets/1a8150e6-af85-423f-b873-718e6d0d42bb" />

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
https://www.fzt.haw-hamburg.de/pers/Scholz/arbeiten/HAW-TextCaers.pdf -> 2.1.4 Long-Range Cruise Speed
https://ansperformance.eu/library/airbus-fuel-economy.pdf

FCOM : 
<img width="792" height="294" alt="image" src="https://github.com/user-attachments/assets/903f714a-f782-476c-8bd9-20cac70ebecd" />

<img width="616" height="709" alt="image" src="https://github.com/user-attachments/assets/cb46c2e2-284b-4595-a44c-898f28c824c2" />

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
Previously, the LCR speed was simply specified as a fixed value, but now it is calculated based on ISA temp, the weight, and the altitude of the aircraft.
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Lucas-IQ

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Fill FMS as usual.
2. Before the cruise phase, the LRC speed in Mach does not appear.
3. Reach cruise phase. 
4. The LCR speed is displayed and varies depending on the cruising altitude, the weight of the aircraft, and the ISA temperature.
5. The LRC cannot be less than 0.75 or greater than 0.88.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
