### PR TITLE
fix(ecam): GW not displaying until engine start

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1863,3 +1863,4 @@
 1. [EFB] Restructured APIs and made Navigraph Auth a reusable component - @MicahBCode (Mischa Binder)
 1. [ECAM] Added F units to CRZ and COND pages for Cabin temps. Currently tied to kg/lbs option in EFB -Patrick Macken  (@PatM on Discord)
 1. [A32NX/FCU] Fixed bug where the FCU selected altitude would immediately switch to 1000s on selecting the 1000ft inteval knob - @elliot747 (Elliot)
+1. [ECAM] Fixed GW not displaying on lower ECAM until engine start. GW now displays correctly when electrical power is available - @Ditoo29 (dito29 on discord)

--- a/fbw-a32nx/src/systems/instruments/src/SD/StatusArea/StatusArea.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/SD/StatusArea/StatusArea.tsx
@@ -27,9 +27,6 @@ export const StatusArea = () => {
   const [airDataSwitch] = useSimVar('L:A32NX_AIR_DATA_SWITCHING_KNOB', 'enum', 200);
   const [attHdgSwitch] = useSimVar('L:A32NX_ATT_HDG_SWITCHING_KNOB', 'enum', 200);
 
-  const [eng1Running] = useSimVar('ENG COMBUSTION:1', 'bool', 1000);
-  const [eng2Running] = useSimVar('ENG COMBUSTION:2', 'bool', 1000);
-
   const [isaVisible, setIsaVisible] = useState(false);
 
   const [airDataReferenceSource, setAirDataSource] = useState(1);
@@ -106,7 +103,7 @@ export const StatusArea = () => {
     const payloadWeight = getPayloadWeight(payloadCount);
     const gw = Math.round(NXUnits.kgToUser(emptyWeight + fuelWeight + payloadWeight));
 
-    if (eng1Running || (eng2Running && gw != null)) {
+    if (gw != null) {
       // Lower EICAS displays GW in increments of 100
       setGwDisplayedValue((Math.floor(gw / 100) * 100).toString());
     } else {
@@ -172,33 +169,17 @@ export const StatusArea = () => {
           </Text>
 
           {/* Gross weight */}
-          {(eng1Running || eng2Running) && (
-            <>
-              <Text title x={445} y={63} alignEnd>
-                GW
-              </Text>
-              <Text value x={512} y={63}>
-                {gwDisplayedValue}
-              </Text>
-              <Text unit x={562} y={61} alignStart>
-                {gwDisplayedUnit}
-              </Text>
-            </>
-          )}
-
-          {!eng1Running && !eng2Running && (
-            <>
-              <Text title x={445} y={63} alignEnd>
-                GW
-              </Text>
-              <Text unit x={512} y={63}>
-                {gwDisplayedValue}
-              </Text>
-              <Text unit x={562} y={61} alignStart>
-                {gwDisplayedUnit}
-              </Text>
-            </>
-          )}
+          <>
+            <Text title x={445} y={63} alignEnd>
+              GW
+            </Text>
+            <Text value x={512} y={63}>
+              {gwDisplayedValue}
+            </Text>
+            <Text unit x={562} y={61} alignStart>
+              {gwDisplayedUnit}
+            </Text>
+          </>
 
           {/* ISA */}
           {isaVisible && (


### PR DESCRIPTION
Fixes #10582

## Summary of Changes
- Removed engine running condition from GW display logic so GW now displays on the lower ECAM as soon as electrical power is available, instead of waiting for engine start
- Fixed GW value text style when engines are off (was incorrectly using `Text unit` instead of `Text value`)

## Screenshots (if necessary)

## References
GW should display whenever AC power is available, consistent with real A320 behaviour.

## Additional context
Bug was introduced and reported in #10582. Previously GW would only appear at ~3% N1 during engine start.

Discord username (if different from GitHub): dito29

## Testing instructions
1. Load A32NX cold & dark at a gate
2. Connect External Power (EXT PWR on overhead ELEC panel)
3. Verify GW displays on the bottom right of the lower ECAM immediately
4. Verify GW value is correct and displayed in the correct style
5. Start an engine and verify GW continues to display correctly during and after engine start