### PR TITLE
fix(a380x/fg): managed speed target not being limited by characteristic speeds

### DIFF
--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcAircraftInterface.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcAircraftInterface.ts
@@ -26,7 +26,7 @@ import {
 } from '@flybywiresim/fbw-sdk';
 import { FlapConf } from '@fmgc/guidance/vnav/common';
 import { MmrRadioTuningStatus } from '@fmgc/navigation/NavaidTuner';
-import { Vmcl, Vmo, maxCertifiedAlt, maxZfw } from '@shared/PerformanceConstants';
+import { Vmcl, maxCertifiedAlt, maxZfw } from '@shared/PerformanceConstants';
 import { FmgcFlightPhase } from '@shared/flightphase';
 import { FmgcDataService } from './fmgc';
 import { ADIRS } from '../shared/Adirs';
@@ -1117,19 +1117,10 @@ export class FmcAircraftInterface {
 
     let Vtap = 0;
     let limitedByVls = false;
-    // VLS protection
+    // Minimum speed protection
     if (this.managedSpeedTarget) {
       const vls = this.speedVls.get();
-      if (this.managedSpeedTarget < vls) {
-        Vtap = vls;
-        limitedByVls = true;
-      }
-    }
-
-    if (!Vtap && this.managedSpeedTarget) {
-      // Overspeed protection and limiting characteristic speed protection
-      const vMax = this.speedVmax.get();
-      const vMin = takeoffGoAround
+      const limitingCharacteristicSpeed = takeoffGoAround
         ? null
         : this.getLimitingCharacteristicSpeed(
             phase === FmgcFlightPhase.Approach ||
@@ -1138,7 +1129,12 @@ export class FmcAircraftInterface {
               this.activeVerticalMode === VerticalMode.ROLL_OUT ||
               this.activeVerticalMode === VerticalMode.LAND,
           );
-      Vtap = Math.min(Math.max(this.managedSpeedTarget ?? Vmo - 5, vMin ?? 0), vMax - 5);
+      const vMax = this.speedVmax.get();
+      // Select the most limiting characteristic speed between speed target, VLS and current flap configuration. Limit by vmax.
+      Vtap = Math.min(Math.max(this.managedSpeedTarget, Math.max(vls, limitingCharacteristicSpeed ?? 0)), vMax - 5);
+      if (Vtap === vls) {
+        limitedByVls = true;
+      }
     }
     this.speedsManagedPfd.set(vPfd);
     this.speedsManagedAthr.set(Vtap);

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcAircraftInterface.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FmcAircraftInterface.ts
@@ -1131,8 +1131,9 @@ export class FmcAircraftInterface {
           );
       const vMax = this.speedVmax.get();
       // Select the most limiting characteristic speed between speed target, VLS and current flap configuration. Limit by vmax.
-      Vtap = Math.min(Math.max(this.managedSpeedTarget, Math.max(vls, limitingCharacteristicSpeed ?? 0)), vMax - 5);
-      if (Vtap === vls) {
+      Vtap = MathUtils.clamp(this.managedSpeedTarget, limitingCharacteristicSpeed ?? 0, vMax - 5);
+      if (Vtap < vls) {
+        Vtap = vls;
         limitedByVls = true;
       }
     }


### PR DESCRIPTION


<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes a regression introduced in #10604 not caught by QA where the flight envelope speed would not be limited by  the characteristic speed if the speed target was below VLS.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
QA not needed, was tested by dan. Commit has been cherry picked from #10642 (as no full QA on the PR yet and somewhat annoying issue).
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
