### PR TITLE
fix: 2020 version check and remove exp leftover code

### DIFF
--- a/fbw-common/src/systems/shared/src/AircraftGithubVersionChecker.ts
+++ b/fbw-common/src/systems/shared/src/AircraftGithubVersionChecker.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-// Copyright (c) 2023-2024 FlyByWire Simulations
+// Copyright (c) 2023-2026 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
 /* eslint-disable no-console */
@@ -36,14 +36,12 @@ export interface VersionInfoData {
 export enum KnowBranchNames {
   rel = 'Stable',
   dev = 'Development',
-  exp = 'Experimental',
 }
 
 export enum FbwBuildEdition {
   Unknown = 0,
   Stable,
   Development,
-  Experimental,
 }
 
 /**
@@ -56,8 +54,6 @@ export class AircraftGithubVersionChecker {
   private static releaseInfo: ReleaseInfo[];
 
   private static newestCommit: CommitInfo;
-
-  private static newestExpCommit: CommitInfo;
 
   private static buildInfo?: BuildInfo;
 
@@ -83,7 +79,7 @@ export class AircraftGithubVersionChecker {
     await this.initialize(aircraft);
 
     // assert all version info is available
-    if (!(this.buildInfo && this.releaseInfo && this.newestCommit && this.newestExpCommit)) {
+    if (!(this.buildInfo && this.releaseInfo && this.newestCommit)) {
       console.error('Not all version information available. Skipping version check.');
       return false;
     }
@@ -188,8 +184,6 @@ export class AircraftGithubVersionChecker {
           return FbwBuildEdition.Stable;
         case KnowBranchNames.dev:
           return FbwBuildEdition.Development;
-        case KnowBranchNames.exp:
-          return FbwBuildEdition.Experimental;
       }
     } catch (e) {
       console.warn('Failed to fetch edition', e);
@@ -213,8 +207,7 @@ export class AircraftGithubVersionChecker {
    */
   private static async initialize(aircraft: string) {
     this.releaseInfo = await GitVersions.getReleases('flybywiresim', aircraft, false, 0, 1);
-    this.newestCommit = await GitVersions.getNewestCommit('flybywiresim', aircraft, 'master');
-    this.newestExpCommit = await GitVersions.getNewestCommit('flybywiresim', aircraft, 'experimental');
+    this.newestCommit = await GitVersions.getNewestCommit('flybywiresim', aircraft, 'fs2020-master');
     this.buildInfo = await AircraftGithubVersionChecker.getBuildInfo(aircraft);
   }
 
@@ -237,7 +230,7 @@ export class AircraftGithubVersionChecker {
     }
 
     // If the user's version is equal or newer than the latest release then check if
-    // the edition is Development or Experimental and if the commit is older than
+    // the edition is Development and if the commit is older than
     // {maxAge} days after the latest release to show notification
 
     const maxAge = 3;
@@ -249,15 +242,6 @@ export class AircraftGithubVersionChecker {
       this.addDays(timestampAircraft, maxAge) < this.newestCommit.timestamp
     ) {
       this.showNotification(versionInfo, timestampAircraft, branchName, this.newestCommit);
-      return true;
-    }
-
-    if (
-      branchName === KnowBranchNames.exp &&
-      versionInfo.commit !== this.newestExpCommit.shortSha &&
-      this.addDays(timestampAircraft, maxAge) < this.newestExpCommit.timestamp
-    ) {
-      this.showNotification(versionInfo, timestampAircraft, branchName, this.newestExpCommit);
       return true;
     }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #10726 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Fixes the mentioned issue and removes leftover code referencing the experimental version.
## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
