### PR TITLE
fix: fs2020 aircraft version check (dev and stable)

### DIFF
--- a/fbw-common/src/systems/shared/src/AircraftGithubVersionChecker.ts
+++ b/fbw-common/src/systems/shared/src/AircraftGithubVersionChecker.ts
@@ -213,7 +213,7 @@ export class AircraftGithubVersionChecker {
    */
   private static async initialize(aircraft: string) {
     this.releaseInfo = await GitVersions.getReleases('flybywiresim', aircraft, false, 0, 1);
-    this.newestCommit = await GitVersions.getNewestCommit('flybywiresim', aircraft, 'master');
+    this.newestCommit = await GitVersions.getNewestCommit('flybywiresim', aircraft, 'fs2020-master');
     this.newestExpCommit = await GitVersions.getNewestCommit('flybywiresim', aircraft, 'experimental');
     this.buildInfo = await AircraftGithubVersionChecker.getBuildInfo(aircraft);
   }

--- a/fbw-common/src/systems/shared/src/AircraftGithubVersionChecker.ts
+++ b/fbw-common/src/systems/shared/src/AircraftGithubVersionChecker.ts
@@ -227,6 +227,7 @@ export class AircraftGithubVersionChecker {
     const branchName = (KnowBranchNames as any)[versionInfo.branch] || versionInfo.branch;
 
     if (branchName === KnowBranchNames.rel) {
+      // The major version indicates FS2020 or FS2024
       const latestRelease = this.releaseInfo.find((r) => semVerMajor(r.name) === versionInfo.major);
 
       // Check if main version is outdated

--- a/fbw-common/src/systems/shared/src/AircraftGithubVersionChecker.ts
+++ b/fbw-common/src/systems/shared/src/AircraftGithubVersionChecker.ts
@@ -1,12 +1,12 @@
-// @ts-strict-ignore
 // Copyright (c) 2023-2024 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
 /* eslint-disable no-console */
 /* eslint-disable no-underscore-dangle */
-import Compare from 'semver/functions/compare';
+import semVerCompare from 'semver/functions/compare';
 import { CommitInfo, GitVersions, ReleaseInfo } from '@flybywiresim/api-client';
 import { PopUpDialog } from '@flybywiresim/fbw-sdk';
+import semVerMajor from 'semver/functions/major';
 
 /**
  * Contains the ${aircraft}_build_info.json file's information in a structured way.
@@ -181,7 +181,7 @@ export class AircraftGithubVersionChecker {
     try {
       const buildInfo = await AircraftGithubVersionChecker.getBuildInfo(aircraft);
       const versionInfo = AircraftGithubVersionChecker.getVersionInfo(aircraft, buildInfo.version);
-      switch (KnowBranchNames[versionInfo.branch]) {
+      switch ((KnowBranchNames as any)[versionInfo.branch]) {
         case KnowBranchNames.rel:
           return FbwBuildEdition.Stable;
         case KnowBranchNames.dev:
@@ -224,18 +224,28 @@ export class AircraftGithubVersionChecker {
    */
   private static checkOutdated(versionInfo: VersionInfoData): boolean {
     // Set branchName to the long versions of the aircraft edition names
-    const branchName = KnowBranchNames[versionInfo.branch] || versionInfo.branch;
+    const branchName = (KnowBranchNames as any)[versionInfo.branch] || versionInfo.branch;
 
-    // Check if main version is outdated
-    if (Compare(versionInfo.version, this.releaseInfo[0].name) < 0) {
-      console.log(`New version available: ${versionInfo.version} ==> ${this.releaseInfo[0].name}`);
-      this.showVersionPopup('', versionInfo.version, this.releaseInfo[0].name);
-      return true;
+    if (branchName === KnowBranchNames.rel) {
+      const latestRelease = this.releaseInfo.find((r) => semVerMajor(r.name) === versionInfo.major);
+
+      // Check if main version is outdated
+      if (latestRelease && semVerCompare(versionInfo.version, latestRelease.name) < 0) {
+        console.log(`New version available: ${versionInfo.version} ==> ${latestRelease.name}`);
+        this.showVersionPopup('', versionInfo.version, latestRelease.name);
+        return true;
+      }
+
+      return false;
     }
 
     // If the user's version is equal or newer than the latest release then check if
     // the edition is Development or Experimental and if the commit is older than
     // {maxAge} days after the latest release to show notification
+
+    if (!this.buildInfo || this.buildInfo.sha === 'unknown') {
+      return false;
+    }
 
     const maxAge = 3;
     const timestampAircraft: Date = new Date(this.buildInfo.built);
@@ -259,7 +269,7 @@ export class AircraftGithubVersionChecker {
    * @param days
    * @private
    */
-  private static addDays(date: Date, days): Date {
+  private static addDays(date: Date, days: number): Date {
     const result = new Date(date);
     result.setDate(date.getDate() + days);
     return result;
@@ -294,7 +304,7 @@ export class AircraftGithubVersionChecker {
    * @param releaseVersion
    * @private
    */
-  private static showVersionPopup(branchName, currentVersion, releaseVersion) {
+  private static showVersionPopup(branchName: string, currentVersion: string, releaseVersion: string) {
     // TODO: Make translation work - move translation from EFB to shared
     const dialog = new PopUpDialog();
     dialog.showInformation(

--- a/fbw-common/src/systems/shared/src/AircraftGithubVersionChecker.ts
+++ b/fbw-common/src/systems/shared/src/AircraftGithubVersionChecker.ts
@@ -57,8 +57,6 @@ export class AircraftGithubVersionChecker {
 
   private static newestCommit: CommitInfo;
 
-  private static newestExpCommit: CommitInfo;
-
   private static buildInfo?: BuildInfo;
 
   /** Promises awaiting fetching of the build info. */
@@ -83,7 +81,7 @@ export class AircraftGithubVersionChecker {
     await this.initialize(aircraft);
 
     // assert all version info is available
-    if (!(this.buildInfo && this.releaseInfo && this.newestCommit && this.newestExpCommit)) {
+    if (!(this.buildInfo && this.releaseInfo && this.newestCommit)) {
       console.error('Not all version information available. Skipping version check.');
       return false;
     }
@@ -214,7 +212,6 @@ export class AircraftGithubVersionChecker {
   private static async initialize(aircraft: string) {
     this.releaseInfo = await GitVersions.getReleases('flybywiresim', aircraft, false, 0, 1);
     this.newestCommit = await GitVersions.getNewestCommit('flybywiresim', aircraft, 'fs2020-master');
-    this.newestExpCommit = await GitVersions.getNewestCommit('flybywiresim', aircraft, 'experimental');
     this.buildInfo = await AircraftGithubVersionChecker.getBuildInfo(aircraft);
   }
 
@@ -249,15 +246,6 @@ export class AircraftGithubVersionChecker {
       this.addDays(timestampAircraft, maxAge) < this.newestCommit.timestamp
     ) {
       this.showNotification(versionInfo, timestampAircraft, branchName, this.newestCommit);
-      return true;
-    }
-
-    if (
-      branchName === KnowBranchNames.exp &&
-      versionInfo.commit !== this.newestExpCommit.shortSha &&
-      this.addDays(timestampAircraft, maxAge) < this.newestExpCommit.timestamp
-    ) {
-      this.showNotification(versionInfo, timestampAircraft, branchName, this.newestExpCommit);
       return true;
     }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #10726 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Fix the master branch check to use the right branch.
- Remove exp from FS2020
- Fix the stable version check (to be ported to master/FS2024 as well).
- Fix type issues in the file and enable strict.

QA not really possible, so this will need some extra care in review.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
