### PR TITLE
fix(a32nx/fms): fix not being able to enter trip wind

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/plans/FlightPlan.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/plans/FlightPlan.ts
@@ -881,7 +881,6 @@ export class FlightPlan<P extends FlightPlanPerformanceData = FlightPlanPerforma
 
   hasWindEntries() {
     return (
-      this.performanceData.pilotTripWind.get() !== null ||
       this.performanceData.climbWindEntries.get().length > 0 ||
       this.performanceData.descentWindEntries.get().length > 0 ||
       this.allLegs.some((el) => isLeg(el) && el.cruiseWindEntries.length > 0)

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A32NX_FMCMainDisplay.ts
@@ -5658,7 +5658,8 @@ export abstract class FMCMainDisplay implements FmsDataInterface, FmsDisplayInte
           () => !plan.pendingWindUplink.isWindUplinkReadyToInsert(),
         );
 
-        const shouldInsertDirectly = !this.isAnEngineOn() && !plan.hasWindEntries();
+        const isTripWindPilotEntered = plan.performanceData.pilotTripWind.get() !== null;
+        const shouldInsertDirectly = !this.isAnEngineOn() && !plan.hasWindEntries() && !isTripWindPilotEntered;
         if (!shouldInsertDirectly) {
           if (this.flightPlanService.hasTemporary) {
             this.addMessageToQueue(NXSystemMessages.windTempUplkPending);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes an issue introduced in #10443 where the trip wind entry would blank out after making an input. 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Load up cold & dark, enter FROM/TO, make sure you can enter and modify a trip wind on INIT FUEL PRED. Make sure you can no longer do that after inserting a wind on the climb, cruise, or descent wind page.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
