### PR TITLE
fix(a380x/fws): add cabin press manual mode memo

### DIFF
--- a/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/EcamMessages/index.ts
+++ b/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/EcamMessages/index.ts
@@ -67,6 +67,8 @@ export const EcamMemos: { [n: string]: string } = {
   '000018001': '\x1b<3mAPU BLEED',
   '000029001': '\x1b<3mSWITCHG PNL',
   '210000001': '\x1b<3mHI ALT AIRPORT',
+  '210000002': '\x1b<4mCAB PRESS MAN MODE',
+  '210000003': '\x1b<3mCAB PRESS MAN MODE',
   '220000001': '\x1b<2mAP OFF',
   '220000002': '\x1b<4mA/THR OFF',
   '221000001': '\x1b<3mFMS SWTG',

--- a/fbw-a380x/src/systems/systems-host/CpiomC/FlightWarningSystem/CabPressMemoUtils.spec.ts
+++ b/fbw-a380x/src/systems/systems-host/CpiomC/FlightWarningSystem/CabPressMemoUtils.spec.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 FlyByWire Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
+import { describe, expect, it } from 'vitest';
+import { FwcFlightPhase } from './FwsFlightPhases';
+import { getCabPressManModeMemoCode, isCabPressManMode } from './CabPressMemoUtils';
+
+describe('CabPressMemoUtils', () => {
+  it('treats either manual pressurization channel as manual mode', () => {
+    expect(isCabPressManMode(false, false)).toBe(false);
+    expect(isCabPressManMode(true, false)).toBe(true);
+    expect(isCabPressManMode(false, true)).toBe(true);
+    expect(isCabPressManMode(true, true)).toBe(true);
+  });
+
+  it('uses the amber memo in phases 1, 2, and 12', () => {
+    expect(getCabPressManModeMemoCode(FwcFlightPhase.ElecPwr)).toBe('210000002');
+    expect(getCabPressManModeMemoCode(FwcFlightPhase.FirstEngineStarted)).toBe('210000002');
+    expect(getCabPressManModeMemoCode(FwcFlightPhase.EnginesShutdown)).toBe('210000002');
+  });
+
+  it('uses the green memo outside phases 1, 2, and 12', () => {
+    expect(getCabPressManModeMemoCode(FwcFlightPhase.SecondEngineTakeOffPower)).toBe('210000003');
+    expect(getCabPressManModeMemoCode(FwcFlightPhase.AtOrAbove1500FeetTo800Feet)).toBe('210000003');
+    expect(getCabPressManModeMemoCode(FwcFlightPhase.AtOrBelowEightyKnots)).toBe('210000003');
+  });
+});

--- a/fbw-a380x/src/systems/systems-host/CpiomC/FlightWarningSystem/CabPressMemoUtils.ts
+++ b/fbw-a380x/src/systems/systems-host/CpiomC/FlightWarningSystem/CabPressMemoUtils.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 FlyByWire Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
+import { FwcFlightPhase } from './FwsFlightPhases';
+
+export function isCabPressManMode(manCabinAltMode: boolean, manCabinVsMode: boolean): boolean {
+  return manCabinAltMode || manCabinVsMode;
+}
+
+export function getCabPressManModeMemoCode(flightPhase: FwcFlightPhase): '210000002' | '210000003' {
+  switch (flightPhase) {
+    case FwcFlightPhase.ElecPwr:
+    case FwcFlightPhase.FirstEngineStarted:
+    case FwcFlightPhase.EnginesShutdown:
+      return '210000002';
+    default:
+      return '210000003';
+  }
+}

--- a/fbw-a380x/src/systems/systems-host/CpiomC/FlightWarningSystem/FwsCore.ts
+++ b/fbw-a380x/src/systems/systems-host/CpiomC/FlightWarningSystem/FwsCore.ts
@@ -76,6 +76,7 @@ import { FwsSystemDisplayLogic } from './FwsSystemDisplayLogic';
 import { FwsInopSys, FwsInopSysPhases } from './FwsInopSys';
 import { FwsInformation } from './FwsInformation';
 import { FwsLimitations, FwsLimitationsPhases } from './FwsLimitations';
+import { isCabPressManMode } from './CabPressMemoUtils';
 import { FGVars } from 'instruments/src/MsfsAvionicsCommon/providers/FGDataPublisher';
 import { FqmsBusEvents } from '@shared/publishers/FqmsBusPublisher';
 import {
@@ -588,6 +589,14 @@ export class FwsCore {
   public readonly flowSelectorKnob = Subject.create(0);
 
   public readonly manCabinAltMode = Subject.create(false);
+
+  public readonly manCabinVsMode = Subject.create(false);
+
+  public readonly cabPressManMode = MappedSubject.create(
+    ([manCabinAltMode, manCabinVsMode]) => isCabPressManMode(manCabinAltMode, manCabinVsMode),
+    this.manCabinAltMode,
+    this.manCabinVsMode,
+  );
 
   private readonly cabinAltitude = Arinc429Register.empty();
 
@@ -4239,6 +4248,7 @@ export class FwsCore {
     );
 
     this.manCabinAltMode.set(!SimVar.GetSimVarValue('L:A32NX_OVHD_PRESS_MAN_ALTITUDE_PB_IS_AUTO', 'bool'));
+    this.manCabinVsMode.set(!SimVar.GetSimVarValue('L:A32NX_OVHD_PRESS_MAN_VS_CTL_PB_IS_AUTO', 'bool'));
 
     if (flightPhase8) {
       this.landingElevation.setFromSimVar('L:A32NX_FM1_LANDING_ELEVATION');

--- a/fbw-a380x/src/systems/systems-host/CpiomC/FlightWarningSystem/FwsMemos.ts
+++ b/fbw-a380x/src/systems/systems-host/CpiomC/FlightWarningSystem/FwsMemos.ts
@@ -11,6 +11,7 @@ import {
   Subscription,
 } from '@microsoft/msfs-sdk';
 import { FwsCore } from 'systems-host/CpiomC/FlightWarningSystem/FwsCore';
+import { getCabPressManModeMemoCode } from './CabPressMemoUtils';
 
 interface EwdMemoItem {
   flightPhaseInhib: number[];
@@ -37,6 +38,13 @@ export class FwsMemos {
       simVarIsActive: this.fws.highLandingFieldElevation,
       whichCodeToReturn: () => [0],
       codesToReturn: ['210000001'],
+      memoInhibit: () => false,
+    },
+    210000002: {
+      flightPhaseInhib: [],
+      simVarIsActive: this.fws.cabPressManMode,
+      whichCodeToReturn: () => [getCabPressManModeMemoCode(this.fws.flightPhase.get()) === '210000002' ? 0 : 1],
+      codesToReturn: ['210000002', '210000003'],
       memoInhibit: () => false,
     },
     271000001: {


### PR DESCRIPTION
Fixes #10675

## Summary of Changes
Show CAB PRESS MAN MODE when either cabin altitude or cabin VS manual channel is out of AUTO; amber in phases 1, 2, and 12, green otherwise.

## Screenshots (if necessary)
N/A

## References
Based on existing FWS memo system implementation in FwsCore.ts and FwsMemos.ts and consistency with other ECAM memo threshold logic.

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
Aligns CAB PRESS memo behavior with existing FWS memo gating logic and phase-based color handling used across ECAM memo system.

Discord username (if different from GitHub): thebanhammer.

## Testing instructions
1. Load A380X in MSFS.
2. Set aircraft to normal electrical configuration.
3. Verify CAB PRESS memo is not displayed in AUTO conditions.
4. Switch cabin altitude or cabin vertical speed channel from AUTO to MANUAL.
5. Confirm CAB PRESS MAN MODE memo appears.
6. Cycle through flight phases 1, 2, and 12:
   - Confirm memo is amber in phases 1, 2, 12.
   - Confirm memo is green in all other phases.
7. Return system to AUTO and confirm memo clears.
8. Verify no unrelated ECAM messages are affected.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
