### PR TITLE
fix(mcdu): ND resets to departure when entering approach

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1881,3 +1881,4 @@
 1. [EFB] Restructured APIs and made Navigraph Auth a reusable component - @MicahBCode (Mischa Binder)
 1. [ECAM] Added F units to CRZ and COND pages for Cabin temps. Currently tied to kg/lbs option in EFB -Patrick Macken  (@PatM on Discord)
 1. [A32NX/FCU] Fixed bug where the FCU selected altitude would immediately switch to 1000s on selecting the 1000ft inteval knob - @elliot747 (Elliot)
+1. [A32NX/MCDU] Fixed bug where the ND resets to the departure airport when selecting the destination for approach entry - @Ditoo29 (dito29 on discord)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -102,6 +102,7 @@
 1. [A32NX/FWS] Add `GEAR NOT DOWNLOCKED` master warning - @FozzieHi (fozzie)
 1. [A380X/FMS] Add secondary flight plans to A380X - @flogross89 (floridude), @BravoMike99 (bruno_pt99)
 1. [A380X/FMS] Allow edition of vnav descent speed - @BravoMike99 (bruno_pt99)
+1. [A32NX/MCDU] Fix ND reset to the departure airport when selecting the destination for approach - @Ditoo29 (dito29)
 
 ## 0.14.0
 
@@ -1881,4 +1882,3 @@
 1. [EFB] Restructured APIs and made Navigraph Auth a reusable component - @MicahBCode (Mischa Binder)
 1. [ECAM] Added F units to CRZ and COND pages for Cabin temps. Currently tied to kg/lbs option in EFB -Patrick Macken  (@PatM on Discord)
 1. [A32NX/FCU] Fixed bug where the FCU selected altitude would immediately switch to 1000s on selecting the 1000ft inteval knob - @elliot747 (Elliot)
-1. [A32NX/MCDU] Fixed bug where the ND resets to the departure airport when selecting the destination for approach entry - @Ditoo29 (dito29 on discord)

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AvailableArrivalsPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AvailableArrivalsPage.ts
@@ -234,6 +234,7 @@ export class CDUAvailableArrivalsPage {
               try {
                 await mcdu.flightPlanService.setApproach(approachOrRunway.databaseId, forPlan, inAlternate);
                 await CDUAvailableArrivalsPage.tryAutoSetApproachVia(mcdu, forPlan, inAlternate);
+                CDUAvailableArrivalsPage.focusPlanEndOnNd(mcdu, forPlan, inAlternate);
 
                 CDUAvailableArrivalsPage.ShowPage(mcdu, airport, 0, true, forPlan, inAlternate);
               } catch (e) {
@@ -273,6 +274,7 @@ export class CDUAvailableArrivalsPage {
               try {
                 await mcdu.flightPlanService.setApproach(undefined, forPlan, inAlternate);
                 await mcdu.flightPlanService.setDestinationRunway(approachOrRunway.ident, forPlan, inAlternate);
+                CDUAvailableArrivalsPage.focusPlanEndOnNd(mcdu, forPlan, inAlternate);
 
                 CDUAvailableArrivalsPage.ShowPage(mcdu, airport, 0, true, forPlan, inAlternate);
               } catch (e) {
@@ -338,6 +340,7 @@ export class CDUAvailableArrivalsPage {
             mcdu.onLeftInput[i + 2] = async () => {
               try {
                 await mcdu.flightPlanService.setArrival(null, forPlan, inAlternate);
+                CDUAvailableArrivalsPage.focusPlanEndOnNd(mcdu, forPlan, inAlternate);
                 if (await CDUAvailableArrivalsPage.tryAutoSetApproachVia(mcdu, forPlan, inAlternate)) {
                   CDUAvailableArrivalsPage.ShowPage(mcdu, airport, 0, true, forPlan, inAlternate);
                 } else {
@@ -390,6 +393,7 @@ export class CDUAvailableArrivalsPage {
                   }
 
                   await mcdu.flightPlanService.setArrival(starDatabaseId, forPlan, inAlternate);
+                  CDUAvailableArrivalsPage.focusPlanEndOnNd(mcdu, forPlan, inAlternate);
 
                   if (await CDUAvailableArrivalsPage.tryAutoSetApproachVia(mcdu, forPlan, inAlternate)) {
                     CDUAvailableArrivalsPage.ShowPage(mcdu, airport, 0, true, forPlan, inAlternate);
@@ -510,7 +514,7 @@ export class CDUAvailableArrivalsPage {
         mcdu.insertTemporaryFlightPlan(() => {
           mcdu.updateTowerHeadwind();
           mcdu.updateConstraints();
-          CDUFlightPlanPage.ShowPage(mcdu, 0, forPlan);
+          CDUFlightPlanPage.ShowDestinationPage(mcdu, forPlan);
         });
       };
     } else {
@@ -667,6 +671,7 @@ export class CDUAvailableArrivalsPage {
           if (!isSelected) {
             try {
               await mcdu.flightPlanService.setApproachVia(via.databaseId, forPlan, inAlternate);
+              CDUAvailableArrivalsPage.focusPlanEndOnNd(mcdu, forPlan, inAlternate);
 
               CDUAvailableArrivalsPage.ShowPage(mcdu, airport, 0, true, forPlan, inAlternate);
             } catch (e) {
@@ -819,5 +824,24 @@ export class CDUAvailableArrivalsPage {
       }
     }
     return false;
+  }
+
+  private static focusPlanEndOnNd(
+    mcdu: LegacyFmsPageInterface,
+    forPlan = FlightPlanIndex.Active,
+    inAlternate = false,
+  ): void {
+    const parentPlan = mcdu.getFlightPlan(forPlan);
+
+    if (!parentPlan) {
+      return;
+    }
+
+    const focusedPlan = inAlternate ? parentPlan.alternateFlightPlan : parentPlan;
+    const focusLegIndex =
+      focusedPlan.destinationLegIndex >= 0 ? focusedPlan.destinationLegIndex : Math.max(focusedPlan.legCount - 1, 0);
+
+    mcdu.efisInterfaces.L.setPlanCentre(parentPlan.index, focusLegIndex, inAlternate);
+    mcdu.efisInterfaces.R.setPlanCentre(parentPlan.index, focusLegIndex, inAlternate);
   }
 }

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_FlightPlanPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_FlightPlanPage.ts
@@ -37,7 +37,11 @@ const Time = Object.freeze({
 });
 
 export class CDUFlightPlanPage {
-  static ShowPage(mcdu: LegacyFmsPageInterface, offset = 0, forPlan = 0) {
+  static ShowDestinationPage(mcdu: LegacyFmsPageInterface, forPlan = 0) {
+    CDUFlightPlanPage.ShowPage(mcdu, 0, forPlan, true);
+  }
+
+  static ShowPage(mcdu: LegacyFmsPageInterface, offset = 0, forPlan = 0, focusDestinationOnOpen = false) {
     // INIT
     function addLskAt(index, delay, callback) {
       mcdu.leftInputDelay[index] = typeof delay === 'function' ? delay : () => delay;
@@ -54,7 +58,7 @@ export class CDUFlightPlanPage {
     mcdu.clearDisplay();
     mcdu.page.Current = mcdu.page.FlightPlanPage;
     mcdu.returnPageCallback = () => {
-      CDUFlightPlanPage.ShowPage(mcdu, offset, forPlan);
+      CDUFlightPlanPage.ShowPage(mcdu, offset, forPlan, focusDestinationOnOpen);
     };
     mcdu.activeSystem = 'FMGC';
 
@@ -68,7 +72,7 @@ export class CDUFlightPlanPage {
     // regular update due to showing dynamic data on this page
     mcdu.SelfPtr = setTimeout(() => {
       if (mcdu.page.Current === mcdu.page.FlightPlanPage) {
-        CDUFlightPlanPage.ShowPage(mcdu, offset, forPlan);
+        CDUFlightPlanPage.ShowPage(mcdu, offset, forPlan, focusDestinationOnOpen);
       }
     }, mcdu.PageTimeout.Medium);
 
@@ -231,6 +235,10 @@ export class CDUFlightPlanPage {
       }
     } else if (targetPlan.legCount > 0) {
       waypointsAndMarkers.push({ marker: Markers.NO_ALTN_FPLN, fpIndex: targetPlan.legCount + 1, inAlternate: true });
+    }
+
+    if (focusDestinationOnOpen) {
+      offset = destinationAirportOffset;
     }
 
     const tocIndex = waypointsAndMarkers.findIndex(({ pwp }) => pwp && pwp.ident === '(T/C)');
@@ -581,7 +589,12 @@ export class CDUFlightPlanPage {
             () => mcdu.getDelaySwitchPage(),
             (value, scratchpadCallback) => {
               if (value === '') {
+                mcdu.returnPageCallback = () => {
+                  CDUFlightPlanPage.ShowDestinationPage(mcdu, forPlan);
+                };
                 CDULateralRevisionPage.ShowPage(mcdu, wp, fpIndex, forPlan, inAlternate);
+                mcdu.efisInterfaces.L.setPlanCentre(targetPlan.index, fpIndex, inAlternate);
+                mcdu.efisInterfaces.R.setPlanCentre(targetPlan.index, fpIndex, inAlternate);
               } else if (value.length > 0) {
                 mcdu.insertWaypoint(
                   value,
@@ -972,7 +985,12 @@ export class CDUFlightPlanPage {
         5,
         () => mcdu.getDelaySwitchPage(),
         () => {
+          mcdu.returnPageCallback = () => {
+            CDUFlightPlanPage.ShowDestinationPage(mcdu, forPlan);
+          };
           CDULateralRevisionPage.ShowPage(mcdu, targetPlan.destinationLeg, targetPlan.destinationLegIndex, forPlan);
+          mcdu.efisInterfaces.L.setPlanCentre(targetPlan.index, targetPlan.destinationLegIndex, false);
+          mcdu.efisInterfaces.R.setPlanCentre(targetPlan.index, targetPlan.destinationLegIndex, false);
         },
       );
 

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_FlightPlanPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_FlightPlanPage.ts
@@ -589,9 +589,6 @@ export class CDUFlightPlanPage {
             () => mcdu.getDelaySwitchPage(),
             (value, scratchpadCallback) => {
               if (value === '') {
-                mcdu.returnPageCallback = () => {
-                  CDUFlightPlanPage.ShowDestinationPage(mcdu, forPlan);
-                };
                 CDULateralRevisionPage.ShowPage(mcdu, wp, fpIndex, forPlan, inAlternate);
                 mcdu.efisInterfaces.L.setPlanCentre(targetPlan.index, fpIndex, inAlternate);
                 mcdu.efisInterfaces.R.setPlanCentre(targetPlan.index, fpIndex, inAlternate);


### PR DESCRIPTION
Fixes #10559

## Summary of Changes
Fixed the Navigation Display resetting to the departure airport when clicking the destination on the MCDU F-PLAN page and when selecting approach procedures.

- Added destination-specific return callback that reopens F-PLAN at destination offset (using sentinel `-1`)
- Added `setPlanCentre` calls after opening LAT REV for destination clicks to prevent unload handler override
- Added `focusPlanEndOnNd` helper to centre ND on plan end after approach/STAR/VIA selection
- Changed temporary F-PLAN INSERT to open at destination/end instead of departure (offset `-1` → `destinationAirportOffset`)

## Screenshots (if necessary)
https://github.com/user-attachments/assets/d339cb48-cd1f-4c9e-9e6f-a980f2290ba0

## References
Bug was reproducible since v0.12.0 as reported in #10559. Fix aligns with expected A320 FMS behaviour where the ND should remain centred on the destination/approach area when entering procedures.

Video references showing expected behaviour:
- https://youtu.be/kKhIENzsb0c?t=754
- https://youtu.be/TqLF8ySn7ok?t=601

## Additional context
Two files changed:
- `A320_Neo_CDU_FlightPlanPage.ts` — destination return callback + re-applied ND centre in both DEST paths
- `A320_Neo_CDU_AvailableArrivalsPage.ts` — centralized ND focus helper + calls after approach/STAR/VIA/INSERT actions

## Testing Instructions
1. Load a flight plan with at least 5 waypoints (e.g. LPPT → EGLL)
2. Open F-PLAN and scroll to show destination
3. Press DEST LSK — verify ND stays on destination
4. Press RETURN — verify F-PLAN reopens at destination
5. Select ARRIVAL > any ILS approach — verify ND immediately centres on destination/approach area
6. Select any STAR — verify ND stays centred on destination/approach
7. Press INSERT* — verify ND stays at end when FPLN closes

Discord username (if different from GitHub): dito29