### PR TITLE
fix: fs2024 aircraft version check (dev and stable)

### DIFF
--- a/fbw-a32nx/src/systems/extras-host/modules/version_check/VersionCheck.ts
+++ b/fbw-a32nx/src/systems/extras-host/modules/version_check/VersionCheck.ts
@@ -21,7 +21,7 @@ export class VersionCheck {
 
   public startPublish(): void {
     console.log('VersionCheck: startPublish()');
-    AircraftGithubVersionChecker.checkVersion(this.aircraftProjectPrefix);
+    AircraftGithubVersionChecker.checkVersion(this.aircraftProjectPrefix, this.bus);
   }
 
   public update(): void {

--- a/fbw-common/src/systems/shared/src/AircraftGithubVersionChecker.ts
+++ b/fbw-common/src/systems/shared/src/AircraftGithubVersionChecker.ts
@@ -91,9 +91,6 @@ export class AircraftGithubVersionChecker {
       const versionInfo = this.getVersionInfo(aircraft, this.buildInfo.version);
       if (this.checkOutdated(versionInfo, bus)) {
         this.setOutdatedVersionFlag(true);
-        console.log(`Aircraft ${aircraft} - version outdated`);
-      } else {
-        console.log(`Aircraft ${aircraft} - version ok`);
       }
       this.versionChecked = true;
     } catch (error) {
@@ -234,7 +231,6 @@ export class AircraftGithubVersionChecker {
 
       // Check if main version is outdated
       if (latestRelease && semVerCompare(versionInfo.version, latestRelease.name) < 0) {
-        console.log(`New version available: ${versionInfo.version} ==> ${this.releaseInfo[0].name}`);
         this.showVersionPopup(bus, 'stable', versionInfo.version, latestRelease.name);
         return true;
       }

--- a/fbw-common/src/systems/shared/src/AircraftGithubVersionChecker.ts
+++ b/fbw-common/src/systems/shared/src/AircraftGithubVersionChecker.ts
@@ -1,12 +1,13 @@
-// @ts-strict-ignore
-// Copyright (c) 2023-2024 FlyByWire Simulations
+// Copyright (c) 2023-2026 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
 /* eslint-disable no-console */
 /* eslint-disable no-underscore-dangle */
-import Compare from 'semver/functions/compare';
 import { CommitInfo, GitVersions, ReleaseInfo } from '@flybywiresim/api-client';
-import { PopUpDialog } from '@flybywiresim/fbw-sdk';
+import { PopupControlEvents, PopupUuid } from '@flybywiresim/fbw-sdk';
+import { EventBus } from '@microsoft/msfs-sdk';
+import semVerCompare from 'semver/functions/compare';
+import semVerMajor from 'semver/functions/major';
 
 /**
  * Contains the ${aircraft}_build_info.json file's information in a structured way.
@@ -72,9 +73,7 @@ export class AircraftGithubVersionChecker {
    *
    * @returns true if the aircraft version has been checked, false if no check has been commenced.
    */
-  public static async checkVersion(aircraft: string): Promise<boolean> {
-    console.log(`Checking aircraft version for A/C project: ${aircraft}`);
-
+  public static async checkVersion(aircraft: string, bus: EventBus): Promise<boolean> {
     // reset previous check data
     this.versionChecked = false;
     this.setOutdatedVersionFlag(false);
@@ -90,7 +89,7 @@ export class AircraftGithubVersionChecker {
 
     try {
       const versionInfo = this.getVersionInfo(aircraft, this.buildInfo.version);
-      if (this.checkOutdated(versionInfo)) {
+      if (this.checkOutdated(versionInfo, bus)) {
         this.setOutdatedVersionFlag(true);
         console.log(`Aircraft ${aircraft} - version outdated`);
       } else {
@@ -183,7 +182,7 @@ export class AircraftGithubVersionChecker {
     try {
       const buildInfo = await AircraftGithubVersionChecker.getBuildInfo(aircraft);
       const versionInfo = AircraftGithubVersionChecker.getVersionInfo(aircraft, buildInfo.version);
-      switch (KnowBranchNames[versionInfo.branch]) {
+      switch ((KnowBranchNames as any)[versionInfo.branch]) {
         case KnowBranchNames.rel:
           return FbwBuildEdition.Stable;
         case KnowBranchNames.dev:
@@ -225,20 +224,31 @@ export class AircraftGithubVersionChecker {
    * @returns true if the version is outdated, false otherwise.
    * @private
    */
-  private static checkOutdated(versionInfo: VersionInfoData): boolean {
+  private static checkOutdated(versionInfo: VersionInfoData, bus: EventBus): boolean {
     // Set branchName to the long versions of the aircraft edition names
-    const branchName = KnowBranchNames[versionInfo.branch] || versionInfo.branch;
+    const branchName = (KnowBranchNames as any)[versionInfo.branch] || versionInfo.branch;
 
-    // Check if main version is outdated
-    if (Compare(versionInfo.version, this.releaseInfo[0].name) < 0) {
-      console.log(`New version available: ${versionInfo.version} ==> ${this.releaseInfo[0].name}`);
-      this.showVersionPopup('', versionInfo.version, this.releaseInfo[0].name);
-      return true;
+    if (branchName === KnowBranchNames.rel) {
+      // The major version indicates FS2020 or FS2024
+      const latestRelease = this.releaseInfo.find((r) => semVerMajor(r.name) === versionInfo.major);
+
+      // Check if main version is outdated
+      if (latestRelease && semVerCompare(versionInfo.version, latestRelease.name) < 0) {
+        console.log(`New version available: ${versionInfo.version} ==> ${this.releaseInfo[0].name}`);
+        this.showVersionPopup(bus, 'stable', versionInfo.version, latestRelease.name);
+        return true;
+      }
+
+      return false;
     }
 
     // If the user's version is equal or newer than the latest release then check if
     // the edition is Development or Experimental and if the commit is older than
     // {maxAge} days after the latest release to show notification
+
+    if (!this.buildInfo || this.buildInfo.sha === 'unknown') {
+      return false;
+    }
 
     const maxAge = 3;
     const timestampAircraft: Date = new Date(this.buildInfo.built);
@@ -248,7 +258,7 @@ export class AircraftGithubVersionChecker {
       versionInfo.commit !== this.newestCommit.shortSha &&
       this.addDays(timestampAircraft, maxAge) < this.newestCommit.timestamp
     ) {
-      this.showNotification(versionInfo, timestampAircraft, branchName, this.newestCommit);
+      this.showNotification(bus, versionInfo, timestampAircraft, branchName, this.newestCommit);
       return true;
     }
 
@@ -257,7 +267,7 @@ export class AircraftGithubVersionChecker {
       versionInfo.commit !== this.newestExpCommit.shortSha &&
       this.addDays(timestampAircraft, maxAge) < this.newestExpCommit.timestamp
     ) {
-      this.showNotification(versionInfo, timestampAircraft, branchName, this.newestExpCommit);
+      this.showNotification(bus, versionInfo, timestampAircraft, branchName, this.newestExpCommit);
       return true;
     }
 
@@ -271,7 +281,7 @@ export class AircraftGithubVersionChecker {
    * @param days
    * @private
    */
-  private static addDays(date: Date, days): Date {
+  private static addDays(date: Date, days: number): Date {
     const result = new Date(date);
     result.setDate(date.getDate() + days);
     return result;
@@ -287,6 +297,7 @@ export class AircraftGithubVersionChecker {
    * @private
    */
   private static showNotification(
+    bus: EventBus,
     versionInfo: VersionInfoData,
     timestampAircraft: Date,
     branchName: string,
@@ -294,8 +305,7 @@ export class AircraftGithubVersionChecker {
   ) {
     const currentVersionStr = `${versionInfo.version}-${versionInfo.branch}.${versionInfo.commit} (${timestampAircraft.toUTCString()})`;
     const releaseVersionStr = `${versionInfo.version}-${versionInfo.branch}.${commitInfo.shortSha} (${commitInfo.timestamp.toUTCString()})`;
-    console.log(`New commit available: ${currentVersionStr} ==> ${releaseVersionStr}`);
-    this.showVersionPopup(branchName, currentVersionStr, releaseVersionStr);
+    this.showVersionPopup(bus, branchName, currentVersionStr, releaseVersionStr);
   }
 
   /**
@@ -306,22 +316,20 @@ export class AircraftGithubVersionChecker {
    * @param releaseVersion
    * @private
    */
-  private static showVersionPopup(branchName, currentVersion, releaseVersion) {
+  private static showVersionPopup(bus: EventBus, branchName: string, currentVersion: string, releaseVersion: string) {
     // TODO: Make translation work - move translation from EFB to shared
-    const dialog = new PopUpDialog();
-    dialog.showInformation(
-      'New Version Available',
-      `<div style="font-size: 120%; text-align: left;">
-                        You are using the ${branchName} edition with version: <br>
-                        <strong>${currentVersion}</strong><br><br>
+    const publisher = bus.getPublisher<PopupControlEvents>();
 
-                        Latest ${branchName} version is <br>
-                        <strong>${releaseVersion}</strong><br/><br/>
-
-                        Please update your aircraft using the FlyByWire Installer.
-                    </div>`,
-      'normal',
-      () => {},
+    publisher.pub(
+      'popup_enqueue_popup',
+      {
+        uuid: PopupUuid.VersionOutdated,
+        title: 'New Version Available',
+        message: `You are using the outdated ${branchName} edition ${currentVersion}, please update to the latest ${releaseVersion} using the FlyByWire Installer.`,
+        timeout: 5_000,
+      },
+      true,
+      false,
     );
   }
 

--- a/fbw-common/src/systems/shared/src/popup/PopupTypes.ts
+++ b/fbw-common/src/systems/shared/src/popup/PopupTypes.ts
@@ -5,6 +5,7 @@ export enum PopupUuid {
   MsfsVersion = 'msfs-version',
   /** Special popup with the pause/unpause functions. */
   TodPause = 'tod-pause',
+  VersionOutdated = 'version-outdated',
 }
 
 export interface PopupDefinition {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes the version check after the branch re-structuring for FS2020/2024 split, including using the new popup system so it's actually seen, and removes the extraneous logging noted in the previous review.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
