### PR TITLE
fix(a32nx/fwc): LGCIU faults should only check their respective words

### DIFF
--- a/fbw-a32nx/src/systems/systems-host/systems/FWC/PseudoFWC.ts
+++ b/fbw-a32nx/src/systems/systems-host/systems/FWC/PseudoFWC.ts
@@ -2041,10 +2041,19 @@ export class PseudoFWC {
     const leftCompressedHardwireLgciu2 =
       this.dc2BusPowered.get() && SimVar.GetSimVarValue('L:A32NX_LGCIU_2_LEFT_GEAR_COMPRESSED', 'bool') > 0;
 
-    const lgciu1Or2DiscreteWord1Invalid = this.lgciu1DiscreteWord1.isInvalid() || this.lgciu2DiscreteWord1.isInvalid();
-    const lgciu1Or2DiscreteWord2Invalid = this.lgciu1DiscreteWord2.isInvalid() || this.lgciu2DiscreteWord2.isInvalid();
-    const lgciu1Or2DiscreteWord3Invalid = this.lgciu1DiscreteWord3.isInvalid() || this.lgciu2DiscreteWord3.isInvalid();
-    const lgciu1Or2DiscreteWord4Invalid = this.lgciu1DiscreteWord4.isInvalid() || this.lgciu2DiscreteWord4.isInvalid();
+    const lgciu1DiscreteWord1Invalid = this.lgciu1DiscreteWord1.isInvalid();
+    const lgciu2DiscreteWord1Invalid = this.lgciu2DiscreteWord1.isInvalid();
+
+    const lgciu1DiscreteWord2Invalid = this.lgciu1DiscreteWord2.isInvalid();
+    const lgciu2DiscreteWord2Invalid = this.lgciu2DiscreteWord2.isInvalid();
+
+    const lgciu1DiscreteWord3Invalid = this.lgciu1DiscreteWord3.isInvalid();
+    const lgciu2DiscreteWord3Invalid = this.lgciu2DiscreteWord3.isInvalid();
+
+    const lgciu1DiscreteWord4Invalid = this.lgciu1DiscreteWord4.isInvalid();
+    const lgciu2DiscreteWord4Invalid = this.lgciu2DiscreteWord4.isInvalid();
+
+    const lgciu1Or2DiscreteWord1Invalid = lgciu1DiscreteWord1Invalid || lgciu2DiscreteWord1Invalid;
 
     const lgciu1LhGearDownlock = this.lgciu1DiscreteWord1.bitValueOr(23, false);
     const lgciu2LhGearDownlock = this.lgciu2DiscreteWord1.bitValueOr(23, false);
@@ -3183,18 +3192,18 @@ export class PseudoFWC {
     this.lgciu1Fault.set(
       this.lgciu1DiscreteWord4.bitValueOr(29, false) ||
         this.lgciu1DiscreteWord2.bitValueOr(29, false) ||
-        (lgciu1Or2DiscreteWord1Invalid &&
-          lgciu1Or2DiscreteWord2Invalid &&
-          lgciu1Or2DiscreteWord3Invalid &&
-          lgciu1Or2DiscreteWord4Invalid),
+        (lgciu1DiscreteWord1Invalid &&
+          lgciu1DiscreteWord2Invalid &&
+          lgciu1DiscreteWord3Invalid &&
+          lgciu1DiscreteWord4Invalid),
     );
     this.lgciu2Fault.set(
       this.lgciu2DiscreteWord4.bitValueOr(29, false) ||
         this.lgciu2DiscreteWord2.bitValueOr(29, false) ||
-        (lgciu1Or2DiscreteWord1Invalid &&
-          lgciu1Or2DiscreteWord2Invalid &&
-          lgciu1Or2DiscreteWord3Invalid &&
-          lgciu1Or2DiscreteWord4Invalid),
+        (lgciu2DiscreteWord1Invalid &&
+          lgciu2DiscreteWord2Invalid &&
+          lgciu2DiscreteWord3Invalid &&
+          lgciu2DiscreteWord4Invalid),
     );
     this.lgciu12Fault.set(this.lgciu1Fault.get() && this.lgciu2Fault.get());
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fix bug introduced in #10521. Each LGCIU fault should only check if it's own words are invalid, not both. My copy and paste error (One bug that AI would never make!).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): fozzie

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
