### PR TITLE
fix(a32nx/elec): Fix electrical bus initialisation (2020)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -135,6 +135,7 @@
 1. [A32NX/EFB] Skip the departure change checklist in efb - @Lucas-IQ21 (Lucas)
 1. [A32NX/FWS] Add `GEAR NOT UPLOCKED` master caution - @FozzieHi (fozzie)
 1. [A32NX/MCDU] Fix NEW DEST not available in LAT REV on first flightplan waypoint - @BravoMike99 (bruno_pt99)
+1. [A32NX/ELEC] Fixed some electrical systems powering up erroneously on load which may have caused spurious FWS warnings - @FozzieHi (fozzie)
 
 ## 0.14.0
 

--- a/fbw-common/src/wasm/systems/systems_wasm/src/aspects.rs
+++ b/fbw-common/src/wasm/systems/systems_wasm/src/aspects.rs
@@ -248,6 +248,23 @@ impl<'a, 'b> MsfsAspectBuilder<'a, 'b> {
         ));
     }
 
+    /// Execute the given function whenever any of the observed variable values changes, using the
+    /// provided values as the initial previous values for change detection.
+    pub fn on_change_with_starting_values(
+        &mut self,
+        execute_on: ExecuteOn,
+        observed: Vec<Variable>,
+        starting_values: Vec<f64>,
+        func: OnChangeFn,
+    ) {
+        let observed = self.variables.register_many(&observed);
+
+        self.actions.push((
+            OnChange::new(observed, starting_values, func).into(),
+            execute_on,
+        ));
+    }
+
     fn precondition_not_aircraft_variable(variable: &Variable) {
         if matches!(variable, Variable::Aircraft(..)) {
             eprintln!("Writing to variable '{}' is unsupported.", variable);

--- a/fbw-common/src/wasm/systems/systems_wasm/src/electrical.rs
+++ b/fbw-common/src/wasm/systems/systems_wasm/src/electrical.rs
@@ -21,11 +21,10 @@ pub(super) fn electrical_buses<const N: usize>(
             const INFINITELY_POWERED_BUS_IDENTIFIER: u32 = 1;
             let variable = Variable::named(&format!("ELEC_{}_BUS_IS_POWERED", bus.0));
 
-            builder.init_variable(variable.clone(), 1.);
-
-            builder.on_change(
+            builder.on_change_with_starting_values(
                 ExecuteOn::PostTick,
                 vec![variable],
+                vec![1.],
                 Box::new(move |_, _| {
                     trigger_key_event_ex1(
                         KEY_ELECTRICAL_BUS_TO_BUS_CONNECTION_TOGGLE,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Cherry-pick of #10667

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): fozzie

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Spawn at a gate without electrical power, switch the external lights on the overhead and check they do not illuminate outside
2. Spawn on the runway, check the external lights illuminate correctly

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
