### PR TITLE
fix(a32nx/fmgc): increase compat of FMA ATHR LVars to previous values

### DIFF
--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -4583,6 +4583,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_EFIS_{side}_NAVAID_{1|2}_MODE
     - Enum
+    - Deprecated
     - Provides the selected NAVAIDs for display on the EFIS
       Value | Meaning
       --- | ---
@@ -4595,6 +4596,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_EFIS_{side}_ND_MODE
     - Enum
+    - Deprecated
     - Provides the selected navigation display mode for the EFIS
       Value | Meaning
       --- | ---
@@ -4609,6 +4611,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_EFIS_{side}_ND_RANGE
     - Enum
+    - Deprecated
     - Provides the selected navigation display range for the EFIS
       Value | Meaning
       --- | ---
@@ -4624,6 +4627,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_EFIS_{side}_OPTION
     - Flags
+    - Deprecated
     - Provides a bitmask of the selected EFIS option/overlays
       Value | Meaning
       --- | ---
@@ -4639,15 +4643,18 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_TRK_FPA_MODE_ACTIVE
     - Bool
+    - Deprecated
     - True if TRK/FPA mode is active
 
 - A32NX_AUTOPILOT_HEADING_SELECTED
     - Number (Degrees)
+    - Deprecated
     - Indicates the selected heading on the FCU, instantly updated
     - In case of managed heading mode, the value is -1
 
 - A32NX_FCU_ALT_MANAGED
     - Boolean
+    - Deprecated
     - Indicates if managed altitude mode is active (dot)
       State | Value
       --- | ---
@@ -4656,6 +4663,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_FCU_VS_MANAGED
     - Boolean
+    - Deprecated
     - Indicates if managed VS/FPA mode is active
       State | Value
       --- | ---
@@ -4664,10 +4672,12 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_AUTOPILOT_NOSEWHEEL_DEMAND
     - Percent over 100
+    - Deprecated
     - Steering demand from autopilot to BSCU [-1;1] -1 left, 0 middle
 
 - A32NX_FMA_LATERAL_MODE
     - Enum
+    - Deprecated
     - Indicates **engaged** lateral mode of the Flight Director / Autopilot
       Mode | Value
       --- | ---
@@ -4686,6 +4696,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_FMA_LATERAL_ARMED
     - Bitmask
+    - Deprecated
     - Indicates **armed** lateral mode of the Flight Director / Autopilot
       Mode | Bit
       --- | ---
@@ -4694,6 +4705,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_FMA_VERTICAL_MODE
     - Enum
+    - Deprecated
     - Indicates **engaged** vertical mode of the Flight Director / Autopilot
       Mode | Value
       --- | ---
@@ -4720,6 +4732,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_FMA_VERTICAL_ARMED
     - Bitmask
+    - Deprecated
     - Indicates **armed** vertical mode of the Flight Director / Autopilot
       Mode | Bit
       --- | ---
@@ -4733,6 +4746,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_FMA_EXPEDITE_MODE
     - Boolean
+    - Deprecated
     - Indicates if expedite mode is engaged
       State | Value
       --- | ---
@@ -4741,6 +4755,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_AUTOPILOT_AUTOLAND_WARNING
     - Boolean
+    - Deprecated
     - Indicates if Autoland warning light is illuminated
     - Possible values:
       State | Value
@@ -4750,6 +4765,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_AUTOPILOT_ACTIVE
     - Boolean
+    - Deprecated
     - Indicates if any Autopilot is engaged
     - Possible values:
       State | Value
@@ -4759,6 +4775,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_AUTOPILOT_{index}_ACTIVE
     - Boolean
+    - Deprecated
     - Indicates if Autopilot {index} is enaged, first Autopilot has the index 1
     - Possible values:
       State | Value
@@ -4768,11 +4785,13 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_AUTOPILOT_H_DOT_RADIO
     - Number (Feet per minute)
+    - Deprecated
     - Indicates the current estimated vertical speed relative to the runway
     - Important: the signal is only usable above the runway and is not to be used elsewhere
 
 - A32NX_AUTOTHRUST_STATUS
     - Enum
+    - Deprecated
     - Indicates the current status of the ATHR system
       Mode | Value
       --- | ---
@@ -4782,6 +4801,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_AUTOTHRUST_MODE
     - Enum
+    - Deprecated
     - Indicates the current thrust mode of the ATHR system
       Mode | Value
       --- | ---
@@ -4802,19 +4822,23 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 - A32NX_AUTOPILOT_SPEED_SELECTED
     - SPEED mode: 100 to 399 (knots)
     - MACH mode: 0.10 to 0.99 (M)
+    - Deprecated
     - Indicates the selected speed on the FCU, instantly updated
     - In case of managed speed mode, the value is -1
 
 - A32NX_AUTOPILOT_FPA_SELECTED
     - Number (Degrees)
+    - Deprecated
     - Indicates the selected FPA on the FCU, instantly updated
 
 - A32NX_AUTOPILOT_VS_SELECTED
     - Number (Feet per minute)
+    - Deprecated
     - Indicates the selected V/S on the FCU, instantly updated
 
 - A32NX_FCU_SPD_MANAGED_DASHES
     - Boolean
+    - Deprecated
     - Indicates if managed speed/mach mode is active and a numerical value is not displayed
       State | Value
       --- | ---
@@ -4823,6 +4847,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_FCU_SPD_MANAGED_DOT
     - Boolean
+    - Deprecated
     - Indicates if managed speed/mach mode is active
       State | Value
       --- | ---
@@ -4831,6 +4856,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_FCU_HDG_MANAGED_DASHES
     - Boolean
+    - Deprecated
     - Indicates if managed heading mode is active and a numerical value is not displayed
       State | Value
       --- | ---
@@ -4839,6 +4865,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_FCU_HDG_MANAGED_DOT
     - Boolean
+    - Deprecated
     - Indicates if managed heading mode is active or armed
       State | Value
       --- | ---
@@ -4847,6 +4874,7 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
 
 - A32NX_AUTOTHRUST_MODE_MESSAGE
     - Enum
+    - Deprecated
     - Indicates ATHR related message to be displayed on the PFD
       Mode | Value
       --- | ---

--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -4786,7 +4786,18 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
       Mode | Value
       --- | ---
       NONE | 0
+      MAN_TOGA | 1
+      MAN_FLEX | 3
+      MAN_MCT | 5
+      MAN_THR | 6
+      SPEED | 7
+      MACH | 8
+      THR_MCT | 9
+      THR_CLB | 10
+      THR_LVR | 11
+      THR_IDLE | 12
       A_FLOOR | 13
+      TOGA_LK | 14
 
 - A32NX_AUTOPILOT_SPEED_SELECTED
     - SPEED mode: 100 to 399 (knots)
@@ -4841,3 +4852,5 @@ Use the `A32NXEcpBusPublisher` and `A32NXEcpBusEvents` for these in A32NX code.
       --- | ---
       NONE | 0
       LVR_CLB | 3
+      LVR_MCT | 4
+      LVR_ASYM | 5

--- a/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
@@ -1345,7 +1345,7 @@ bool FlyByWireInterface::updateAdirs(int adirsIndex) {
 
 bool FlyByWireInterface::updateTcas() {
   tcasBusOutputs.sensitivity_level = Arinc429Utils::fromSimVar(idTcasModeWord->get());
-  tcasBusOutputs.vertical_resolution_advisory =Arinc429Utils::fromSimVar(idTcasVerticalAdvisoryWord->get());
+  tcasBusOutputs.vertical_resolution_advisory = Arinc429Utils::fromSimVar(idTcasVerticalAdvisoryWord->get());
 
   if (clientDataEnabled) {
     simConnectInterface.setClientDataTcas(tcasBusOutputs);
@@ -2023,13 +2023,39 @@ bool FlyByWireInterface::updateFmgcShim(double sampleTime) {
   }
 
   int athrMode = 0;
-  if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 17, false)) {
+  if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 11, false)) {
+    athrMode = 1;
+  } else if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 13, false)) {
+    athrMode = 3;
+  } else if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 12, false) && atEngaged && !atActive) {
+    athrMode = 5;
+  } else if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 15, false) && atEngaged && !atActive) {
+    athrMode = 6;
+  } else if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 19, false)) {
+    athrMode = 7;
+  } else if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 20, false)) {
+    athrMode = 8;
+  } else if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 12, false) && atEngaged && atActive) {
+    athrMode = 9;
+  } else if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 14, false)) {
+    athrMode = 10;
+  } else if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 15, false) && atEngaged && atActive) {
+    athrMode = 11;
+  } else if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 16, false)) {
+    athrMode = 12;
+  } else if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 17, false)) {
     athrMode = 13;
+  } else if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 18, false)) {
+    athrMode = 14;
   }
 
   int athrModeMessage = 0;
   if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 22, false)) {
     athrModeMessage = 3;
+  } else if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 23, false)) {
+    athrModeMessage = 4;
+  } else if (Arinc429Utils::bitFromValueOr(fcuBusOutputs.ats_fma_discrete_word, 21, false)) {
+    athrModeMessage = 5;
   }
 
   // Autoland warning


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Re-adds most values for `A32NX_AUTOTHRUST_MODE` and `A32NX_AUTOTHRUST_MODE_MESSAGE` that were dropped in #7587, to fix backward compatability. For clarification, these Lvars are still deprecated. 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo**, **flybywire-aircraft-a380-842 (4K)** or **flybywire-aircraft-a380-842 (8K)** download link at the bottom of the page
