### PR TITLE
fix(a32nx/mcdu): Fix destination QNH not being converted from inHg to hPa

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -68,7 +68,6 @@
 1. [A32NX/GPWS] Implement simulated GPWC in rust systems - @lukecologne (luke)
 1. [A32NX/FWC] Improve CAB PR LO DIFF PR warning logic to avoid spurious warnings - @tracernz (Mike)
 1. [A32NX/FWS] Fixed stall warning not working - @tracernz (Mike)
-1. [A32NX/MCDU] Fixed inHg destination QNH conversion bug which resulted in incorrect diff pressure calculation - @FozzieHi (fozzie)
 
 ## 0.14.0
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #10511

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes a small regression introduced by #9627.

Before we used to convert the destination QNH from inHg to hPa if applicable in the MCDU:
https://github.com/flybywiresim/aircraft/blame/f1e8a0f24e81c024811147f8809bfd35ab02e79c/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts#L3941C97-L3941C97

However, we now just set the QNH directly, meaning the pressurisation system receives values in inHg, when it expect values in hPa:
https://github.com/flybywiresim/aircraft/blame/b472d0dd2e37bc2b5de6900aaaa8303b04e5738b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts#L5506

This led to wildly incorrect diff pressure, and may have been a cause in the big increase of the reports of `LO DIFF PR` cautions we saw recently.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Destination QNH used as `ref_press_hpa` below

Before:
<img width="612" height="400" alt="image" src="https://github.com/user-attachments/assets/86e4ec5c-7a58-4c7a-9f8e-9cc793dd3e8c" />
After:
<img width="596" height="77" alt="Screenshot 2026-01-27 225217" src="https://github.com/user-attachments/assets/e2e83588-0621-4a8f-a48e-e0f8e80239f6" />

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): fozzie

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
