### PR TITLE
feat(a32nx): add TCAS bus, improve PFD TCAS display

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -152,6 +152,7 @@
 1. [EFB] Add FAA and LIDO charts supplied by MSFS2024 - @tracernz (Mike)
 1. [EFB] Added a cold temperature correction calculator - @tracernz (Mike)
 1. [A32NX/FLIGHT MODEL] Updated A32NX flight model for MSFS 2024 - @donstim (donbikes)
+1. [A32NX/TCAS] Improve PFD Resolution Advisory graphics, introduce TCAS bus - @lukecologne (luke)
 
 ## 0.14.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## 2024.2.0
 
 1. [ATSU] Add support for BeyondATC and SayIntentions AI as METAR/ATIS sources - @saschl
+1. [A32NX/TCAS] Improve PFD Resolution Advisory graphics, introduce TCAS bus - @lukecologne (luke)
 
 ## 2024.1.0
 
@@ -152,7 +153,6 @@
 1. [EFB] Add FAA and LIDO charts supplied by MSFS2024 - @tracernz (Mike)
 1. [EFB] Added a cold temperature correction calculator - @tracernz (Mike)
 1. [A32NX/FLIGHT MODEL] Updated A32NX flight model for MSFS 2024 - @donstim (donbikes)
-1. [A32NX/TCAS] Improve PFD Resolution Advisory graphics, introduce TCAS bus - @lukecologne (luke)
 
 ## 0.14.0
 

--- a/fbw-a32nx/src/systems/instruments/src/PFD/AltitudeIndicator.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/AltitudeIndicator.tsx
@@ -311,8 +311,6 @@ export class AltitudeIndicatorOfftape extends DisplayComponent<AltitudeIndicator
 
   private readonly altFlagVisible = this.altitude.map((v) => !v.isNormalOperation() && !v.isFunctionalTest());
 
-  private readonly tcasFailed = ConsumerSubject.create(null, false);
-
   private fcuSelectedAlt = new Arinc429Word(0);
 
   private altConstraint = new Arinc429Word(0);
@@ -329,8 +327,6 @@ export class AltitudeIndicatorOfftape extends DisplayComponent<AltitudeIndicator
     super.onAfterRender(node);
 
     const sub = this.props.bus.getSubscriber<PFDSimvars & FgBus & FcuBus>();
-
-    this.tcasFailed.setConsumer(sub.on('tcasFail'));
 
     sub
       .on('fmgcDiscreteWord1')
@@ -377,20 +373,6 @@ export class AltitudeIndicatorOfftape extends DisplayComponent<AltitudeIndicator
             </text>
           </FlashOneHertz>
         </g>
-        <FlashOneHertz bus={this.props.bus} flashDuration={9} visible={this.tcasFailed}>
-          <text class="FontMedium Amber EndAlign" x="141.5" y="100">
-            T
-          </text>
-          <text class="FontMedium Amber EndAlign" x="141.5" y="105">
-            C
-          </text>
-          <text class="FontMedium Amber EndAlign" x="141.5" y="110">
-            A
-          </text>
-          <text class="FontMedium Amber EndAlign" x="141.5" y="115">
-            S
-          </text>
-        </FlashOneHertz>
         <FlashOneHertz bus={this.props.bus} flashDuration={9} visible={this.isCheckAltVisible}>
           <g
             id="CheckAltWarning"

--- a/fbw-a32nx/src/systems/instruments/src/PFD/AltitudeIndicator.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/AltitudeIndicator.tsx
@@ -5,7 +5,6 @@
 
 import {
   ClockEvents,
-  ConsumerSubject,
   DisplayComponent,
   FSComponent,
   MappedSubject,

--- a/fbw-a32nx/src/systems/instruments/src/PFD/VerticalSpeedIndicator.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/VerticalSpeedIndicator.tsx
@@ -78,13 +78,15 @@ export class VerticalSpeedIndicator extends DisplayComponent<VerticalSpeedIndica
 
   private readonly ra = ConsumerSubject.create(this.sub.on('chosenRa'), Arinc429Word.empty());
 
-  private verticalResolutionAdvisoryWord = Arinc429LocalVarConsumerSubject.create(
+  private readonly verticalResolutionAdvisoryWord = Arinc429LocalVarConsumerSubject.create(
     this.sub.on('a32nx_tcas_vertical_resolution_advisory_word'),
   );
 
-  private tcasModeWord = Arinc429LocalVarConsumerSubject.create(this.sub.on('a32nx_tcas_mode_word'));
+  private readonly tcasModeWord = Arinc429LocalVarConsumerSubject.create(this.sub.on('a32nx_tcas_mode_word'));
 
-  private tcasFaultSummaryWord = Arinc429LocalVarConsumerSubject.create(this.sub.on('a32nx_tcas_fault_summary_word'));
+  private readonly tcasFaultSummaryWord = Arinc429LocalVarConsumerSubject.create(
+    this.sub.on('a32nx_tcas_fault_summary_word'),
+  );
 
   private readonly vsFlagVisible = this.verticalSpeed.map((vs) => !vs.isNormalOperation());
 

--- a/fbw-a32nx/src/systems/instruments/src/PFD/VerticalSpeedIndicator.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/VerticalSpeedIndicator.tsx
@@ -3,20 +3,58 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import {
-  ClockEvents,
   ComponentProps,
+  ConsumerSubject,
   DisplayComponent,
   FSComponent,
+  MappedSubject,
   Subject,
   Subscribable,
   VNode,
 } from '@microsoft/msfs-sdk';
-import { ArincEventBus, Arinc429Word } from '@flybywiresim/fbw-sdk';
+import { ArincEventBus, Arinc429Word, Arinc429LocalVarConsumerSubject, Arinc429WordData } from '@flybywiresim/fbw-sdk';
 
 import { Arinc429Values } from './shared/ArincValueProvider';
-import { PFDSimvars } from './shared/PFDSimvarPublisher';
 import { LagFilter } from './PFDUtils';
 import { FlashOneHertz } from '../MsfsAvionicsCommon/FlashingElementUtils';
+import { A32NXTcasBusEvents } from '@shared/publishers/A32NXTcasBusPublisher';
+
+function bitsToInteger(word: Arinc429WordData, startBit: number, endBit: number): number {
+  const mask = ((1 << (endBit - startBit + 1)) - 1) << (startBit - 1);
+
+  return (word.value & mask) >> (startBit - 1);
+}
+
+function resolutionAdvisoryNumberToVs(resAdv: number, rateToMaintain: number, sign: number) {
+  if (resAdv == 1) {
+    return rateToMaintain;
+  } else if (resAdv == 2) {
+    return sign * 250;
+  } else if (resAdv == 3) {
+    return sign * 500;
+  } else if (resAdv == 4) {
+    return sign * 1000;
+  } else if (resAdv == 5) {
+    return sign * 2000;
+  } else {
+    return sign * 32767;
+  }
+}
+
+function yPosFromVs(vsValue: number): number {
+  const absVSpeed = Math.abs(vsValue);
+  const sign = Math.sign(vsValue);
+
+  if (absVSpeed < 1000) {
+    return (vsValue / 1000) * -27.22;
+  } else if (absVSpeed < 2000) {
+    return ((vsValue - sign * 1000) / 1000) * -10.1 - sign * 27.22;
+  } else if (absVSpeed < 6000) {
+    return ((vsValue - sign * 2000) / 4000) * -10.1 - sign * 37.32;
+  } else {
+    return sign * -47.37;
+  }
+}
 
 interface VerticalSpeedIndicatorProps {
   bus: ArincEventBus;
@@ -24,154 +62,131 @@ interface VerticalSpeedIndicatorProps {
   filteredRadioAltitude: Subscribable<number>;
 }
 
-interface TcasState {
-  tcasState: number;
-  isTcasCorrective: boolean;
-  tcasRedZoneL: number;
-  tcasRedZoneH: number;
-  tcasGreenZoneL: number;
-  tcasGreenZoneH: number;
-}
-
 export class VerticalSpeedIndicator extends DisplayComponent<VerticalSpeedIndicatorProps> {
-  private yOffsetSub = Subject.create(0);
+  private readonly sub = this.props.bus.getArincSubscriber<A32NXTcasBusEvents & Arinc429Values>();
 
-  private needleColour = Subject.create('Green');
+  private readonly verticalSpeed = ConsumerSubject.create(
+    this.sub.on('vs').withArinc429Precision(3),
+    Arinc429Word.empty(),
+  );
 
-  private radioAlt = new Arinc429Word(0);
+  private readonly lagFilter = new LagFilter(2);
 
-  private readonly vsFlagVisible = Subject.create(false);
+  private readonly filteredVerticalSpeed = this.verticalSpeed.map((vs) =>
+    this.lagFilter.step(vs.value, this.props.instrument.deltaTime / 1000),
+  );
 
-  private vsNormal = FSComponent.createRef<SVGGElement>();
+  private readonly ra = ConsumerSubject.create(this.sub.on('chosenRa'), Arinc429Word.empty());
 
-  private lagFilter = new LagFilter(2);
+  private verticalResolutionAdvisoryWord = Arinc429LocalVarConsumerSubject.create(
+    this.sub.on('a32nx_tcas_vertical_resolution_advisory_word'),
+  );
 
-  private needsUpdate = false;
+  private readonly vsFlagVisible = this.verticalSpeed.map((vs) => !vs.isNormalOperation());
 
-  private vspeedTcas = FSComponent.createRef<VSpeedTcas>();
+  private readonly needleYOffset = this.filteredVerticalSpeed.map((filteredVS) => {
+    return yPosFromVs(filteredVS);
+  });
 
-  private filteredRadioAltitude = 0;
+  private readonly tcasVerticalResolutionWordValid = this.verticalResolutionAdvisoryWord.map(
+    (word) => !word.isFailureWarning(),
+  );
 
-  private tcasState: TcasState = {
-    tcasState: 0,
-    isTcasCorrective: false,
-    tcasRedZoneL: 0,
-    tcasRedZoneH: 0,
-    tcasGreenZoneL: 0,
-    tcasGreenZoneH: 0,
-  };
+  private readonly downResolutionAdvisory = this.verticalResolutionAdvisoryWord.map((word) =>
+    bitsToInteger(word, 27, 29),
+  );
 
-  onAfterRender(node: VNode): void {
-    super.onAfterRender(node);
+  private readonly downResolutionAdvisoryActive = MappedSubject.create(
+    ([downResolutionAdvisory, tcasVerticalResolutionWordValid]) =>
+      tcasVerticalResolutionWordValid && downResolutionAdvisory > 0 && downResolutionAdvisory < 6,
+    this.downResolutionAdvisory,
+    this.tcasVerticalResolutionWordValid,
+  );
 
-    const sub = this.props.bus.getArincSubscriber<PFDSimvars & Arinc429Values & ClockEvents>();
+  private readonly upResolutionAdvisory = this.verticalResolutionAdvisoryWord.map((word) =>
+    bitsToInteger(word, 24, 26),
+  );
 
-    sub
-      .on('tcasState')
-      .whenChanged()
-      .handle((s) => {
-        this.tcasState.tcasState = s;
-        this.needsUpdate = true;
-      });
+  private readonly upResolutionAdvisoryActive = MappedSubject.create(
+    ([upResolutionAdvisory, tcasVerticalResolutionWordValid]) =>
+      tcasVerticalResolutionWordValid && upResolutionAdvisory > 0 && upResolutionAdvisory < 6,
+    this.upResolutionAdvisory,
+    this.tcasVerticalResolutionWordValid,
+  );
 
-    sub
-      .on('tcasCorrective')
-      .whenChanged()
-      .handle((s) => {
-        this.tcasState.isTcasCorrective = s;
-        this.needsUpdate = true;
-      });
-    sub
-      .on('tcasRedZoneL')
-      .whenChanged()
-      .handle((s) => {
-        this.tcasState.tcasRedZoneL = s;
-        this.needsUpdate = true;
-      });
-    sub
-      .on('tcasRedZoneH')
-      .whenChanged()
-      .handle((s) => {
-        this.tcasState.tcasRedZoneH = s;
-        this.needsUpdate = true;
-      });
-    sub
-      .on('tcasGreenZoneL')
-      .whenChanged()
-      .handle((s) => {
-        this.tcasState.tcasGreenZoneL = s;
-        this.needsUpdate = true;
-      });
-    sub
-      .on('tcasGreenZoneH')
-      .whenChanged()
-      .handle((s) => {
-        this.tcasState.tcasGreenZoneH = s;
-        this.needsUpdate = true;
-      });
+  private readonly rateToMaintain = this.verticalResolutionAdvisoryWord.map((word) => {
+    const sign = word.bitValue(17) ? -1 : 1;
+    return sign * Math.min(bitsToInteger(word, 11, 16), 6000) * 100;
+  });
 
-    sub.on('simTime').handle((_r) => {
-      if (this.needsUpdate) {
-        if (this.tcasState.tcasState === 2) {
-          this.needleColour.set('White');
-        }
-        this.vspeedTcas.instance.update(this.tcasState);
+  private readonly upperVsLimit = MappedSubject.create(
+    ([downResolutionAdvisory, rateToMaintain]) =>
+      resolutionAdvisoryNumberToVs(downResolutionAdvisory, rateToMaintain, 1),
+    this.downResolutionAdvisory,
+    this.rateToMaintain,
+  );
+
+  private readonly lowerVsLimit = MappedSubject.create(
+    ([upResolutionAdvisory, rateToMaintain]) => resolutionAdvisoryNumberToVs(upResolutionAdvisory, rateToMaintain, -1),
+    this.upResolutionAdvisory,
+    this.rateToMaintain,
+  );
+
+  private readonly combinedControl = this.verticalResolutionAdvisoryWord.map((word) => bitsToInteger(word, 18, 20));
+
+  private readonly excessiveVs = MappedSubject.create(
+    ([raWord, filteredRa, filteredVs]) => {
+      const absVSpeed = Math.abs(filteredVs);
+      const raValid = !(raWord.isNoComputedData() || raWord.isFailureWarning());
+
+      return (
+        absVSpeed >= 6000 ||
+        (filteredVs <= -2000 && raValid && filteredRa <= 2500 && filteredRa >= 1000) ||
+        (filteredVs <= -1200 && raValid && filteredRa <= 1000)
+      );
+    },
+    this.ra,
+    this.props.filteredRadioAltitude,
+    this.filteredVerticalSpeed,
+  );
+
+  private readonly needleColour = MappedSubject.create(
+    ([excessiveVs, downRaActive, upRaActive]) => {
+      const resolutionAdvisoryActive = downRaActive || upRaActive;
+
+      if (resolutionAdvisoryActive) {
+        return 'White';
+      } else if (excessiveVs) {
+        return 'Amber';
+      } else {
+        return 'Green';
       }
-    });
+    },
+    this.excessiveVs,
+    this.downResolutionAdvisoryActive,
+    this.upResolutionAdvisoryActive,
+  );
 
-    sub
-      .on('vs')
-      .withArinc429Precision(3)
-      .handle((vs) => {
-        const filteredVS = this.lagFilter.step(vs.value, this.props.instrument.deltaTime / 1000);
+  private readonly textColour = MappedSubject.create(
+    ([upRaActive, downRaActive, upperVsLimit, lowerVsLimit, filteredVs, excessiveVs]) => {
+      const tcasRaInRedSector =
+        (upRaActive && lowerVsLimit > filteredVs) || (downRaActive && upperVsLimit < filteredVs);
 
-        const absVSpeed = Math.abs(filteredVS);
-
-        if (!vs.isNormalOperation()) {
-          this.vsFlagVisible.set(true);
-          this.vsNormal.instance.style.visibility = 'hidden';
-        } else {
-          this.vsFlagVisible.set(false);
-          this.vsNormal.instance.style.visibility = 'visible';
-        }
-
-        const radioAltitudeValid = !this.radioAlt.isNoComputedData() && !this.radioAlt.isFailureWarning();
-        if (this.tcasState.tcasState !== 2) {
-          if (
-            absVSpeed >= 6000 ||
-            (vs.value <= -2000 &&
-              radioAltitudeValid &&
-              this.filteredRadioAltitude <= 2500 &&
-              this.filteredRadioAltitude >= 1000) ||
-            (vs.value <= -1200 && radioAltitudeValid && this.filteredRadioAltitude <= 1000)
-          ) {
-            this.needleColour.set('Amber');
-          } else {
-            this.needleColour.set('Green');
-          }
-        }
-
-        const sign = Math.sign(filteredVS);
-
-        if (absVSpeed < 1000) {
-          this.yOffsetSub.set((filteredVS / 1000) * -27.22);
-        } else if (absVSpeed < 2000) {
-          this.yOffsetSub.set(((filteredVS - sign * 1000) / 1000) * -10.1 - sign * 27.22);
-        } else if (absVSpeed < 6000) {
-          this.yOffsetSub.set(((filteredVS - sign * 2000) / 4000) * -10.1 - sign * 37.32);
-        } else {
-          this.yOffsetSub.set(sign * -47.37);
-        }
-      });
-
-    sub.on('chosenRa').handle((ra) => {
-      this.radioAlt = ra;
-    });
-
-    this.props.filteredRadioAltitude.sub((filteredRadioAltitude) => {
-      this.filteredRadioAltitude = filteredRadioAltitude;
-    });
-  }
+      if (tcasRaInRedSector) {
+        return 'Red';
+      } else if (excessiveVs) {
+        return 'Amber';
+      } else {
+        return 'Green';
+      }
+    },
+    this.upResolutionAdvisoryActive,
+    this.downResolutionAdvisoryActive,
+    this.upperVsLimit,
+    this.lowerVsLimit,
+    this.filteredVerticalSpeed,
+    this.excessiveVs,
+  );
 
   render(): VNode {
     return (
@@ -190,9 +205,19 @@ export class VerticalSpeedIndicator extends DisplayComponent<VerticalSpeedIndica
           </text>
         </FlashOneHertz>
 
-        <VSpeedTcas ref={this.vspeedTcas} bus={this.props.bus} />
+        <VSpeedTcas
+          bus={this.props.bus}
+          upRaActive={this.upResolutionAdvisoryActive}
+          downRaActive={this.downResolutionAdvisoryActive}
+          combinedControl={this.combinedControl}
+          vsUpperLimit={this.upperVsLimit}
+          vsLowerLimit={this.lowerVsLimit}
+        />
 
-        <g id="VerticalSpeedGroup" ref={this.vsNormal}>
+        <g
+          id="VerticalSpeedGroup"
+          visibility={this.vsFlagVisible.map((flagVisible) => (flagVisible ? 'hidden' : 'visible'))}
+        >
           <g class="Fill White">
             <path d="m149.92 54.339v-1.4615h1.9151v1.4615z" />
             <path d="m149.92 44.26v-1.4615h1.9151v1.4615z" />
@@ -230,12 +255,13 @@ export class VerticalSpeedIndicator extends DisplayComponent<VerticalSpeedIndica
             </text>
           </g>
           <path class="Fill Yellow" d="m145.79 80.067h6.0476v1.5119h-6.0476z" />
-          <VSpeedNeedle yOffset={this.yOffsetSub} needleColour={this.needleColour} />
+          <VSpeedNeedle yOffset={this.needleYOffset} needleColour={this.needleColour} />
 
           <VSpeedText
             bus={this.props.bus}
-            yOffset={this.yOffsetSub}
-            textColour={this.needleColour.map((c) => (c === 'White' ? 'Green' : c))}
+            yOffset={this.needleYOffset}
+            textColour={this.textColour}
+            filteredVs={this.filteredVerticalSpeed}
           />
         </g>
       </g>
@@ -281,6 +307,7 @@ class VSpeedText extends DisplayComponent<{
   bus: ArincEventBus;
   yOffset: Subscribable<number>;
   textColour: Subscribable<string>;
+  filteredVs: Subscribable<number>;
 }> {
   private vsTextRef = FSComponent.createRef<SVGTextElement>();
 
@@ -291,28 +318,23 @@ class VSpeedText extends DisplayComponent<{
   onAfterRender(node: VNode): void {
     super.onAfterRender(node);
 
-    const sub = this.props.bus.getArincSubscriber<Arinc429Values>();
+    this.props.filteredVs.sub((vs) => {
+      const absVSpeed = Math.abs(vs);
 
-    sub
-      .on('vs')
-      .withArinc429Precision(2)
-      .handle((vs) => {
-        const absVSpeed = Math.abs(vs.value);
+      if (absVSpeed < 200) {
+        this.visibilitySub.set('hidden');
+      } else {
+        this.visibilitySub.set('visible');
+      }
 
-        if (absVSpeed < 200) {
-          this.visibilitySub.set('hidden');
-        } else {
-          this.visibilitySub.set('visible');
-        }
+      const sign = Math.sign(vs);
 
-        const sign = Math.sign(vs.value);
+      const textOffset = this.props.yOffset.get() - sign * 2.4;
 
-        const textOffset = this.props.yOffset.get() - sign * 2.4;
-
-        const text = (Math.round(absVSpeed / 100) < 10 ? '0' : '') + Math.round(absVSpeed / 100).toString();
-        this.vsTextRef.instance.textContent = text;
-        this.groupRef.instance.style.transform = `translate3d(0px, ${textOffset}px, 0px)`;
-      });
+      const text = (Math.round(absVSpeed / 100) < 10 ? '0' : '') + Math.round(absVSpeed / 100).toString();
+      this.vsTextRef.instance.textContent = text;
+      this.groupRef.instance.style.transform = `translate3d(0px, ${textOffset}px, 0px)`;
+    });
 
     this.props.textColour.sub((colour) => {
       const className = `FontSmallest MiddleAlign ${colour}`;
@@ -330,200 +352,173 @@ class VSpeedText extends DisplayComponent<{
   }
 }
 
+function getRedSectorPath(vs: number, isUpperSector: boolean) {
+  const dxFull = 10.9;
+  const dxBorder = 6.77;
+  const centerX = 162.74;
+  const centerY = 80.822;
+
+  const yOffset = yPosFromVs(vs);
+
+  const y1 = isUpperSector ? 29.92 : 131.72;
+  const y2 = centerY + yOffset;
+
+  const y3 = centerY + (dxBorder / dxFull) * yOffset;
+  const y4 = y1;
+
+  const x1 = centerX - dxFull;
+  const x2 = centerX - dxBorder;
+
+  return `m${x1},${y1} L${x1},${y2} L${x2},${y3} L${x2},${y4} z`;
+}
+
 interface VSpeedTcasProps extends ComponentProps {
   bus: ArincEventBus;
+  upRaActive: Subscribable<boolean>;
+  downRaActive: Subscribable<boolean>;
+  combinedControl: Subscribable<number>;
+  vsUpperLimit: Subscribable<number>;
+  vsLowerLimit: Subscribable<number>;
 }
 class VSpeedTcas extends DisplayComponent<VSpeedTcasProps> {
-  private tcasGroup = FSComponent.createRef<SVGGElement>();
+  private readonly upAndDownResolutionAdvisoryActive = MappedSubject.create(
+    ([upResolutionAdvisoryActive, downResolutionAdvisoryActive]) =>
+      upResolutionAdvisoryActive && downResolutionAdvisoryActive,
+    this.props.upRaActive,
+    this.props.downRaActive,
+  );
 
-  private nonCorrective = FSComponent.createRef<SVGGElement>();
+  private readonly downCorrectiveResolutionAdvisoryActive = MappedSubject.create(
+    ([combinedControl, upAndDownResolutionAdvisoryActive]) =>
+      combinedControl == 5 && !upAndDownResolutionAdvisoryActive,
+    this.props.combinedControl,
+    this.upAndDownResolutionAdvisoryActive,
+  );
 
-  private background = FSComponent.createRef<SVGRectElement>();
+  private readonly upCorrectiveResolutionAdvisoryActive = MappedSubject.create(
+    ([combinedControl, upAndDownResolutionAdvisoryActive]) =>
+      combinedControl == 4 && !upAndDownResolutionAdvisoryActive,
+    this.props.combinedControl,
+    this.upAndDownResolutionAdvisoryActive,
+  );
 
-  private redZoneElement = FSComponent.createRef<VSpeedTcasZone>();
+  private readonly upAndDownCorrectiveResolutionAdvisoryActive = MappedSubject.create(
+    ([combinedControl, upAndDownResolutionAdvisoryActive]) =>
+      (combinedControl == 4 || combinedControl == 5) && upAndDownResolutionAdvisoryActive,
+    this.props.combinedControl,
+    this.upAndDownResolutionAdvisoryActive,
+  );
 
-  private greenZoneElement = FSComponent.createRef<VSpeedTcasZone>();
+  private readonly downResolutionAdvsioryZoneVisible = MappedSubject.create(
+    ([downRaActive, upDownCorrectiveRaActive]) => downRaActive || upDownCorrectiveRaActive,
+    this.props.downRaActive,
+    this.upAndDownCorrectiveResolutionAdvisoryActive,
+  );
 
-  private redZone = Subject.create(-1);
+  private readonly upResolutionAdvsioryZoneVisible = MappedSubject.create(
+    ([upRaActive, upDownCorrectiveRaActive]) => upRaActive || upDownCorrectiveRaActive,
+    this.props.upRaActive,
+    this.upAndDownCorrectiveResolutionAdvisoryActive,
+  );
 
-  private redZoneHigh = Subject.create(-1);
+  private readonly flyToZoneVisible = MappedSubject.create(
+    ([upRaActive, upCorrectiveRaActive, downRaActive, downCorrectiveRaActive, upDownCorrectiveRaActive]) =>
+      (upRaActive && upCorrectiveRaActive) || (downRaActive && downCorrectiveRaActive) || upDownCorrectiveRaActive,
+    this.props.upRaActive,
+    this.upCorrectiveResolutionAdvisoryActive,
+    this.props.downRaActive,
+    this.downCorrectiveResolutionAdvisoryActive,
+    this.upAndDownCorrectiveResolutionAdvisoryActive,
+  );
 
-  private greenZone = Subject.create(-1);
+  private readonly tcasIndicationsVisible = MappedSubject.create(
+    ([upRaActive, downRaActive]) => upRaActive || downRaActive,
+    this.props.upRaActive,
+    this.props.downRaActive,
+  );
 
-  private greenZoneHigh = Subject.create(-1);
+  private readonly downResolutionAdvisoryZonePath = this.props.vsUpperLimit.map((vs) => getRedSectorPath(vs, true));
 
-  private extended = Subject.create(false);
+  private readonly upResolutionAdvisoryZonePath = this.props.vsLowerLimit.map((vs) => getRedSectorPath(vs, false));
 
-  private isCorrective = Subject.create(false);
+  private readonly flyToZonePath = MappedSubject.create(
+    ([
+      vsUpperLimit,
+      vsLowerLimit,
+      upRaActive,
+      upCorrectiveResolutionAdvisoryActive,
+      downRaActive,
+      downCorrectiveResolutionAdvisoryActive,
+    ]) => {
+      const dxFull = 10.9;
+      const dxBorder = 6.77;
+      const centerX = 162.74;
+      const centerY = 80.822;
 
-  public update(state: TcasState) {
-    if (state.tcasState !== 2) {
-      this.tcasGroup.instance.classList.add('HiddenElement');
-      this.nonCorrective.instance.classList.add('HiddenElement');
-    } else if (state.isTcasCorrective) {
-      this.tcasGroup.instance.classList.remove('HiddenElement');
-      this.background.instance.classList.remove('HiddenElement');
-      this.redZone.set(state.tcasRedZoneL);
-      this.redZoneHigh.set(state.tcasRedZoneH);
-      this.greenZone.set(state.tcasGreenZoneL);
-      this.greenZoneHigh.set(state.tcasGreenZoneH);
-      this.nonCorrective.instance.classList.add('HiddenElement');
-    } else {
-      this.background.instance.classList.add('HiddenElement');
-      this.nonCorrective.instance.classList.add('HiddenElement');
+      const yOffsetForCorrective = 18;
 
-      this.isCorrective.set(false);
-      this.extended.set(false);
-      this.redZone.set(state.tcasRedZoneL);
-      this.redZoneHigh.set(state.tcasRedZoneH);
-    }
-  }
+      const upCorrectiveActive = upRaActive && upCorrectiveResolutionAdvisoryActive;
+      const downCorrectiveActive = downRaActive && downCorrectiveResolutionAdvisoryActive;
+
+      const upperSectorYOffset = yPosFromVs(vsUpperLimit);
+      const lowerSectorYOffset = yPosFromVs(vsLowerLimit);
+
+      let y1: number, y2: number, y3: number, y4: number;
+
+      if (upCorrectiveActive) {
+        y1 = centerY + lowerSectorYOffset * (dxBorder / dxFull) - yOffsetForCorrective;
+        y4 = y1;
+      } else {
+        y1 = centerY + upperSectorYOffset;
+        y4 = centerY + (dxBorder / dxFull) * upperSectorYOffset;
+      }
+
+      if (downCorrectiveActive) {
+        y2 = centerY + upperSectorYOffset * (dxBorder / dxFull) + yOffsetForCorrective;
+        y3 = y2;
+      } else {
+        y2 = centerY + lowerSectorYOffset;
+        y3 = centerY + (dxBorder / dxFull) * lowerSectorYOffset;
+      }
+
+      const x1 = centerX - dxFull;
+      const x2 = centerX - dxBorder;
+
+      return `m${x1},${y1} L${x1},${y2} L${x2},${y3} L${x2},${y4} z`;
+    },
+    this.props.vsUpperLimit,
+    this.props.vsLowerLimit,
+    this.props.upRaActive,
+    this.upCorrectiveResolutionAdvisoryActive,
+    this.props.downRaActive,
+    this.downCorrectiveResolutionAdvisoryActive,
+  );
 
   render(): VNode {
     return (
       <>
-        <g id="VerticalSpeedTCASGroup" ref={this.tcasGroup}>
-          <rect ref={this.background} class="TapeBackground" height="101.8" width="5.5404" y="29.92" x="151.84" />
-          <VSpeedTcasZone
-            ref={this.redZoneElement}
-            zoneBoundLow={this.redZone}
-            zoneBoundHigh={this.redZoneHigh}
-            zoneClass="Fill Red"
-            isCorrective={this.isCorrective}
-            extended={Subject.create(false)}
+        <g
+          id="VerticalSpeedTCASGroup"
+          visibility={this.tcasIndicationsVisible.map((visible) => (visible ? 'visible' : 'hidden'))}
+        >
+          <rect class="TapeBackground" height="101.8" width="4.1301" y="29.92" x="151.84" />
+          <path
+            d={this.downResolutionAdvisoryZonePath}
+            visibility={this.downResolutionAdvsioryZoneVisible.map((visible) => (visible ? 'visible' : 'hidden'))}
+            class="Fill Red"
           />
-          <VSpeedTcasZone
-            ref={this.greenZoneElement}
-            zoneBoundLow={this.greenZone}
-            zoneBoundHigh={this.greenZoneHigh}
-            zoneClass="Fill Green"
-            extended={this.extended}
-            isCorrective={this.isCorrective}
+          <path
+            d={this.upResolutionAdvisoryZonePath}
+            visibility={this.upResolutionAdvsioryZoneVisible.map((visible) => (visible ? 'visible' : 'hidden'))}
+            class="Fill Red"
           />
-        </g>
-        <g id="VerticalSpeedTCASGroupNonCorrective" ref={this.nonCorrective}>
-          <VSpeedTcasZone
-            zoneBoundLow={this.redZone}
-            zoneBoundHigh={this.redZoneHigh}
-            zoneClass="Fill Red"
-            extended={Subject.create(false)}
-            isCorrective={Subject.create(false)}
+          <path
+            d={this.flyToZonePath}
+            visibility={this.flyToZoneVisible.map((visible) => (visible ? 'visible' : 'hidden'))}
+            class="Fill Green"
           />
         </g>
       </>
     );
-  }
-}
-
-interface VSpeedTcasZoneProps extends ComponentProps {
-  zoneBoundLow: Subscribable<number>;
-  zoneBoundHigh: Subscribable<number>;
-  zoneClass: string;
-  isCorrective: Subscribable<boolean>;
-  extended: Subscribable<boolean>;
-}
-class VSpeedTcasZone extends DisplayComponent<VSpeedTcasZoneProps> {
-  private zoneUpper = 0;
-
-  private zoneLower = 0;
-
-  private extended = false;
-
-  private isCorrective = false;
-
-  private path = FSComponent.createRef<SVGPathElement>();
-
-  private getYoffset = (VSpeed: number) => {
-    const absVSpeed = Math.abs(VSpeed);
-    const sign = Math.sign(VSpeed);
-
-    if (absVSpeed < 1000) {
-      return (VSpeed / 1000) * -27.22;
-    }
-    if (absVSpeed < 2000) {
-      return ((VSpeed - sign * 1000) / 1000) * -10.1 - sign * 27.22;
-    }
-    if (absVSpeed < 6000) {
-      return ((VSpeed - sign * 2000) / 4000) * -10.1 - sign * 37.32;
-    }
-    return sign * -47.37;
-  };
-
-  private drawTcasZone() {
-    if (this.zoneLower !== -1 && this.zoneUpper !== -1) {
-      let y1;
-      let y2;
-      let y3;
-      let y4;
-
-      if (this.zoneLower >= 6000) {
-        y1 = 29.92;
-      } else if (this.zoneLower <= -6000) {
-        y1 = 131.72;
-      } else {
-        y1 = 80.822 + this.getYoffset(this.zoneLower);
-      }
-
-      if (this.zoneUpper >= 6000) {
-        y2 = 29.92;
-      } else if (this.zoneUpper <= -6000) {
-        y2 = 131.72;
-      } else {
-        y2 = 80.822 + this.getYoffset(this.zoneUpper);
-      }
-
-      if (
-        (Math.abs(this.zoneUpper) > 1750 && Math.abs(this.zoneUpper) > Math.abs(this.zoneLower)) ||
-        (this.isCorrective && this.props.zoneClass === 'Fill Red')
-      ) {
-        y3 = y2;
-      } else {
-        // y3 = 80.822 + getYoffset(zoneBounds[1] / 2);
-        y3 = 80.822;
-      }
-
-      if (
-        (Math.abs(this.zoneLower) > 1750 && Math.abs(this.zoneLower) > Math.abs(this.zoneUpper)) ||
-        (this.isCorrective && this.props.zoneClass === 'Fill Red')
-      ) {
-        y4 = y1;
-      } else {
-        // y4 = 80.822 + getYoffset(zoneBounds[0] / 2);
-        y4 = 80.822;
-      }
-
-      const x1 = 151.84;
-      const x2 = this.extended ? 162.74 : 157.3804;
-
-      this.path.instance.setAttribute('d', `m${x1},${y1} L${x1},${y2} L${x2},${y3} L${x2},${y4} L${x1},${y1}z`);
-    }
-  }
-
-  onAfterRender(node: VNode): void {
-    super.onAfterRender(node);
-
-    this.props.zoneBoundLow.sub((z) => {
-      this.zoneLower = z;
-      this.drawTcasZone();
-    });
-
-    this.props.zoneBoundHigh.sub((z) => {
-      this.zoneUpper = z;
-      this.drawTcasZone();
-    });
-
-    this.props.extended.sub((z) => {
-      this.extended = z;
-      this.drawTcasZone();
-    });
-
-    this.props.isCorrective.sub((z) => {
-      this.isCorrective = z;
-      this.drawTcasZone();
-    });
-  }
-
-  render(): VNode {
-    return <path ref={this.path} class={this.props.zoneClass} />;
   }
 }

--- a/fbw-a32nx/src/systems/instruments/src/PFD/VerticalSpeedIndicator.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/VerticalSpeedIndicator.tsx
@@ -234,15 +234,6 @@ export class VerticalSpeedIndicator extends DisplayComponent<VerticalSpeedIndica
           </text>
         </FlashOneHertz>
 
-        <VSpeedTcas
-          bus={this.props.bus}
-          upRaActive={this.upResolutionAdvisoryActive}
-          downRaActive={this.downResolutionAdvisoryActive}
-          combinedControl={this.combinedControl}
-          vsUpperLimit={this.upperVsLimit}
-          vsLowerLimit={this.lowerVsLimit}
-        />
-
         <FlashOneHertz bus={this.props.bus} flashDuration={9} visible={this.tcasInvalid}>
           <text class="FontMedium Amber EndAlign" x="141.5" y="100">
             T
@@ -262,6 +253,14 @@ export class VerticalSpeedIndicator extends DisplayComponent<VerticalSpeedIndica
           id="VerticalSpeedGroup"
           visibility={this.vsFlagVisible.map((flagVisible) => (flagVisible ? 'hidden' : 'visible'))}
         >
+          <VSpeedTcas
+            bus={this.props.bus}
+            upRaActive={this.upResolutionAdvisoryActive}
+            downRaActive={this.downResolutionAdvisoryActive}
+            combinedControl={this.combinedControl}
+            vsUpperLimit={this.upperVsLimit}
+            vsLowerLimit={this.lowerVsLimit}
+          />
           <g class="Fill White">
             <path d="m149.92 54.339v-1.4615h1.9151v1.4615z" />
             <path d="m149.92 44.26v-1.4615h1.9151v1.4615z" />
@@ -330,7 +329,7 @@ class VSpeedNeedle extends DisplayComponent<{ yOffset: Subscribable<number>; nee
       const path = `m${centerX - dxBorder} ${centerY + (dxBorder / dxFull) * yOffset} l ${dxBorder - dxFull} ${(1 - dxBorder / dxFull) * yOffset}`;
 
       this.pathSub.set(path);
-    });
+    }, true);
 
     this.props.needleColour.sub((colour) => {
       this.indicatorRef.instance.setAttribute('class', `HugeStroke ${colour}`);
@@ -378,7 +377,7 @@ class VSpeedText extends DisplayComponent<{
       const text = (Math.round(absVSpeed / 100) < 10 ? '0' : '') + Math.round(absVSpeed / 100).toString();
       this.vsTextRef.instance.textContent = text;
       this.groupRef.instance.style.transform = `translate3d(0px, ${textOffset}px, 0px)`;
-    });
+    }, true);
 
     this.props.textColour.sub((colour) => {
       const className = `FontSmallest MiddleAlign ${colour}`;

--- a/fbw-a32nx/src/systems/instruments/src/PFD/VerticalSpeedIndicator.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/VerticalSpeedIndicator.tsx
@@ -88,7 +88,7 @@ export class VerticalSpeedIndicator extends DisplayComponent<VerticalSpeedIndica
     this.sub.on('a32nx_tcas_fault_summary_word'),
   );
 
-  private readonly vsFlagVisible = this.verticalSpeed.map((vs) => !vs.isNormalOperation());
+  private readonly vsFlagVisible = this.verticalSpeed.map((vs) => vs.isFailureWarning());
 
   private readonly tcasInvalid = MappedSubject.create(
     ([verticalResolutionAdvisoryWord, tcasModeWord, tcasFaultSummaryWord]) => {

--- a/fbw-a32nx/src/systems/instruments/src/PFD/VerticalSpeedIndicator.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/VerticalSpeedIndicator.tsx
@@ -82,7 +82,28 @@ export class VerticalSpeedIndicator extends DisplayComponent<VerticalSpeedIndica
     this.sub.on('a32nx_tcas_vertical_resolution_advisory_word'),
   );
 
+  private tcasModeWord = Arinc429LocalVarConsumerSubject.create(this.sub.on('a32nx_tcas_mode_word'));
+
+  private tcasFaultSummaryWord = Arinc429LocalVarConsumerSubject.create(this.sub.on('a32nx_tcas_fault_summary_word'));
+
   private readonly vsFlagVisible = this.verticalSpeed.map((vs) => !vs.isNormalOperation());
+
+  private readonly tcasInvalid = MappedSubject.create(
+    ([verticalResolutionAdvisoryWord, tcasModeWord, tcasFaultSummaryWord]) => {
+      const tcasFailure =
+        verticalResolutionAdvisoryWord.isFailureWarning() ||
+        tcasFaultSummaryWord.isFailureWarning() ||
+        tcasFaultSummaryWord.bitValue(20);
+      const tcasStandby =
+        tcasModeWord.bitValue(25) &&
+        !(tcasModeWord.bitValue(23) || tcasModeWord.bitValue(24) || tcasModeWord.isFailureWarning());
+
+      return tcasFailure && !tcasStandby;
+    },
+    this.verticalResolutionAdvisoryWord,
+    this.tcasModeWord,
+    this.tcasFaultSummaryWord,
+  );
 
   private readonly needleYOffset = this.filteredVerticalSpeed.map((filteredVS) => {
     return yPosFromVs(filteredVS);
@@ -213,6 +234,21 @@ export class VerticalSpeedIndicator extends DisplayComponent<VerticalSpeedIndica
           vsUpperLimit={this.upperVsLimit}
           vsLowerLimit={this.lowerVsLimit}
         />
+
+        <FlashOneHertz bus={this.props.bus} flashDuration={9} visible={this.tcasInvalid}>
+          <text class="FontMedium Amber EndAlign" x="141.5" y="100">
+            T
+          </text>
+          <text class="FontMedium Amber EndAlign" x="141.5" y="105">
+            C
+          </text>
+          <text class="FontMedium Amber EndAlign" x="141.5" y="110">
+            A
+          </text>
+          <text class="FontMedium Amber EndAlign" x="141.5" y="115">
+            S
+          </text>
+        </FlashOneHertz>
 
         <g
           id="VerticalSpeedGroup"

--- a/fbw-a32nx/src/systems/instruments/src/PFD/VerticalSpeedIndicator.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/VerticalSpeedIndicator.tsx
@@ -368,7 +368,7 @@ class VSpeedText extends DisplayComponent<{
       if (absVSpeed < 200) {
         this.visibilitySub.set('hidden');
       } else {
-        this.visibilitySub.set('visible');
+        this.visibilitySub.set('inherit');
       }
 
       const sign = Math.sign(vs);
@@ -543,22 +543,22 @@ class VSpeedTcas extends DisplayComponent<VSpeedTcasProps> {
       <>
         <g
           id="VerticalSpeedTCASGroup"
-          visibility={this.tcasIndicationsVisible.map((visible) => (visible ? 'visible' : 'hidden'))}
+          visibility={this.tcasIndicationsVisible.map((visible) => (visible ? 'inherit' : 'hidden'))}
         >
           <rect class="TapeBackground" height="101.8" width="4.1301" y="29.92" x="151.84" />
           <path
             d={this.downResolutionAdvisoryZonePath}
-            visibility={this.downResolutionAdvsioryZoneVisible.map((visible) => (visible ? 'visible' : 'hidden'))}
+            visibility={this.downResolutionAdvsioryZoneVisible.map((visible) => (visible ? 'inherit' : 'hidden'))}
             class="Fill Red"
           />
           <path
             d={this.upResolutionAdvisoryZonePath}
-            visibility={this.upResolutionAdvsioryZoneVisible.map((visible) => (visible ? 'visible' : 'hidden'))}
+            visibility={this.upResolutionAdvsioryZoneVisible.map((visible) => (visible ? 'inherit' : 'hidden'))}
             class="Fill Red"
           />
           <path
             d={this.flyToZonePath}
-            visibility={this.flyToZoneVisible.map((visible) => (visible ? 'visible' : 'hidden'))}
+            visibility={this.flyToZoneVisible.map((visible) => (visible ? 'inherit' : 'hidden'))}
             class="Fill Green"
           />
         </g>

--- a/fbw-a32nx/src/systems/instruments/src/PFD/VerticalSpeedIndicator.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/VerticalSpeedIndicator.tsx
@@ -3,11 +3,13 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import {
+  ClockEvents,
   ComponentProps,
   ConsumerSubject,
   DisplayComponent,
   FSComponent,
   MappedSubject,
+  MathUtils,
   Subject,
   Subscribable,
   VNode,
@@ -63,18 +65,13 @@ interface VerticalSpeedIndicatorProps {
 }
 
 export class VerticalSpeedIndicator extends DisplayComponent<VerticalSpeedIndicatorProps> {
-  private readonly sub = this.props.bus.getArincSubscriber<A32NXTcasBusEvents & Arinc429Values>();
+  private readonly sub = this.props.bus.getArincSubscriber<A32NXTcasBusEvents & Arinc429Values & ClockEvents>();
 
-  private readonly verticalSpeed = ConsumerSubject.create(
-    this.sub.on('vs').withArinc429Precision(3),
-    Arinc429Word.empty(),
-  );
+  private readonly verticalSpeed = ConsumerSubject.create(this.sub.on('vs'), Arinc429Word.empty());
 
   private readonly lagFilter = new LagFilter(2);
 
-  private readonly filteredVerticalSpeed = this.verticalSpeed.map((vs) =>
-    this.lagFilter.step(vs.value, this.props.instrument.deltaTime / 1000),
-  );
+  private readonly filteredVerticalSpeed = Subject.create(0);
 
   private readonly ra = ConsumerSubject.create(this.sub.on('chosenRa'), Arinc429Word.empty());
 
@@ -210,6 +207,15 @@ export class VerticalSpeedIndicator extends DisplayComponent<VerticalSpeedIndica
     this.filteredVerticalSpeed,
     this.excessiveVs,
   );
+
+  onAfterRender(node: VNode): void {
+    super.onAfterRender(node);
+
+    this.sub.on('simTime').handle(() => {
+      const filtered = this.lagFilter.step(this.verticalSpeed.get().value, this.props.instrument.deltaTime / 1000);
+      this.filteredVerticalSpeed.set(MathUtils.round(filtered, 0.1));
+    });
+  }
 
   render(): VNode {
     return (

--- a/fbw-a32nx/src/systems/instruments/src/PFD/instrument.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/instrument.tsx
@@ -19,6 +19,7 @@ import { PFDSimvarPublisher, PFDSimvars } from './shared/PFDSimvarPublisher';
 import { A32NXFcuBusPublisher } from '@shared/publishers/A32NXFcuBusPublisher';
 import { A32NXElectricalSystemPublisher } from '@shared/publishers/A32NXElectricalSystemPublisher';
 import { A32NXFwcBusPublisher } from '@shared/publishers/A32NXFwcBusPublisher';
+import { A32NXTcasBusPublisher } from '@shared/publishers/A32NXTcasBusPublisher';
 import { PseudoDmc } from './PseudoDmc';
 
 import './style.scss';
@@ -58,6 +59,7 @@ class A32NX_PFD extends BaseInstrument {
   private readonly fwcBusPublisher = new A32NXFwcBusPublisher(this.bus);
   private readonly elecSystemPublisher = new A32NXElectricalSystemPublisher(this.bus);
   private readonly irBusPublisher = new IrBusPublisher(this.bus);
+  private readonly tcasBusPublisher = new A32NXTcasBusPublisher(this.bus);
 
   private readonly pseudoDmc = new PseudoDmc(this.bus, this);
 
@@ -87,6 +89,7 @@ class A32NX_PFD extends BaseInstrument {
     this.backplane.addPublisher('ElectricalSystem', this.elecSystemPublisher);
     this.backplane.addPublisher('FwcBus', this.fwcBusPublisher);
     this.backplane.addPublisher('IrBus', this.irBusPublisher);
+    this.backplane.addPublisher('TcasBus', this.tcasBusPublisher);
     this.backplane.addInstrument('PseudoDMC', this.pseudoDmc);
     this.backplane.addInstrument('ExtendedClock', this.extendedClockProvider);
   }

--- a/fbw-a32nx/src/systems/instruments/src/PFD/shared/PFDSimvarPublisher.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/shared/PFDSimvarPublisher.tsx
@@ -52,13 +52,6 @@ export type PFDSimvars = AdirsSimVars &
     tla1: number;
     tla2: number;
     landingElevation: number;
-    tcasState: number;
-    tcasCorrective: boolean;
-    tcasRedZoneL: number;
-    tcasRedZoneH: number;
-    tcasGreenZoneL: number;
-    tcasGreenZoneH: number;
-    tcasFail: boolean;
     engOneRunning: boolean;
     engTwoRunning: boolean;
     setHoldSpeed: boolean;
@@ -227,13 +220,6 @@ export enum PFDVars {
   ilsCourse = 'L:A32NX_FM_LS_COURSE',
   tla1 = 'L:A32NX_AUTOTHRUST_TLA:1',
   tla2 = 'L:A32NX_AUTOTHRUST_TLA:2',
-  tcasState = 'L:A32NX_TCAS_STATE',
-  tcasCorrective = 'L:A32NX_TCAS_RA_CORRECTIVE',
-  tcasRedZoneL = 'L:A32NX_TCAS_VSPEED_RED:1',
-  tcasRedZoneH = 'L:A32NX_TCAS_VSPEED_RED:2',
-  tcasGreenZoneL = 'L:A32NX_TCAS_VSPEED_GREEN:1',
-  tcasGreenZoneH = 'L:A32NX_TCAS_VSPEED_GREEN:2',
-  tcasFail = 'L:A32NX_TCAS_FAULT',
   engOneRunning = 'GENERAL ENG COMBUSTION:1',
   engTwoRunning = 'GENERAL ENG COMBUSTION:2',
   setHoldSpeed = 'L:A32NX_PFD_MSG_SET_HOLD_SPEED',
@@ -407,13 +393,6 @@ export class PFDSimvarPublisher extends UpdatableSimVarPublisher<PFDSimvars> {
     ['ilsCourse', { name: PFDVars.ilsCourse, type: SimVarValueType.Number }],
     ['tla1', { name: PFDVars.tla1, type: SimVarValueType.Number }],
     ['tla2', { name: PFDVars.tla2, type: SimVarValueType.Number }],
-    ['tcasState', { name: PFDVars.tcasState, type: SimVarValueType.Enum }],
-    ['tcasCorrective', { name: PFDVars.tcasCorrective, type: SimVarValueType.Bool }],
-    ['tcasRedZoneL', { name: PFDVars.tcasRedZoneL, type: SimVarValueType.Number }],
-    ['tcasRedZoneH', { name: PFDVars.tcasRedZoneH, type: SimVarValueType.Number }],
-    ['tcasGreenZoneL', { name: PFDVars.tcasGreenZoneL, type: SimVarValueType.Number }],
-    ['tcasGreenZoneH', { name: PFDVars.tcasGreenZoneH, type: SimVarValueType.Number }],
-    ['tcasFail', { name: PFDVars.tcasFail, type: SimVarValueType.Bool }],
     ['engOneRunning', { name: PFDVars.engOneRunning, type: SimVarValueType.Bool }],
     ['engTwoRunning', { name: PFDVars.engTwoRunning, type: SimVarValueType.Bool }],
     ['setHoldSpeed', { name: PFDVars.setHoldSpeed, type: SimVarValueType.Bool }],

--- a/fbw-a32nx/src/systems/shared/src/publishers/A32NXTcasBusPublisher.ts
+++ b/fbw-a32nx/src/systems/shared/src/publishers/A32NXTcasBusPublisher.ts
@@ -1,5 +1,4 @@
-// @ts-strict-ignore
-// Copyright (c) 2025 FlyByWire Simulations
+// Copyright (c) 2026 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
 import {

--- a/fbw-a32nx/src/systems/shared/src/publishers/A32NXTcasBusPublisher.ts
+++ b/fbw-a32nx/src/systems/shared/src/publishers/A32NXTcasBusPublisher.ts
@@ -121,7 +121,7 @@ interface A32NXTcasBusBaseEvents {
   a32nx_tcas_fault_summary_word: number;
 }
 
-type IndexedTopics = null;
+type IndexedTopics = never;
 
 type A32NXTcasBusIndexedEvents = {
   [P in keyof Pick<A32NXTcasBusBaseEvents, IndexedTopics> as IndexedEventType<P>]: A32NXTcasBusBaseEvents[P];

--- a/fbw-a32nx/src/systems/shared/src/publishers/A32NXTcasBusPublisher.ts
+++ b/fbw-a32nx/src/systems/shared/src/publishers/A32NXTcasBusPublisher.ts
@@ -93,7 +93,33 @@ interface A32NXTcasBusBaseEvents {
    * |     | |TA/RA      | 1  1  0  0  |       |
    * |     | |Reserved   | 0  0  1  0  |       |
    */
-  a32nx_tcas_sensitivity_level_word: number;
+  a32nx_tcas_mode_word: number;
+  /**
+   * TCAS Computer fault summary word, label 350.
+   * Raw ARINC word.
+   * | Bit |            Description            |
+   * |:---:|:---------------------------------:|
+   * | 11  | TCAS Computer Unit Fault          |
+   * | 12  | Upper Antenna Fault               |
+   * | 13  | Lower Antenna Fault               |
+   * | 14  | Radio Alt 1 Input Bus Fault       |
+   * | 15  | Radio Alt 2 Input Bus Fault       |
+   * | 16  | ATC/Mode S XPDR 1 Fault/STBY      |
+   * | 17  | ATC/Mode S XPDR 2 Fault/STBY      |
+   * | 18  | ATT Input Bus Inactive            |
+   * | 19  | Mag Hdg Input Bus Inactive        |
+   * | 20  | TCAS System Fault                 |
+   * | 21  | Flight Perf. Input Bus Inactive   |
+   * | 22  | ADSB System Failure               |
+   * | 23  | TA 1 Display Failure              |
+   * | 24  | TA 2 Display Failure              |
+   * | 25  | RA 1 Display Failure              |
+   * | 26  | RA 2 Display Failure              |
+   * | 27  | CFDIU Input Bus Inactive          |
+   * | 28  | BITE Logic                        |
+   * | 29  | BITE Logic                        |
+   */
+  a32nx_tcas_fault_summary_word: number;
 }
 
 type IndexedTopics = null;
@@ -122,9 +148,10 @@ export class A32NXTcasBusPublisher extends SimVarPublisher<A32NXTcasBusPublisher
     const simvars = new Map<keyof A32NXTcasBusPublisherEvents, SimVarPublisherEntry<any>>([
       [
         'a32nx_tcas_vertical_resolution_advisory_word',
-        { name: 'L:A32NX_TCAS_VERTICAL_ADV_TEST', type: SimVarValueType.Enum },
+        { name: 'L:A32NX_TCAS_VERTICAL_RESOLUTION_ADVISORY_WORD', type: SimVarValueType.Enum },
       ],
-      ['a32nx_tcas_sensitivity_level_word', { name: 'L:A32NX_TCAS_VERTICAL_ADV_TEST', type: SimVarValueType.Enum }],
+      ['a32nx_tcas_mode_word', { name: 'L:A32NX_TCAS_MODE_WORD', type: SimVarValueType.Enum }],
+      ['a32nx_tcas_fault_summary_word', { name: 'L:A32NX_TCAS_FAULT_SUMMARY_WORD', type: SimVarValueType.Enum }],
     ]);
 
     super(simvars, bus, pacer);

--- a/fbw-a32nx/src/systems/shared/src/publishers/A32NXTcasBusPublisher.ts
+++ b/fbw-a32nx/src/systems/shared/src/publishers/A32NXTcasBusPublisher.ts
@@ -1,0 +1,132 @@
+// @ts-strict-ignore
+// Copyright (c) 2025 FlyByWire Simulations
+// SPDX-License-Identifier: GPL-3.0
+
+import {
+  EventBus,
+  IndexedEventType,
+  PublishPacer,
+  SimVarPublisher,
+  SimVarPublisherEntry,
+  SimVarValueType,
+} from '@microsoft/msfs-sdk';
+
+interface A32NXTcasBusBaseEvents {
+  /**
+   * TCAS discrete word label 270 containing RA information
+   * Raw ARINC word.
+   * | Bit |            Description            |
+   * |:---:|:---------------------------------:|
+   * | 11  | Rate to Maintain                  |
+   * | -   | Max value 6400 ft/min             |
+   * | 17  | Bit 17 is sign bit                |
+   * |-----|-----------------------------------|
+   * | 18  | Combined Control                  |
+   * | -   |  |BIT       | 20 19 18 |          |
+   * | 20  |  |NO ADV    | 0  0  0  |          |
+   * |     |  |CLR OF CON| 0  0  1  |          |
+   * |     |  |DROP TRACK| 0  1  0  |          |
+   * |     |  |ALT LOST  | 0  1  1  |          |
+   * |     |  |UP CORR   | 1  0  0  |          |
+   * |     |  |DOWN CORR | 1  0  1  |          |
+   * |     |  |PREVENTIVE| 1  1  0  |          |
+   * |     |  |NOT USED  | 1  1  1  |          |
+   * |-----|-----------------------------------|
+   * | 21  | Vertical Control                  |
+   * | -   |  |BIT       | 23 22 21 |          |
+   * | 23  |  |NO ADV    | 0  0  0  |          |
+   * |     |  |CROSSING  | 0  0  1  |          |
+   * |     |  |REVERSAL  | 0  1  0  |          |
+   * |     |  |INCREASE  | 0  1  1  |          |
+   * |     |  |MAINT     | 1  0  0  |          |
+   * |     |  |UNUSED    | 1  0  1  |          |
+   * |     |  |UNUSED    | 1  1  0  |          |
+   * |     |  |UNUSED    | 1  1  1  |          |
+   * |-----|-----------------------------------|
+   * | 24  | Up resolution advisory            |
+   * | -   |  |BIT       | 26 25 24 |          |
+   * | 26  |  |NO UP ADV | 0  0  0  |          |
+   * |     |  |CLIMB     | 0  0  1  |          |
+   * |     |  |DON'T DESC| 0  1  0  |          |
+   * |     |  |DON'T DESC| 0  1  1  |          |
+   * |     |  |> 500     |          |          |
+   * |     |  |DON'T DESC| 1  0  0  |          |
+   * |     |  |> 1000    |          |          |
+   * |     |  |DON'T DESC| 1  0  1  |          |
+   * |     |  |> 2000    |          |          |
+   * |     |  |UNUSED    | 1  1  0  |          |
+   * |     |  |UNUSED    | 1  1  1  |          |
+   * |-----|-----------------------------------|
+   * | 27  | Down resolution advisory          |
+   * | -   |  |BIT       | 26 25 24 |          |
+   * | 29  |  |NO DWN ADV| 0  0  0  |          |
+   * |     |  |DESC      | 0  0  1  |          |
+   * |     |  |DON'T CLB | 0  1  0  |          |
+   * |     |  |DON'T CLB | 0  1  1  |          |
+   * |     |  |> 500     |          |          |
+   * |     |  |DON'T CLB | 1  0  0  |          |
+   * |     |  |> 1000    |          |          |
+   * |     |  |DON'T CLB | 1  0  1  |          |
+   * |     |  |> 2000    |          |          |
+   * |     |  |UNUSED    | 1  1  0  |          |
+   * |     |  |UNUSED    | 1  1  1  |          |
+   * |-----|-----------------------------------|
+   */
+  a32nx_tcas_vertical_resolution_advisory_word: number;
+  /**
+   * TCAS word label 274 containing sensitivity level information
+   * Raw ARINC word.
+   * | Bit |            Description            |
+   * |:---:|:---------------------------------:|
+   * | 11  |                                   |
+   * | -   | Reserved                          |
+   * | 22  |                                   |
+   * | 23  | TCAS computer mode                |
+   * | -   | |BIT       | 25 24 23 |           |
+   * | 25  | |STBY      | 1  0  0  |           |
+   * |     | |Undefined |All others|           |
+   * |-----|-----------------------------------|
+   * | 26  | |BIT        | 29 28 27 26 |       |
+   * | -   | |OTHER      | 0  0  0  0  |       |
+   * | 29  | |Not Defined| 1  0  0  0  |       |
+   * |     | |TA ONLY    | 0  1  0  0  |       |
+   * |     | |TA/RA      | 1  1  0  0  |       |
+   * |     | |Reserved   | 0  0  1  0  |       |
+   */
+  a32nx_tcas_sensitivity_level_word: number;
+}
+
+type IndexedTopics = null;
+
+type A32NXTcasBusIndexedEvents = {
+  [P in keyof Pick<A32NXTcasBusBaseEvents, IndexedTopics> as IndexedEventType<P>]: A32NXTcasBusBaseEvents[P];
+};
+
+interface A32NXTcasBusPublisherEvents extends A32NXTcasBusBaseEvents, A32NXTcasBusIndexedEvents {}
+
+/**
+ * Events for A32NX TCAS bus local vars.
+ */
+export interface A32NXTcasBusEvents extends Omit<A32NXTcasBusBaseEvents, IndexedTopics>, A32NXTcasBusIndexedEvents {}
+
+/**
+ * Publisher for A32NX TCAS bus local vars.
+ */
+export class A32NXTcasBusPublisher extends SimVarPublisher<A32NXTcasBusPublisherEvents> {
+  /**
+   * Create a publisher.
+   * @param bus The EventBus to publish to
+   * @param pacer An optional pacer to use to control the rate of publishing
+   */
+  public constructor(bus: EventBus, pacer?: PublishPacer<A32NXTcasBusPublisherEvents>) {
+    const simvars = new Map<keyof A32NXTcasBusPublisherEvents, SimVarPublisherEntry<any>>([
+      [
+        'a32nx_tcas_vertical_resolution_advisory_word',
+        { name: 'L:A32NX_TCAS_VERTICAL_ADV_TEST', type: SimVarValueType.Enum },
+      ],
+      ['a32nx_tcas_sensitivity_level_word', { name: 'L:A32NX_TCAS_VERTICAL_ADV_TEST', type: SimVarValueType.Enum }],
+    ]);
+
+    super(simvars, bus, pacer);
+  }
+}

--- a/fbw-a32nx/src/systems/tcas/src/components/TcasComputer.ts
+++ b/fbw-a32nx/src/systems/tcas/src/components/TcasComputer.ts
@@ -1188,6 +1188,10 @@ export class TcasComputer {
             console.log('TCAS: CLEAR OF CONFLICT');
           }
           this.soundManager.tryPlaySound(TCAS.SOUNDS.clear_of_conflict, true);
+          this.upAdvisoryStatus.setVar(UpDownAdvisoryStatus.NO_ADVISORY);
+          this.downAdvisoryStatus.setVar(UpDownAdvisoryStatus.NO_ADVISORY);
+          this.rateToMaintain.setVar(0);
+          this.raType.setVar(RaType2.NONE);
           this.activeRa.info = null;
         }
         break;

--- a/fbw-a32nx/src/systems/tcas/src/components/TcasComputer.ts
+++ b/fbw-a32nx/src/systems/tcas/src/components/TcasComputer.ts
@@ -1332,9 +1332,9 @@ export class TcasComputer {
       (uintRateToMaintain << 10) |
         (this.rateToMaintain.getVar() < 0 ? 1 << 16 : 0) |
         (combinedControl << 17) |
-        (((this.raType.getVar() as number) & 0b00000111) << 20) |
-        (((this.upAdvisoryStatus.getVar() as number) & 0b00000111) << 23) |
-        (((this.downAdvisoryStatus.getVar() as number) & 0b00000111) << 26),
+        ((this.raType.getVar() & 0b00000111) << 20) |
+        ((this.upAdvisoryStatus.getVar() & 0b00000111) << 23) |
+        ((this.downAdvisoryStatus.getVar() & 0b00000111) << 26),
     );
     this.tcasBusResolutionAdvisoryWord.writeToSimVar('L:A32NX_TCAS_VERTICAL_RESOLUTION_ADVISORY_WORD');
 

--- a/fbw-a32nx/src/systems/tcas/src/components/TcasComputer.ts
+++ b/fbw-a32nx/src/systems/tcas/src/components/TcasComputer.ts
@@ -1328,16 +1328,14 @@ export class TcasComputer {
       combinedControl = 6;
     }
 
-    const resolutionAdvisoryWord =
+    this.tcasBusResolutionAdvisoryWord.setValue(
       (uintRateToMaintain << 10) |
-      (this.rateToMaintain.getVar() < 0 ? 1 << 16 : 0) |
-      (combinedControl << 17) |
-      (((this.raType.getVar() as number) & 0b00000111) << 20) |
-      (((this.upAdvisoryStatus.getVar() as number) & 0b00000111) << 23) |
-      (((this.downAdvisoryStatus.getVar() as number) & 0b00000111) << 26);
-    const rateToMaintainFloat = new Float32Array(new Uint32Array([resolutionAdvisoryWord >>> 0]).buffer)[0];
-
-    this.tcasBusResolutionAdvisoryWord.setValue(rateToMaintainFloat);
+        (this.rateToMaintain.getVar() < 0 ? 1 << 16 : 0) |
+        (combinedControl << 17) |
+        (((this.raType.getVar() as number) & 0b00000111) << 20) |
+        (((this.upAdvisoryStatus.getVar() as number) & 0b00000111) << 23) |
+        (((this.downAdvisoryStatus.getVar() as number) & 0b00000111) << 26),
+    );
     this.tcasBusResolutionAdvisoryWord.writeToSimVar('L:A32NX_TCAS_VERTICAL_RESOLUTION_ADVISORY_WORD');
 
     this.tcasBusTcasModeWord.setSsm(

--- a/fbw-a32nx/src/systems/tcas/src/components/TcasComputer.ts
+++ b/fbw-a32nx/src/systems/tcas/src/components/TcasComputer.ts
@@ -210,11 +210,11 @@ export class TcasComputer {
 
   private downAdvisoryStatus: LocalSimVar<UpDownAdvisoryStatus>; // Down adivsory status (descend, don't climb, don't climb >500 etc.)
 
-  private tcasBusResolutionAdvisoryWord: Arinc429Register;
+  private tcasBusResolutionAdvisoryWord?: Arinc429Register;
 
-  private tcasBusTcasModeWord: Arinc429Register;
+  private tcasBusTcasModeWord?: Arinc429Register;
 
-  private tcasBusTcasFaultSummaryWord: Arinc429Register;
+  private tcasBusTcasFaultSummaryWord?: Arinc429Register;
 
   private isSlewActive: boolean; // Slew Mode on?
 

--- a/fbw-a32nx/src/systems/tcas/src/components/TcasComputer.ts
+++ b/fbw-a32nx/src/systems/tcas/src/components/TcasComputer.ts
@@ -11,6 +11,8 @@ import {
   LocalSimVar,
   AirDataSwitchingKnob,
   registerTrafficListener,
+  Arinc429Register,
+  Arinc429SignStatusMatrix,
 } from '@flybywiresim/fbw-sdk';
 import { Coordinates } from 'msfs-geo';
 import {
@@ -208,6 +210,12 @@ export class TcasComputer {
 
   private downAdvisoryStatus: LocalSimVar<UpDownAdvisoryStatus>; // Down adivsory status (descend, don't climb, don't climb >500 etc.)
 
+  private tcasBusResolutionAdvisoryWord: Arinc429Register;
+
+  private tcasBusTcasModeWord: Arinc429Register;
+
+  private tcasBusTcasFaultSummaryWord: Arinc429Register;
+
   private isSlewActive: boolean; // Slew Mode on?
 
   private simRate: number; // Simulation Rate
@@ -268,6 +276,9 @@ export class TcasComputer {
     this.rateToMaintain = new LocalSimVar('L:A32NX_TCAS_RA_RATE_TO_MAINTAIN', 'number');
     this.upAdvisoryStatus = new LocalSimVar('L:A32NX_TCAS_RA_UP_ADVISORY_STATUS', 'Enum');
     this.downAdvisoryStatus = new LocalSimVar('L:A32NX_TCAS_RA_DOWN_ADVISORY_STATUS', 'Enum');
+    this.tcasBusResolutionAdvisoryWord = Arinc429Register.empty();
+    this.tcasBusTcasModeWord = Arinc429Register.empty();
+    this.tcasBusTcasFaultSummaryWord = Arinc429Register.empty();
     this.airTraffic = [];
     this.raTraffic = [];
     this.sensitivity = new LocalSimVar('L:A32NX_TCAS_SENSITIVITY', 'number');
@@ -1302,6 +1313,48 @@ export class TcasComputer {
     this.syncer.sendEvent('A32NX_TCAS_TRAFFIC', this.sendAirTraffic);
   }
 
+  private updateBus(): void {
+    this.tcasBusResolutionAdvisoryWord.setSsm(
+      !this.tcasPower ? Arinc429SignStatusMatrix.FailureWarning : Arinc429SignStatusMatrix.NormalOperation,
+    );
+
+    const uintRateToMaintain = Math.round(Math.abs(this.rateToMaintain.getVar()) / 100) & 0b00111111;
+    let combinedControl = 0;
+    if (this.tcasState.getVar() < TcasState.RA) {
+      combinedControl = 0;
+    } else if (this.correctiveRa.getVar()) {
+      combinedControl = this.rateToMaintain.getVar() > 0 ? 4 : 5;
+    } else {
+      combinedControl = 6;
+    }
+
+    const resolutionAdvisoryWord =
+      (uintRateToMaintain << 10) |
+      (this.rateToMaintain.getVar() < 0 ? 1 << 16 : 0) |
+      (combinedControl << 17) |
+      (((this.raType.getVar() as number) & 0b00000111) << 20) |
+      (((this.upAdvisoryStatus.getVar() as number) & 0b00000111) << 23) |
+      (((this.downAdvisoryStatus.getVar() as number) & 0b00000111) << 26);
+    const rateToMaintainFloat = new Float32Array(new Uint32Array([resolutionAdvisoryWord >>> 0]).buffer)[0];
+
+    this.tcasBusResolutionAdvisoryWord.setValue(rateToMaintainFloat);
+    this.tcasBusResolutionAdvisoryWord.writeToSimVar('L:A32NX_TCAS_VERTICAL_RESOLUTION_ADVISORY_WORD');
+
+    this.tcasBusTcasModeWord.setSsm(
+      !this.tcasPower ? Arinc429SignStatusMatrix.FailureWarning : Arinc429SignStatusMatrix.NormalOperation,
+    );
+    this.tcasBusTcasModeWord.setBitValue(25, this.tcasMode.getVar() === TcasMode.STBY);
+    this.tcasBusTcasModeWord.setBitValue(26, this.sensitivity.getVar() > 1);
+    this.tcasBusTcasModeWord.setBitValue(27, this.sensitivity.getVar() > 2);
+    this.tcasBusTcasModeWord.writeToSimVar('L:A32NX_TCAS_MODE_WORD');
+
+    this.tcasBusTcasFaultSummaryWord.setSsm(
+      !this.tcasPower ? Arinc429SignStatusMatrix.FailureWarning : Arinc429SignStatusMatrix.NormalOperation,
+    );
+    this.tcasBusTcasFaultSummaryWord.setBitValue(20, this.tcasFault.getVar() == 1);
+    this.tcasBusTcasFaultSummaryWord.writeToSimVar('L:A32NX_TCAS_FAULT_SUMMARY_WORD');
+  }
+
   /**
    * Main update loop
    * @param deltaTime delta time of this frame
@@ -1340,11 +1393,13 @@ export class TcasComputer {
         this.sendAirTraffic.length = 0;
         this.syncer.sendEvent('A32NX_TCAS_TRAFFIC', this.sendAirTraffic);
       }
+      this.updateBus();
       return;
     }
     this.fetchRawTraffic(deltaTime);
     this.updateTraffic(deltaTime);
     this.updateRa(deltaTime);
     this.emitDisplay();
+    this.updateBus();
   }
 }

--- a/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
@@ -403,16 +403,9 @@ void FlyByWireInterface::setupLocalVariables() {
   idFmFinalCanEngage = std::make_unique<LocalVariable>("A32NX_FG_FINAL_CAN_ENGAGE");
   idFmNavCaptureCondition = std::make_unique<LocalVariable>("A32NX_FM1_NAV_CAPTURE_CONDITION");
 
-  idTcasFault = std::make_unique<LocalVariable>("A32NX_TCAS_FAULT");
-  idTcasMode = std::make_unique<LocalVariable>("A32NX_TCAS_MODE");
-  idTcasTaOnly = std::make_unique<LocalVariable>("A32NX_TCAS_TA_ONLY");
   idTcasState = std::make_unique<LocalVariable>("A32NX_TCAS_STATE");
-  idTcasRaCorrective = std::make_unique<LocalVariable>("A32NX_TCAS_RA_CORRECTIVE");
-  idTcasRaType = std::make_unique<LocalVariable>("A32NX_TCAS_RA_TYPE");
-  idTcasRaRateToMaintain = std::make_unique<LocalVariable>("A32NX_TCAS_RA_RATE_TO_MAINTAIN");
-  idTcasRaUpAdvStatus = std::make_unique<LocalVariable>("A32NX_TCAS_RA_UP_ADVISORY_STATUS");
-  idTcasRaDownAdvStatus = std::make_unique<LocalVariable>("A32NX_TCAS_RA_DOWN_ADVISORY_STATUS");
-  idTcasSensitivityLevel = std::make_unique<LocalVariable>("A32NX_TCAS_SENSITIVITY");
+  idTcasModeWord = std::make_unique<LocalVariable>("A32NX_TCAS_MODE_WORD");
+  idTcasVerticalAdvisoryWord = std::make_unique<LocalVariable>("A32NX_TCAS_VERTICAL_RESOLUTION_ADVISORY_WORD");
 
   idThrottlePosition3d_1 = std::make_unique<LocalVariable>("A32NX_3D_THROTTLE_LEVER_POSITION_1");
   idThrottlePosition3d_2 = std::make_unique<LocalVariable>("A32NX_3D_THROTTLE_LEVER_POSITION_2");
@@ -1351,37 +1344,8 @@ bool FlyByWireInterface::updateAdirs(int adirsIndex) {
 }
 
 bool FlyByWireInterface::updateTcas() {
-  uint8_t mode = 0;
-  if (idTcasMode->get() == 0) {
-    mode = 0;
-  } else if (idTcasTaOnly->get()) {
-    mode = 0b0010;
-  } else {
-    mode = 0b0011;
-  }
-
-  tcasBusOutputs.sensitivity_level.SSM = Arinc429SignStatus::NormalOperation;
-  tcasBusOutputs.sensitivity_level.Data = static_cast<float>(((idTcasMode->get() == 0 ? 1 : 0) << 24) | (mode << 25));
-
-  auto rateToMaintain = idTcasRaRateToMaintain->get();
-  uint8_t uintRateToMaintain = static_cast<uint8_t>(std::abs(rateToMaintain) / 100) & 0b00111111;
-  uint8_t combinedControl = 0;
-  if (idTcasState->get() < 2) {
-    combinedControl = 0;
-  } else if (idTcasRaCorrective->get() == 1) {
-    combinedControl = rateToMaintain > 0 ? 4 : 5;
-  } else if (idTcasRaCorrective->get() == 0) {
-    combinedControl = 6;
-  }
-  uint8_t verticalControl = static_cast<uint8_t>(idTcasRaType->get()) & 0b00000111;
-  uint8_t upAdvisory = static_cast<uint8_t>(idTcasRaUpAdvStatus->get()) & 0b00000111;
-  uint8_t downAdvisory = static_cast<uint8_t>(idTcasRaDownAdvStatus->get()) & 0b00000111;
-
-  tcasBusOutputs.vertical_resolution_advisory.SSM =
-      idTcasMode->get() < 2 ? Arinc429SignStatus::NoComputedData : Arinc429SignStatus::NormalOperation;
-  tcasBusOutputs.vertical_resolution_advisory.Data =
-      static_cast<float>((uintRateToMaintain << 10) | (rateToMaintain < 0 ? 1u << 16 : 0) | (combinedControl << 17) |
-                         (verticalControl << 20) | (upAdvisory << 23) | (downAdvisory << 26));
+  tcasBusOutputs.sensitivity_level = Arinc429Utils::fromSimVar(idTcasModeWord->get());
+  tcasBusOutputs.vertical_resolution_advisory =Arinc429Utils::fromSimVar(idTcasVerticalAdvisoryWord->get());
 
   if (clientDataEnabled) {
     simConnectInterface.setClientDataTcas(tcasBusOutputs);

--- a/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.h
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.h
@@ -211,16 +211,9 @@ class FlyByWireInterface {
   std::unique_ptr<LocalVariable> idFmFinalCanEngage;
   std::unique_ptr<LocalVariable> idFmNavCaptureCondition;
 
-  std::unique_ptr<LocalVariable> idTcasFault;
-  std::unique_ptr<LocalVariable> idTcasMode;
-  std::unique_ptr<LocalVariable> idTcasTaOnly;
   std::unique_ptr<LocalVariable> idTcasState;
-  std::unique_ptr<LocalVariable> idTcasRaCorrective;
-  std::unique_ptr<LocalVariable> idTcasRaType;
-  std::unique_ptr<LocalVariable> idTcasRaRateToMaintain;
-  std::unique_ptr<LocalVariable> idTcasRaUpAdvStatus;
-  std::unique_ptr<LocalVariable> idTcasRaDownAdvStatus;
-  std::unique_ptr<LocalVariable> idTcasSensitivityLevel;
+  std::unique_ptr<LocalVariable> idTcasModeWord;
+  std::unique_ptr<LocalVariable> idTcasVerticalAdvisoryWord;
 
   std::unique_ptr<LocalVariable> idFwcFlightPhase;
   std::unique_ptr<LocalVariable> idFmgcFlightPhase;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* Implement the TCAS high speed output bus.
* Refactor the PFD V/S indicator to use MappedSubject pattern
* Improve the PFD TCAS RA indication graphics and logic, and switch to the new TCAS bus.
  * The V/S digital indicator is now colored red when inside the up or down red resolution advisory zones
  * The zone border is now properly angle so that the V/S needle aligns. The green fly to zone is now properly extended and flat during either up or down corrective resolution adivsories.
  * Multi-Aircraft RAs are also supported by the RA display, but our TCAS implementation does not support them currently.
  * The TCAS amber flag now also uses the TCAS bus.
* Also switch the FMGC from a TCAS bus shim to the new TCAS bus.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Graphics comparison:
| Before | After|
|--------|--------|
| <img width="616" height="697" alt="grafik" src="https://github.com/user-attachments/assets/436ea454-053f-44df-b5fd-47b175452717" />| <img width="674" height="710" alt="grafik" src="https://github.com/user-attachments/assets/33ed1f89-a80f-4c33-b04e-56676146381c" />|
| <img width="616" height="699" alt="grafik" src="https://github.com/user-attachments/assets/f715a917-d335-4b5a-943c-4aacdf8c108e" />| <img width="674" height="711" alt="grafik" src="https://github.com/user-attachments/assets/e77bc319-9b87-443c-89a6-6ae440ce8dbb" />| 

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
Example of the PFD TCAS RA indications https://www.youtube.com/watch?v=nwL51Vs7sOw

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
* Trigger TCAS RAs, check that the RA indication is reasonable and corresponds to the aural command given. Also check that the AP/FD TCAS mode properly follows the indicated TCAS RA order.
* Check that the TCAS flag on the PFD appears when the TCAS is unable to provide RA information (Radio Altimeter, ADR off etc.), provided that the TCAS is not in standby.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
