### PR TITLE
fix(a32nx/flight model): A32NX Flight Model update for MSFS 2024

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -83,6 +83,7 @@
 1. [A380X/FWS] Fixed overspeed VFE blue and selectable - @matze-tech (matze2346)
 1. [A380X/FUEL] Add first FQMS fuel measuring implementation - @Gurgel100 (Pascal)
 1. [FUEL] Fix fuel getting consumed when in Active Pause or Pause at T/D - @Maximilian-Reuter (\_chaoz_)
+1. [A32NX/FLIGHT MODEL] Updated flight model for MSFS 2024 - @donstim (donbikes)
 
 
 ## 0.14.0

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/flight_model.cfg
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/flight_model.cfg
@@ -13,6 +13,7 @@ empty_weight_pitch_MOI = 2453714 ; Empty pitch moment of inertia, Jxx (SLUG SQ F
 empty_weight_roll_MOI = 989005 ; Empty roll moment of inertia, Jzz (SLUG SQ FEET)
 empty_weight_yaw_MOI = 3166138 ; Empty yaw moment of inertia, Jyy (SLUG SQ FEET)
 empty_weight_coupled_MOI = 1000 ; Empty transverse moment of inertia, Jyz (SLUG SQ FEET)
+empty_inertia_tensor = 2453714, 3166138, 989005
 activate_mach_limit_based_on_cg = 0 ; Activate mach limitation depending on CG position (true if > 0 /false othewise). Mostly for Concorde).
 activate_cg_limit_based_on_mach = 0 ; Activate cg limitation depending on mach value (true if > 0 /false othewise). Mostly for Concorde).
 ; weight & balance for A320-251N (WV055) - 174 economy class seats (Azul A20N)
@@ -232,20 +233,33 @@ fly_by_wire = 0 ; Fly-by-wire available true/false
 elevator_elasticity_table = 0:1, 400:1
 aileron_elasticity_table = 0:1, 400:1
 rudder_elasticity_table = 0:1, 400:1
-elevator_trim_elasticity_table = 0:0.3, 58:0.75, 100:0.75, 120:1, 400:1
-;controls_reactivity_scalar = 1 ; Reactivity scalar for all controls
+elevator_trim_elasticity_table = 0:1, 400:1
 
 [AERODYNAMICS]
+lift_coef_flaps = 1.59 ; Change in lift due to flaps
+lift_coef_spoilers = -0.466875 ; Change in lift due to spoilers
+drag_coef_zero_lift = 0.01846 ; The zero lift drag polar
+drag_coef_flaps = 0.1234
+drag_coef_gear = 0.0372
+drag_coef_spoilers = 0.05775;  Change in drag due to spoilers
+compute_aero_center = 0
+aero_center_lift = -8.75 ; Init to center
+lift_coef_aoa_table = -3.15:0, 0:0.138, 0.139:1.32, 0.2:1.48, 0.26:1.76, 0.29:1.750, 0.32:1.60, 0.5:1.50, 3.15:0
+lift_coef_ground_effect_mach_table = 0.0:1.178, 0.15:1.178, 0.19:1.178, 0.20:1.176, 0.22:1.173, 0.25:1.17, 0.27:1.1675, 0.30:1.164, 0.35:1.159, 1.0:1
+drag_coef_zero_lift_mach_tab = 0:0, 0.5:0, 0.55:0, 0.6:0.0002, 0.65:0.0003, 0.7:0.0004, 0.75:0.0008, 0.8:0.0015, 0.85:0.010, 0.9:0.15, 0.95:0.333, 1:0.5
+elevator_scaling_table = 0:1 ;  scales control based on its deflection
+aileron_scaling_table = 0:1 ; scales control based on its deflection
+rudder_scaling_table = 0:1 ; scales control based on its deflection
+lift_coef_at_drag_zero = 0.1750
+lift_coef_at_drag_zero_flaps = 0.4200
+;fuselage_lateral_cx = 0.44; Defines fuselage lift and side force vs fuselage angle-of-attack and beta
+
+;Legacy Aerodynamics Parameters (not used by modern flight model, but must be present)
+
 lift_coef_pitch_rate = -57.116 ; The change in lift per change in pitch rate
 lift_coef_daoa = 0 ; lift per change in angle of attack rate
 lift_coef_delta_elevator = -1.652 ; The change in lift per change in elevator deflection
 lift_coef_horizontal_incidence = 0 ; The change in lift per change in horizontal incidence angle
-lift_coef_flaps = 1.844 ; Change in lift due to flaps
-lift_coef_spoilers = -0.466875 ; Change in lift due to spoilers
-drag_coef_zero_lift = 0.01873 ; The zero lift drag polar
-drag_coef_flaps = 0.1316
-drag_coef_gear = 0.0372
-drag_coef_spoilers = 0.05775;  Change in drag due to spoilers
 side_force_slip_angle = -3.252 ; (yaw angle) The change in side force per change in side slip angle
 side_force_roll_rate = 1.833 ; (roll velocity)  The change in side force per change in roll rate
 side_force_yaw_rate = 17.395 ; (yaw velocity) The change in side force per change in yaw rate
@@ -276,16 +290,11 @@ yaw_moment_delta_aileron = -0.007 ; (adverse yaw)  The change in yaw moment per 
 yaw_moment_delta_rudder = 1.321 ; (control)The change in yaw moment per change in rudder deflection PRIMARY YAW POWER FACTOR
 yaw_moment_delta_rudder_propwash = 1.321 ; (control)
 yaw_moment_delta_rudder_trim_scalar = 1.321 ; Change in yaw moment due to rudder trim
-compute_aero_center = 0
-aero_center_lift = -8.75 ; Init to center
-lift_coef_aoa_table = -3.15:0, 0:0.138, 0.139:1.32, 0.2:1.48, 0.26:1.76, 0.29:1.750, 0.32:1.60, 0.5:1.50, 3.15:0
-lift_coef_ground_effect_mach_table = 0.0:1.178, 0.15:1.178, 0.19:1.178, 0.20:1.176, 0.22:1.173, 0.25:1.17, 0.27:1.1675, 0.30:1.164, 0.35:1.159, 1.0:1
 lift_coef_mach_table = 0:1
 lift_coef_delta_elevator_mach_table = 0:0
 lift_coef_daoa_mach_table = 0:0
 lift_coef_pitch_rate_mach_table = 0:0
 lift_coef_horizontal_incidence_mach_table = 0:0
-drag_coef_zero_lift_mach_tab = 0:0, 0.5:0, 0.55:0, 0.6:0.0002, 0.65:0.0003, 0.7:0.0004, 0.75:0.0008, 0.8:0.0015, 0.85:0.010, 0.9:0.15, 0.95:0.333, 1:0.5
 side_force_slip_angle_mach_table = 0:0
 side_force_delta_rudder_mach_table = 0:0
 side_force_yaw_rate_mach_table = 0:0
@@ -318,15 +327,7 @@ yaw_moment_delta_rudder_mach_table = 0:0
 yaw_moment_delta_aileron_mach_table = 0:0
 yaw_moment_yaw_rate_mach_table = 0:0
 yaw_moment_roll_rate_mach_table = 0:0
-elevator_scaling_table = 0:1 ;  scales control based on its deflection
-aileron_scaling_table = 0:1 ; scales control based on its deflection
-rudder_scaling_table = 0:1 ; scales control based on its deflection
 aileron_load_factor_effectiveness_table = 0:1 ; scaling of roll_moment_delta_aileron versus gravity forces, G effects on aileron effectiveness, acts on roll_moment_delta_aileron
-lift_coef_at_drag_zero = 0.1750
-lift_coef_at_drag_zero_flaps = 0.4200
-;elevator_lift_coef = 1.5 ; Defines elevator lift vs elevator angle-of-attack
-;rudder_lift_coef = 0.5 ; Defines rudder lift vs rudder angle-of-attack
-;fuselage_lateral_cx = 0.5; Defines fuselage lift and side force vs fuselage angle-of-attack and beta
 
 [FLIGHT_TUNING]
 modern_fm_only = 1; (true) forces use of modern flight model regardless of what user selected in MSFS options menu. 0 (false) allows use of user-selected flight model
@@ -335,7 +336,7 @@ disable_assistances = 0; 1(true) disables all AI assistance settings as they are
 ;icing_scalar = 1 ; Scales effect of icing on lift and weight
 cruise_lift_scalar = 0.945
 parasite_drag_scalar = 1
-induced_drag_scalar = 1.703
+induced_drag_scalar = 1.734
 flap_induced_drag_scalar = 0.365
 elevator_effectiveness = 1
 elevator_maxangle_scalar = 0.465
@@ -348,11 +349,9 @@ yaw_stability = 1
 pitch_gyro_stability = 6
 roll_gyro_stability = 4.5
 yaw_gyro_stability = 1
-elevator_trim_effectiveness = 3.89
+elevator_trim_effectiveness = 1
 aileron_trim_effectiveness = 1
 rudder_trim_effectiveness = 0
-hi_alpha_on_roll = 0
-hi_alpha_on_yaw = 0
 p_factor_on_yaw = 0
 torque_on_roll = 0
 gyro_precession_on_roll = 0
@@ -364,6 +363,10 @@ ground_crosswind_effect_zero_speed = 10
 ground_crosswind_effect_max_speed = 90
 ground_high_speed_steeringwheel_static_friction_scalar = 1
 ground_high_speed_otherwheel_static_friction_scalar = 1
+
+; Legacy Flight Tuning parameters
+hi_alpha_on_roll = 0
+hi_alpha_on_yaw = 0
 
 [REFERENCE SPEEDS]
 full_flaps_stall_speed = 115 ; Knots True (KTAS)

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/flight_model.cfg
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/flight_model.cfg
@@ -236,10 +236,10 @@ rudder_elasticity_table = 0:1, 400:1
 elevator_trim_elasticity_table = 0:1, 400:1
 
 [AERODYNAMICS]
-lift_coef_flaps = 1.59 ; Change in lift due to flaps
+lift_coef_flaps = 1.607 ; Change in lift due to flaps
 lift_coef_spoilers = -0.466875 ; Change in lift due to spoilers
-drag_coef_zero_lift = 0.01846 ; The zero lift drag polar
-drag_coef_flaps = 0.1234
+drag_coef_zero_lift = 0.01862 ; The zero lift drag polar
+drag_coef_flaps = 0.1252
 drag_coef_gear = 0.0372
 drag_coef_spoilers = 0.05775;  Change in drag due to spoilers
 compute_aero_center = 0
@@ -252,7 +252,7 @@ aileron_scaling_table = 0:1 ; scales control based on its deflection
 rudder_scaling_table = 0:1 ; scales control based on its deflection
 lift_coef_at_drag_zero = 0.1750
 lift_coef_at_drag_zero_flaps = 0.4200
-;fuselage_lateral_cx = 0.44; Defines fuselage lift and side force vs fuselage angle-of-attack and beta
+fuselage_lateral_cx = 0.44; Defines fuselage lift and side force vs fuselage angle-of-attack and beta
 
 ;Legacy Aerodynamics Parameters (not used by modern flight model, but must be present)
 
@@ -336,7 +336,7 @@ disable_assistances = 0; 1(true) disables all AI assistance settings as they are
 ;icing_scalar = 1 ; Scales effect of icing on lift and weight
 cruise_lift_scalar = 0.945
 parasite_drag_scalar = 1
-induced_drag_scalar = 1.734
+induced_drag_scalar = 1.703
 flap_induced_drag_scalar = 0.365
 elevator_effectiveness = 1
 elevator_maxangle_scalar = 0.465
@@ -426,6 +426,7 @@ lift_scalar = 0 ; Scalar coefficient to ponderate global flap lift coef (non dim
 drag_scalar = 0 ; Scalar coefficient to ponderate global flap drag coef (non dimensioned)
 pitch_scalar = 0 ; Scalar coefficient to ponderate global flap pitch coef (non dimensioned)
 max_on_ground_position = 5 ; Dynamically set in-tool to last flap-position index by defaut when -1 is found.
+;Flap section index number, flap position in degrees, airspeed limit, drag scalar, lift scalar, area scalar, add camber (radians), add aft feet (pos value moves center of lift forward), add incidence - scalar setting proportion of additional lift added at 0 degrees AOA (with 100% at stall AOA)
 flaps-position.0 =  0.00,  -1, 0.00, 0.00 ; CONF 0
 flaps-position.1 =  0.01,  -1, 1.00, 1.00 ; CONF 1
 flaps-position.2 = 10.00, 215, 1.00, 1.00 ; CONF 1+F
@@ -446,12 +447,13 @@ lift_scalar = 1 ; Scalar coefficient to ponderate global flap lift coef (non dim
 drag_scalar = 1 ; Scalar coefficient to ponderate global flap drag coef (non dimensioned)
 pitch_scalar = 1 ; Scalar coefficient to ponderate global flap pitch coef (non dimensioned)
 max_on_ground_position = 5 ; Dynamically set in-tool to last flap-position index by defaut when -1 is found.
+;Flap section index number, flap position in degrees, airspeed limit, drag scalar, lift scalar, area scalar, add camber (radians), add aft feet (pos value moves center of lift forward), add incidence - scalar setting proportion of additional lift added at 0 degrees AOA (with 100% at stall AOA)
 flaps-position.0 =  0.00,  -1, 0, 0.0 ; CONF 0
-flaps-position.1 =  5.0,  -1, 0.33, 0.01 ; CONF 1
-flaps-position.2 = 10.00, 215, 0.63, 1.30 ; CONF 1+F
-flaps-position.3 = 15.00, 200, 0.85, 1.30 ; CONF 2
-flaps-position.4 = 20.00, 185, 0.97, 1.17 ; CONF 3
-flaps-position.5 = 40.00, 177, 0.939, 1.00 ; CONF FULL
+flaps-position.1 =  5.0,  -1, 0.34, 0.01, 1.00 ; CONF 1
+flaps-position.2 = 10.00, 215, 0.69, 1.30, 1.00, 0.00,  2.00 ; CONF 1+F
+flaps-position.3 = 15.00, 200, 0.87, 1.30, 1.00, 0.00,  3.00 ; CONF 2
+flaps-position.4 = 20.00, 185, 1.06, 1.16, 1.00, 0.00,  3.50 ; CONF 3
+flaps-position.5 = 40.00, 177, 1.00, 1.00, 1.02, 0.015, 4.00 ; CONF FULL
 
 [FLAPS.2]
 type = 2 ; Flap type 0 = None, 1 = trailing edge, 2 = leading edge
@@ -466,9 +468,10 @@ lift_scalar = 0.01 ; Scalar coefficient to ponderate global flap lift coef (non 
 drag_scalar = 0.5 ; Scalar coefficient to ponderate global flap drag coef (non dimensioned)
 pitch_scalar = 1 ; Scalar coefficient to ponderate global flap pitch coef (non dimensioned)
 max_on_ground_position = 5 ; Dynamically set in-tool to last flap-position index by defaut when -1 is found.
+;Flap section index number, flap position in degrees, airspeed limit, drag scalar, lift scalar, area scalar, add camber (radians), add aft feet (pos value moves center of lift forward), add incidence - scalar setting proportion of additional lift added at 0 degrees AOA (with 100% at stall AOA)
 flaps-position.0 =  0.00,  -1, 1.00, 1.00 ; CONF 0
-flaps-position.1 = 18.00, 230, 0.33, 1.00 ; CONF 1
-flaps-position.2 = 18.01, 230, 0.63, 1.00 ; CONF 1+F
-flaps-position.3 = 22.00, 200, 0.85, 1.00 ; CONF 2
-flaps-position.4 = 22.01, 185, 0.97, 1.00 ; CONF 3
-flaps-position.5 = 27.00, 177, 0.939, 1.00 ; CONF FULL
+flaps-position.1 = 18.00, 230, 0.36, 1.00 ; CONF 1
+flaps-position.2 = 18.01, 230, 0.69, 1.00 ; CONF 1+F
+flaps-position.3 = 22.00, 200, 0.87, 1.00 ; CONF 2
+flaps-position.4 = 22.01, 185, 1.08, 1.00 ; CONF 3
+flaps-position.5 = 27.00, 177, 1.00, 1.00 ; CONF FULL

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/A320AircraftConfig.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/A320AircraftConfig.ts
@@ -46,11 +46,11 @@ const flightModelParams: FlightModelParameters = {
   speedBrakeDrag: 0.01008,
   gearDrag: 0.0372,
   dragPolarCoefficients: {
-    [FlapConf.CLEAN]: [0.0215, -0.015, 0.0412, 0.0211],
-    [FlapConf.CONF_1]: [0.0398, -0.0538, 0.1166, -0.064, 0.0303],
-    [FlapConf.CONF_2]: [0.0729, -0.0037, -0.0018, 0.0168],
-    [FlapConf.CONF_3]: [0.0902, 0.0005, -0.0056, 0.013],
-    [FlapConf.CONF_FULL]: [0.1405, -0.001, -0.0056, 0.0077],
+    [FlapConf.CLEAN]: [0.0206, -0.0084, 0.0272, 0.0286],
+    [FlapConf.CONF_1]: [0.0212, 0.0348, -0.0337, 0.0462],
+    [FlapConf.CONF_2]: [0.067, 0.0098, -0.0112, 0.0178],
+    [FlapConf.CONF_3]: [0.0891, 0.0122, -0.0125, 0.0134],
+    [FlapConf.CONF_FULL]: [0.1417, -0.0022, -0.0017, 0.0058],
   },
 };
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
This PR is equivalent to #10312 but for MSFS 2024 only. It also, when combined with https://github.com/flybywiresim/aircraft/pull/10554 , is intended to provide consistent takeoffs (no auto-rotation before VR or difficulty in rotating) when trim is set anywhere within the green trim band, regardless of weight or cg (as long as they are within the certified weight-cg envelope). (Still need to verify whether the THS tables in that PR work for this one in MSFS 2024.) It also addresses flight model differences between MSFS 2020 and MSFS 2024.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): donbikes

## Testing instructions
Perform takeoffs and landings at various weights and cg conditions. Confirm that no auto-rotation occurs before VR, there is no difficulty in rotating the airplane for takeoff with the trim set anywhere within the green trim band, and that no regressions in flight characteristics are present. Use takeoff speeds and flex thrust settings from the takeoff performance calculator in the EFB.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
