### PR TITLE
fix(a32nx/mcdu): reject airway waypoint mismatch

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AirwaysFromWaypointPage.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AirwaysFromWaypointPage.ts
@@ -152,15 +152,20 @@ export class A320_Neo_CDU_AirwaysFromWaypointPage {
                   inAlternate,
                 );
 
-                A320_Neo_CDU_AirwaysFromWaypointPage.ShowPage(
-                  mcdu,
-                  reviseIndex,
-                  undefined,
-                  result ? 1 : -1,
-                  forPlan,
-                  inAlternate,
-                  planIndexToEdit,
-                );
+                if (result) {
+                  A320_Neo_CDU_AirwaysFromWaypointPage.ShowPage(
+                    mcdu,
+                    reviseIndex,
+                    undefined,
+                    1,
+                    forPlan,
+                    inAlternate,
+                    planIndexToEdit,
+                  );
+                } else {
+                  mcdu.setScratchpadMessage(NXSystemMessages.awyWptMismatch);
+                  scratchpadCallback();
+                }
               } else {
                 mcdu.setScratchpadMessage(NXSystemMessages.awyWptMismatch);
                 scratchpadCallback();


### PR DESCRIPTION
## Summary
- keep the AIRWAYS page on the pending airway entry when the entered TO waypoint is not on that airway
- show AWY/WPT MISMATCH instead of redrawing back to a blank VIA entry
- preserve the existing successful airway termination flow

Fixes #10512

## Testing
- git diff --check
- node .\node_modules\eslint\bin\eslint.js fbw-a32nx/src/systems/instruments/src/MCDU/legacy_pages/A320_Neo_CDU_AirwaysFromWaypointPage.ts
- mach build --config fbw-a32nx/mach.config.js --work-in-config-dir --filter MCDU