### PR TITLE
docs: added line to documentation that the `-4k` flag only works with `build.sh`

### DIFF
--- a/.github/Contributing.md
+++ b/.github/Contributing.md
@@ -33,7 +33,7 @@ git submodule update --init
 
 Note that you should use `run.sh` instead of `run.cmd` if you are on Linux (including WSL).
 
-To build only the A32NX or the A380X, change `build.sh` to `build_a32nx.sh` or `build_a380x.sh`. To build the A380X with 4K textures instead of maximum quality (8K), add the `-4k` flag at the end of the command. Note that the `-4k` flag only works with the build `build.sh` and not with `build_a32nx.sh` or `build_a380x.sh`. Alternatively you can define the `USE_4K_TEXTURES=true` environment variable in a `.env` file at the root of the repo.
+To build only the A32NX or the A380X, change `build.sh` to `build_a32nx.sh` or `build_a380x.sh`. To build the A380X with 4K textures instead of maximum quality (8K), add the `-4k` flag at the end of the command. Note that the `-4k` flag only works with `build.sh` and not with `build_a32nx.sh` or `build_a380x.sh`. Alternatively you can define the `USE_4K_TEXTURES=true` environment variable in a `.env` file at the root of the repo.
 
 If you are using WSL, ensure that the `Vmmem` process is not memory limited. At least `10GB` of memory is the recommended setting. This can be configured in `C:\<user>\.wslconfig`.
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
Added line to documentation that the `-4k` flag only works with `build.sh`. In the documentation options are described when working only on the 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
Please verify that the commands build_a32nx.sh -4k and build_a380x.sh -4k are not working and the `-4k` flag only works as build.sh -4k.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
