### PR TITLE
fix(a32nx/sd): clamp cruise cabin vs gauge by sign

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/SD/Pages/Crz/Crz.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Pages/Crz/Crz.tsx
@@ -5,7 +5,7 @@
 import React, { useEffect, useState } from 'react';
 import { GaugeComponent, GaugeMarkerComponent, splitDecimals } from '@instruments/common/gauges';
 import { UnitType } from '@microsoft/msfs-sdk';
-import { useSimVar, useArinc429Var, usePersistentSetting } from '@flybywiresim/fbw-sdk-react';
+import { MathUtils, useSimVar, useArinc429Var, usePersistentSetting } from '@flybywiresim/fbw-sdk-react';
 import { fuelForDisplay } from '../../Common/FuelFunctions';
 
 import './Crz.scss';
@@ -303,7 +303,7 @@ export const PressureComponent = () => {
             textNudgeY={-10}
           />
           <GaugeMarkerComponent
-            value={Math.abs(((cabinVs / 50) * 50) / 1000) <= 2.25 ? ((cabinVs / 50) * 50) / 1000 : 2.25}
+            value={MathUtils.clamp((Math.round(cabinVs / 50) * 50) / 1000, -2.25, 2.25)}
             x={vsx}
             y={y}
             min={-2}


### PR DESCRIPTION
Fixes #10672

## Summary of Changes
Clamps the A32NX SD CRUISE page cabin vertical speed gauge with the correct sign when values exceed the display scale.

Previously, excessive negative cabin V/S values saturated to +2.25, which could draw the needle at the top of the gauge. This now matches the signed clamp behavior already used by the CAB PRESS page.

## Testing instructions
- Turn on MAN V/S CTL.
- Drive cabin V/S below the lower gauge scale.
- Verify the CRUISE page CAB V/S needle saturates at the bottom of the scale instead of wrapping to the top.