### PR TITLE
fix(a380x/mfd): fix radio button group not updating visually 

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -136,6 +136,8 @@
 1. [A32NX/FWS] Add `GEAR NOT UPLOCKED` master caution - @FozzieHi (fozzie)
 1. [A32NX/MCDU] Fix NEW DEST not available in LAT REV on first flightplan waypoint - @BravoMike99 (bruno_pt99)
 1. [A32NX/ELEC] Fixed some electrical systems powering up erroneously on load which may have caused spurious FWS warnings - @FozzieHi (fozzie)
+1. [A380X/MFD] Fix SURV page radio buttons not matching the actual state of the TCAS system - @heclak (Heclak)
+1. [A380X/MFD] Fix TAKEOFF PERF page radio buttons not syncing correctly when both MFDs are used - @heclak (Heclak)
 
 ## 0.14.0
 

--- a/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/UiWidgets/RadioButtonGroup.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MsfsAvionicsCommon/UiWidgets/RadioButtonGroup.tsx
@@ -39,7 +39,7 @@ export class RadioButtonGroup extends DisplayComponent<RadioButtonGroupProps> {
     FSComponent.createRef<HTMLLabelElement>(),
   );
   private readonly inputRefs = Array.from(Array(this.props.values.length), () =>
-    FSComponent.createRef<HTMLLabelElement>(),
+    FSComponent.createRef<HTMLInputElement>(),
   );
 
   private changeEventHandler(i: number) {
@@ -68,9 +68,9 @@ export class RadioButtonGroup extends DisplayComponent<RadioButtonGroupProps> {
       this.props.selectedIndex.sub((val) => {
         this.inputRefs.forEach((ref, index) => {
           if (index === val) {
-            ref.instance.setAttribute('checked', 'checked');
+            ref.instance.checked = true;
           } else {
-            ref.instance.removeAttribute('checked');
+            ref.instance.checked = false;
           }
         });
       }, true),


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
A cherry pick of #10691 to 2020 as the issue also seems to occur here.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): bruno_pt99

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Tested locally after the cherry pick with the 2024 instructions. Can skip QA as minor change.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
