### PR TITLE
feat(a32nx/efb): Skip departure change checklist in efb- 2020

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -132,6 +132,7 @@
 1. [A32NX/FWS] Added Five Hundred callout only not on glide option - @BravoMike99 (bruno_pt99)
 1. [A32NX] Split navigation lights into two separate systems - @tracernz (Mike)
 1. [A380X/FG] Fixed autopilot managed speed target not limited by characteristic speeds outside of approach - @BravoMike99 (bruno_pt99)
+1. [A32NX/EFB] Skip the departure change checklist in efb - @Lucas-IQ21 (Lucas)
 
 ## 0.14.0
 

--- a/fbw-common/src/systems/instruments/src/EFB/Checklists/CompletionButton.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/Checklists/CompletionButton.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { t, useAppDispatch, useAppSelector } from '@flybywiresim/flypad';
-import { usePersistentNumberProperty, useSimVar } from '@flybywiresim/fbw-sdk';
+import { ChecklistJsonDefinition, usePersistentNumberProperty, useSimVar } from '@flybywiresim/fbw-sdk';
 import React, { useEffect } from 'react';
 
 import {
@@ -33,6 +33,14 @@ export const CompletionButton = () => {
     return !item.completed;
   });
 
+  const getNextChecklistIndex = (currentIndex: number, aircraftChecklists: ChecklistJsonDefinition[]) => {
+    let nextIndex = currentIndex + 1;
+    while (nextIndex < aircraftChecklists.length && aircraftChecklists[nextIndex].name === '<< DEPARTURE CHANGE >>') {
+      nextIndex++;
+    }
+    return nextIndex;
+  };
+
   // allows the completion button to be used via LVar - if the LVar is set to true, the button will be clicked,
   // and the LVar will be reset to false. This can be used, for example, to trigger completion from a hardware button.
   const [completeItemVar, setCompleteItemVar] = useSimVar('L:A32NX_EFB_CHECKLIST_COMPLETE_ITEM', 'bool', 200);
@@ -43,7 +51,7 @@ export const CompletionButton = () => {
     if (completeItemVar) {
       setCompleteItemVar(false);
       if (checklists[selectedChecklistIndex].markedCompleted && selectedChecklistIndex < checklists.length - 1) {
-        dispatch(setSelectedChecklistIndex(selectedChecklistIndex + 1));
+        dispatch(setSelectedChecklistIndex(getNextChecklistIndex(selectedChecklistIndex, aircraftChecklists)));
       } else if (firstIncompleteIdx !== -1) {
         dispatch(
           setChecklistItemCompletion({
@@ -68,7 +76,7 @@ export const CompletionButton = () => {
                                bg-theme-body py-2 text-center font-bold text-theme-highlight transition duration-100
                                hover:bg-theme-highlight hover:text-theme-body"
           onClick={() => {
-            dispatch(setSelectedChecklistIndex(selectedChecklistIndex + 1));
+            dispatch(setSelectedChecklistIndex(getNextChecklistIndex(selectedChecklistIndex, aircraftChecklists)));
           }}
         >
           {t('Checklists.ProceedToNextChecklist')}


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Cherry pick of #10664  to 2020

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
QA not needed. Was already tested in both sims as pre split PR.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
