### PR TITLE
fix(press): actively correct cabin altitude overshoot above MAX_CLIMB_CABIN_ALTITUDE

### DIFF
--- a/fbw-common/src/wasm/systems/systems/src/air_conditioning/cabin_pressure_controller.rs
+++ b/fbw-common/src/wasm/systems/systems/src/air_conditioning/cabin_pressure_controller.rs
@@ -341,7 +341,7 @@ impl<C: PressurizationConstants> CabinPressureController<C> {
                     } else if self.cabin_altitude()
                         >= Length::new::<foot>(C::MAX_CLIMB_CABIN_ALTITUDE)
                     {
-                        0.
+                        C::MAX_DESCENT_RATE
                     } else if target_vs_fpm <= C::MAX_DESCENT_RATE {
                         C::MAX_DESCENT_RATE
                     } else {


### PR DESCRIPTION
## Summary of Changes
In `calculate_cabin_target_vs`, the `ClimbInternal` branch returned a target
vertical speed of `0.` when cabin altitude reached or exceeded
`MAX_CLIMB_CABIN_ALTITUDE` (8050 ft). The PI controller's integrator accumulates
error during climb and, when the target suddenly drops to 0, the residual
integrator value holds the outflow valve partially open. This allows cabin
altitude to overshoot, triggering a spurious CAB PR EXCESS CAB ALT ECAM warning.

Changed the return value from `0.` to `C::MAX_DESCENT_RATE` so the controller
actively drives the outflow valve closed once the ceiling is reached, preventing
overshoot.

## Screenshots (if necessary)
Reproduced at SCCF (Calama, Chile, elevation 7027 ft MSL): CAB PR EXCESS CAB ALT
warning triggers immediately after takeoff before the fix, and does not appear
after the fix.

## References
Airbus A320 FCOM DSC-21 Air Conditioning and Pressurization, cabin altitude
ceiling schedule and outflow valve control logic.

## Additional context
The issue is most noticeable at high-elevation airports (SCCF 7027 ft,
SKBO 8357 ft, SEQM 9228 ft) where the initial cabin altitude is already close
to the MAX_CLIMB_CABIN_ALTITUDE limit, giving the integrator less time to
wind down before the ceiling is hit.

## Testing instructions
1. Set departure airport to SCCF (Calama, Chile, elevation 7027 ft MSL)
2. Load fuel and passengers, complete normal preflight
3. Take off and climb to cruise altitude
4. Verify no CAB PR EXCESS CAB ALT warning appears on ECAM
5. Optionally repeat at SKBO (Bogota, 8357 ft) and SEQM (Quito, 9228 ft)
