### PR TITLE
fix(a380x/fcdc): wire aileron fault into BTV LOST landing distance

### DIFF
--- a/fbw-a380x/src/wasm/fbw_a380/src/fcdc/Fcdc.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/fcdc/Fcdc.cpp
@@ -382,7 +382,9 @@ void Fcdc::updateBtvRowRop(double deltaTime) {
   bool doubleElevFault = (elevStatusWord->bitFromValueOr(11, false) ? 1 : 0) + (elevStatusWord->bitFromValueOr(14, false) ? 1 : 0) +
                              (elevStatusWord->bitFromValueOr(17, false) ? 1 : 0) <
                          2;
-  bool anyAileronFault = false;  // FIXME add
+  Arinc429DiscreteWord* ailStatusWord =
+      reinterpret_cast<Arinc429DiscreteWord*>(&busInputs.prims[masterPrimIndex].aileron_status_word);
+  bool anyAileronFault = !ailStatusWord->bitFromValueOr(11, false) || !ailStatusWord->bitFromValueOr(14, false);
   Arinc429DiscreteWord* sfcc1StatusWord =
       reinterpret_cast<Arinc429DiscreteWord*>(&busInputs.sfccBusOutputs[0].slat_flap_system_status_word);
   Arinc429DiscreteWord* sfcc2StatusWord =


### PR DESCRIPTION
## Summary

The FCDC's `anyAileronFault` flag at Fcdc.cpp:385 was hardcoded to `false`
with a `// FIXME add` comment. Aileron failures never contributed to
`ldgDistAffectedBtvLost`, so BTV LOST never fired on aileron failure during
landing rollout.

## Change

Mirror the existing elevator pattern at Fcdc.cpp:381 by reading the master
PRIM's `aileron_status_word`. Bits 11 and 14 are the aileron healthy bits
per the inversion convention used in efcsStatus2/3 at Fcdc.cpp:103-106;
fail-safe default `false` matches the neighbouring SFCC and elevator
handling.

## Test plan

- [ ] Inject a simulated aileron failure and verify BTV LOST appears on landing rollout
- [ ] With no failures, verify BTV remains armable and operational
- [ ] With master PRIM dead / aileron_status_word SSM bad, verify BTV LOST fires (fail-safe path)

## Notes

- No Simulink regen needed; pure FCDC change.
- Bits 11/14 are the only `aileron_status_word` bits referenced elsewhere in
  this file. If PRIM emits additional aileron fault bits, the OR list may
  need extending.