### PR TITLE
fix(a380x/model): Maintenance panel button fixes

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -36,7 +36,7 @@
 1. [A32NX/FMS] Adjusted TRANS ALT allowed entry range - @Jonny23787 (Jonathan)
 1. [A32NX/FMS] Fix "NOT ALLOWED IN NAV" when sequencing TO waypoint while in LOC mode - @BravoMike99 (bruno_pt99)
 1. [A380X/SD] Improve STS page: Add deferred procedures, page switching, MORE page, improve performance - @flogross89 (floridude)
-1. [A32NX/FMS] Adjusted position of flight phase and flight number on PROG page  - @Jonny23787 (Jonathan)
+1. [A32NX/FMS] Adjusted position of flight phase and flight number on PROG page - @Jonny23787 (Jonathan)
 1. [A32NX/A380X] Properly handle `PARKING_BRAKE_ON` and `PARKING_BRAKE_OFF` key events - @tracernz (Mike)
 1. [A380X/PFD] Increase PFD trim wheel rotation speed - @lukecologne (luke)
 1. [A380X/FWS] Add FCTL and OVERSPEED abnormal sensed procedures - @Jonny23787 (Jonathan)
@@ -104,8 +104,8 @@
 1. [A380X/FMS] Allow edition of vnav descent speed - @BravoMike99 (bruno_pt99)
 1. [A32NX/MCDU] Fix ND reset to the departure airport when selecting the destination for approach - @Ditoo29 (dito29)
 1. [A380X/FMS] Allow "INSERT NEXT WPT" revision at the flightplan origin - @BravoMike99 (bruno_pt99)
-1. [A380X/MODEL] Unlink CKPT DOOR LCKG SYS and OXYGEN RESET buttons  - @Jonny23787 (Jonathan)
-1. [A380X/MODEL] Match animation speed of GND HYD buttons to other overhead buttons  - @Jonny23787 (Jonathan)
+1. [A380X/MODEL] Unlink CKPT DOOR LCKG SYS and OXYGEN RESET buttons - @Jonny23787 (Jonathan)
+1. [A380X/MODEL] Match animation speed of GND HYD buttons to other overhead buttons - @Jonny23787 (Jonathan)
 
 ## 0.14.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -104,6 +104,8 @@
 1. [A380X/FMS] Allow edition of vnav descent speed - @BravoMike99 (bruno_pt99)
 1. [A32NX/MCDU] Fix ND reset to the departure airport when selecting the destination for approach - @Ditoo29 (dito29)
 1. [A380X/FMS] Allow "INSERT NEXT WPT" revision at the flightplan origin - @BravoMike99 (bruno_pt99)
+1. [A380X/MODEL] Unlink CKPT DOOR LCKG SYS and OXYGEN RESET buttons  - @Jonny23787 (Jonathan)
+1. [A380X/MODEL] Match animation speed of GND HYD buttons to other overhead buttons  - @Jonny23787 (Jonathan)
 
 ## 0.14.0
 

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/A380_COCKPIT.xml
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380_842/model/A380_COCKPIT.xml
@@ -3461,20 +3461,10 @@
                         <UseTemplate Name="FBW_Covered_Push_Toggle">
                             <NODE_ID>PUSH_DOOR_LCKG_SYS</NODE_ID>
                             <LOCK_NODE_ID>LOCK_DOOR_LCKG_SYS</LOCK_NODE_ID>
-                            <LEFT_SINGLE_CODE>
-                                (L:A32NX_OXYGEN_TMR_RESET, Bool) ! (&gt;L:A32NX_OXYGEN_TMR_RESET,
-                                Bool)
-                                (L:A32NX_OXYGEN_MASKS_DEPLOYED, Bool) !
-                                (&gt;L:A32NX_OXYGEN_MASKS_DEPLOYED, Bool)
-                                0 (&gt;L:A32NX_OXYGEN_PASSENGER_LIGHT_ON)
-                            </LEFT_SINGLE_CODE>
                             <SEQ_POWERED>(L:A32NX_ELEC_AC_ESS_SHED_BUS_IS_POWERED, Bool)</SEQ_POWERED>
-                            <SEQ1_CODE>(L:A32NX_OXYGEN_TMR_RESET_FAULT, Bool)</SEQ1_CODE>
-                            <SEQ2_CODE>(L:A32NX_OXYGEN_TMR_RESET, Bool)</SEQ2_CODE>
                             <SEQ2_EMISSIVE_DRIVES_VISIBILITY>False</SEQ2_EMISSIVE_DRIVES_VISIBILITY>
                             <SEQ1_CODE_DRIVES_VISIBILITY>False</SEQ1_CODE_DRIVES_VISIBILITY>
                             <SEQ2_CODE_DRIVES_VISIBILITY>False</SEQ2_CODE_DRIVES_VISIBILITY>
-                            <TOOLTIPID>Reset oxygen timer</TOOLTIPID>
                         </UseTemplate>
 
                         <!-- Data Loading Selector-->
@@ -4450,9 +4440,7 @@
                 <Component ID="Overhead_Back_Panel">
 
                     <!-- "GREEN PUMP A" -->
-                    <UseTemplate Name="FBW_Anim_Interactions">
-                        <ANIM_TYPE>KORRY_PROTECTED</ANIM_TYPE>
-                        <ANIM_TEMPLATE>FBW_Covered_Push_Toggle</ANIM_TEMPLATE>
+                    <UseTemplate Name="FBW_Covered_Push_Toggle">
                         <NODE_ID>PUSH_OVHD_HYD_GPUMPA</NODE_ID>
                         <LOCK_NODE_ID>LOCK_OVHD_HYD_GPUMPA</LOCK_NODE_ID>
                         <TOGGLE_SIMVAR>L:A32NX_OVHD_HYD_EPUMPGA_ON_PB_IS_AUTO</TOGGLE_SIMVAR>
@@ -4468,9 +4456,7 @@
                     </UseTemplate>
 
                     <!-- "GREEN PUMP B" -->
-                    <UseTemplate Name="FBW_Anim_Interactions">
-                        <ANIM_TYPE>KORRY_PROTECTED</ANIM_TYPE>
-                        <ANIM_TEMPLATE>FBW_Covered_Push_Toggle</ANIM_TEMPLATE>
+                    <UseTemplate Name="FBW_Covered_Push_Toggle">
                         <NODE_ID>PUSH_OVHD_HYD_GPUMPB</NODE_ID>
                         <LOCK_NODE_ID>LOCK_OVHD_HYD_GPUMPB</LOCK_NODE_ID>
                         <TOGGLE_SIMVAR>L:A32NX_OVHD_HYD_EPUMPGB_ON_PB_IS_AUTO</TOGGLE_SIMVAR>
@@ -4486,9 +4472,7 @@
                     </UseTemplate>
 
                     <!-- "YELLOW PUMP A" -->
-                    <UseTemplate Name="FBW_Anim_Interactions">
-                        <ANIM_TYPE>KORRY_PROTECTED</ANIM_TYPE>
-                        <ANIM_TEMPLATE>FBW_Covered_Push_Toggle</ANIM_TEMPLATE>
+                    <UseTemplate Name="FBW_Covered_Push_Toggle">
                         <NODE_ID>PUSH_OVHD_HYD_YPUMPA</NODE_ID>
                         <LOCK_NODE_ID>LOCK_OVHD_HYD_YPUMPA</LOCK_NODE_ID>
                         <TOGGLE_SIMVAR>L:A32NX_OVHD_HYD_EPUMPYA_ON_PB_IS_AUTO</TOGGLE_SIMVAR>
@@ -4504,9 +4488,7 @@
                     </UseTemplate>
 
                     <!-- "YELLOW PUMP B" -->
-                    <UseTemplate Name="FBW_Anim_Interactions">
-                        <ANIM_TYPE>KORRY_PROTECTED</ANIM_TYPE>
-                        <ANIM_TEMPLATE>FBW_Covered_Push_Toggle</ANIM_TEMPLATE>
+                    <UseTemplate Name="FBW_Covered_Push_Toggle">
                         <NODE_ID>PUSH_OVHD_HYD_YPUMPB</NODE_ID>
                         <LOCK_NODE_ID>LOCK_OVHD_HYD_YPUMPB</LOCK_NODE_ID>
                         <TOGGLE_SIMVAR>L:A32NX_OVHD_HYD_EPUMPYB_ON_PB_IS_AUTO</TOGGLE_SIMVAR>
@@ -4524,9 +4506,7 @@
                     <!-- "HYD " -->
 
                     <!-- Green A -->
-                    <UseTemplate Name="FBW_Anim_Interactions">
-                        <ANIM_TYPE>KORRY_BUTTON</ANIM_TYPE>
-                        <ANIM_TEMPLATE>FBW_Push_Toggle</ANIM_TEMPLATE>
+                    <UseTemplate Name="FBW_Push_Toggle">
                         <NODE_ID>PUSH_OVHD_HYD_G_A</NODE_ID>
                         <TOGGLE_SIMVAR>L:A32NX_OVHD_HYD_EPUMPGA_OFF_PB_IS_AUTO</TOGGLE_SIMVAR>
                         <SEQ_POWERED>(L:A32NX_ELEC_AC_2_BUS_IS_POWERED, Bool)</SEQ_POWERED>
@@ -4540,9 +4520,7 @@
                     </UseTemplate>
 
                     <!-- Green B -->
-                    <UseTemplate Name="FBW_Anim_Interactions">
-                        <ANIM_TYPE>KORRY_BUTTON</ANIM_TYPE>
-                        <ANIM_TEMPLATE>FBW_Push_Toggle</ANIM_TEMPLATE>
+                    <UseTemplate Name="FBW_Push_Toggle">
                         <NODE_ID>PUSH_OVHD_HYD_G_B</NODE_ID>
                         <TOGGLE_SIMVAR>L:A32NX_OVHD_HYD_EPUMPGB_OFF_PB_IS_AUTO</TOGGLE_SIMVAR>
                         <SEQ_POWERED>(L:A32NX_ELEC_AC_2_BUS_IS_POWERED, Bool)</SEQ_POWERED>
@@ -4556,9 +4534,7 @@
                     </UseTemplate>
 
                     <!-- Yellow A -->
-                    <UseTemplate Name="FBW_Anim_Interactions">
-                        <ANIM_TYPE>KORRY_BUTTON</ANIM_TYPE>
-                        <ANIM_TEMPLATE>FBW_Push_Toggle</ANIM_TEMPLATE>
+                    <UseTemplate Name="FBW_Push_Toggle">
                         <NODE_ID>PUSH_OVHD_HYD_Y_A</NODE_ID>
                         <TOGGLE_SIMVAR>L:A32NX_OVHD_HYD_EPUMPYA_OFF_PB_IS_AUTO</TOGGLE_SIMVAR>
                         <SEQ_POWERED>(L:A32NX_ELEC_AC_2_BUS_IS_POWERED, Bool)</SEQ_POWERED>
@@ -4572,9 +4548,7 @@
                     </UseTemplate>
 
                     <!-- Yellow B -->
-                    <UseTemplate Name="FBW_Anim_Interactions">
-                        <ANIM_TYPE>KORRY_BUTTON</ANIM_TYPE>
-                        <ANIM_TEMPLATE>FBW_Push_Toggle</ANIM_TEMPLATE>
+                    <UseTemplate Name="FBW_Push_Toggle">
                         <NODE_ID>PUSH_OVHD_HYD_Y_B</NODE_ID>
                         <TOGGLE_SIMVAR>L:A32NX_OVHD_HYD_EPUMPYB_OFF_PB_IS_AUTO</TOGGLE_SIMVAR>
                         <SEQ_POWERED>(L:A32NX_ELEC_AC_2_BUS_IS_POWERED, Bool)</SEQ_POWERED>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes

- Unlink CKPT DOOR LCKG SYS and OXYGEN RESET buttons.
- Match animation speed of GND HYD buttons to other overhead buttons.

<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
jonny_23

## Testing instructions

1. Confirm animation of GND HYD buttons and guards match the speed of other overhead buttons.
2. Confirm pressing CKPT DOOR LCKG SYS does not turn on OXYGEN RESET and visa versa.
3. Confirm functionality of buttons still work by confirming on ECAM EWD memos (CKPT DOOR LCKG SYS does not currently work). 

<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
