### PR TITLE
fix(a32nx/fws): Remove HYD secondary failures

### DIFF
--- a/fbw-a32nx/src/systems/shared/src/EwdMessages.ts
+++ b/fbw-a32nx/src/systems/shared/src/EwdMessages.ts
@@ -503,8 +503,6 @@ const EwdMessages = new Map<string, { group?: string; text: string }>([
   ['220001501', { text: '\x1b<2mAP OFF' }],
   ['220002101', { text: '\x1b<4mA/THR OFF' }],
   ['320000001', { text: '\x1b<4mAUTO BRK OFF' }],
-  ['290031001', { text: '\x1b<4m*HYD' }],
-  ['290031201', { text: '\x1b<4m*HYD' }],
   ['000006001', { text: '\x1b<3mSPEED BRK' }],
   ['000006002', { text: '\x1b<4mSPEED BRK' }],
   ['000020001', { text: '\x1b<3mPARK BRK' }],

--- a/fbw-a32nx/src/systems/systems-host/systems/FWC/PseudoFWC.ts
+++ b/fbw-a32nx/src/systems/systems-host/systems/FWC/PseudoFWC.ts
@@ -6194,50 +6194,6 @@ export class PseudoFWC {
       sysPage: EcamSysPage.HYD,
       side: 'LEFT',
     },
-    2900310: {
-      // *HYD  - Blue
-      flightPhaseInhib: [1, 4, 5, 10],
-      simVarIsActive: MappedSubject.create(
-        ([blueRvrOvht, blueRvrLow, blueElecPumpPBAuto, dcESSBusPowered, ac1BusPowered, blueLP, emergencyGeneratorOn]) =>
-          !(blueRvrOvht || blueRvrLow || !blueElecPumpPBAuto) &&
-          (!dcESSBusPowered || !ac1BusPowered) &&
-          blueLP &&
-          !emergencyGeneratorOn,
-        this.blueRvrOvht,
-        this.blueRvrLow,
-        this.blueElecPumpPBAuto,
-        this.dcESSBusPowered,
-        this.ac1BusPowered,
-        this.blueLP,
-        this.emergencyGeneratorOn,
-      ),
-      whichCodeToReturn: () => [0],
-      codesToReturn: ['290031001'],
-      memoInhibit: () => false,
-      failure: 0,
-      sysPage: EcamSysPage.HYD,
-      side: 'RIGHT',
-    },
-    2900312: {
-      // *HYD  - Green Engine 1 //
-      flightPhaseInhib: [1, 2, 9, 10],
-      simVarIsActive: MappedSubject.create(
-        ([greenLP, eng1pumpPBisAuto, emergencyGeneratorOn]) =>
-          greenLP &&
-          // && ENG 1 OUT - not implemented
-          eng1pumpPBisAuto &&
-          !emergencyGeneratorOn,
-        this.greenLP,
-        this.eng1pumpPBisAuto,
-        this.emergencyGeneratorOn,
-      ),
-      whichCodeToReturn: () => [0],
-      codesToReturn: ['290031201'],
-      memoInhibit: () => false,
-      failure: 0,
-      sysPage: EcamSysPage.HYD,
-      side: 'RIGHT',
-    },
     2800145: {
       // L+R WING TK LO LVL
       flightPhaseInhib: [3, 4, 5, 7, 8, 9],


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Removes the `*HYD` secondary failures until we can model both a) secondary failures properly (through #10651), and b) the HYD ones in particiularly properly without relying on flight phase inhibits (needs some further work on HYD in the FWS).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): fozzie

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
