### PR TITLE
fix(a380x): Amber boxes on PERF APPR page -2020

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -17,6 +17,7 @@
 1. [A380X/MFD] Fix TOW on FUEL&LOAD page showing gross weight instead of takeoff weight in flight - @HendersonTyler
 1. [PFD] Reduced size of white FMA messages on PFD - @BravoMike99 (bruno_pt99)
 1. [A380X/MFD] Dash TAXI fuel entry on FUEL&LOAD page after takeoff - @HendersonTyler
+1. [A380X/MFD] Show approach QNH and TEMP as mandatory only when closer than 180 NM to destination or when predictions are unavailable - @matze-tech (matze2346)
 
 ## 2020.15.0
 

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/fmgc.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/fmgc.ts
@@ -501,8 +501,8 @@ export class FmgcDataService implements Fmgc {
   }
 
   /** in nautical miles. null if not set */
-  getDistanceToDestination(): number | null {
-    return this.guidanceController?.vnavDriver.getDestinationPrediction()?.distanceFromAircraft ?? null;
+  getDistanceToDestination(forPlan = FlightPlanIndex.Active): number | null {
+    return this.guidanceController?.getAlongTrackDistanceToDestination(forPlan) ?? null;
   }
 
   /** In percentage. Null if not set */

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/MfdFmsPerf.tsx
@@ -104,6 +104,8 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
     (it) => it === FlightPlanIndex.Active || it === FlightPlanIndex.Temporary,
   );
 
+  private readonly approachParametersMandatory = Subject.create<boolean>(false);
+
   private readonly visibilityConsideringFlightPlanIndex = this.loadedFlightPlanIndex.map((it) =>
     it === FlightPlanIndex.Active || it === FlightPlanIndex.Temporary ? 'inherit' : 'hidden',
   );
@@ -1017,8 +1019,10 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
   private drawPage(tab?: FlightPhaseTabIndex) {
     this.loadFlightPlanPerformanceData();
 
-    // Update REC MAX FL, OPT FL. Only for active and temporary flightplan.
     const fpIndex = this.loadedFlightPlanIndex.get();
+    const isActiveOrTmpy = fpIndex === FlightPlanIndex.Active || fpIndex === FlightPlanIndex.Temporary;
+
+    // Update REC MAX FL, OPT FL. Only for active and temporary flightplan.
     if (fpIndex === FlightPlanIndex.Active || fpIndex === FlightPlanIndex.Temporary) {
       const recMaxFl = this.props.fmcService.master.getRecMaxFlightLevel();
       this.recMaxFl.set(recMaxFl && Number.isFinite(recMaxFl) ? recMaxFl.toFixed(0) : '---');
@@ -1320,7 +1324,10 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
       this.approachGreenDotSpeed.set(this.props.fmcService.master.getApproachGreenDotSpeed(fpIndex) ?? null);
     }
     if (selectedTabIndex === FlightPhaseTabIndex.Approach) {
-      // Update APPR page
+      // Update APPR page // FIXME: Logic should be in FMS code
+      const distanceToDest = this.props.fmcService.master.fmgc.getDistanceToDestination(fpIndex);
+      this.approachParametersMandatory.set(isActiveOrTmpy && (distanceToDest ?? 0) <= 180);
+
       this.approachVappPilotEntry.set(this.loadedFlightPlan?.performanceData.pilotVapp.get() !== null);
       this.apprLandingWeight.set(this.props.fmcService.master.getLandingWeight(fpIndex) ?? NaN);
       this.approachVapp.set(this.props.fmcService.master.getApproachVapp(fpIndex) ?? null);
@@ -1347,6 +1354,8 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
         this.towerHeadwind.set(null);
         this.apprCrosswind.set('---');
       }
+    } else {
+      this.approachParametersMandatory.set(false);
     }
   }
 
@@ -3113,7 +3122,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                               this.loadedFlightPlanIndex.get(),
                             );
                           }}
-                          mandatory={this.mandatoryAndActiveFpln}
+                          mandatory={this.approachParametersMandatory}
                           readonlyValue={this.approachTemperature}
                           containerStyle="width: 125px;"
                           alignText="flex-end"
@@ -3144,7 +3153,7 @@ export class MfdFmsPerf extends FmsPage<MfdFmsPerfProps> {
                             );
                             SimVar.SetSimVarValue('L:A32NX_DESTINATION_QNH', 'Millibar', qnhMillibar);
                           }}
-                          mandatory={this.mandatoryAndActiveFpln}
+                          mandatory={this.approachParametersMandatory}
                           readonlyValue={this.approachQnh}
                           containerStyle="width: 125px;"
                           alignText="flex-end"


### PR DESCRIPTION

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Cherry pick of #10778 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): bruno_pt99

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
With no flightplan, verify temperature and QNH boxes are amber on the MFD PERF APPR page of the active flightplan.
Insert a flightplan with less than 180NM of distance between the origin and destination, check that the fields are amber when empty.
Insert a flightplan with more than 180NM of distance between the origin and destination, check that the fields are cyan.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
