### PR TITLE
fix(a380x/MFD): LS not dashed on arr page if rwy has no LS

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -46,6 +46,7 @@
 1. [A380X/MFD] Show approach QNH and TEMP as mandatory only when closer than 180 NM to destination or when predictions are unavailable - @matze-tech (matze2346)
 1. [A380X/FWS] Improve ROW/ROP callouts, changed autobrake off master caution light to 3 seconds - @BravoMike99 (bruno_pt99)
 1. [A380X/OIT] Restart FLT OPS startup sequence after laptop power loss - @HendersonTyler (Tyler Henderson)
+1. [A380X/MFD] Fix LS field remaining blank on F-PLN arrival page when no landing system is available or selected - @matze-tech (matze2346)
 
 ## 2024.1.0
 

--- a/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnArr.tsx
+++ b/fbw-a380x/src/systems/instruments/src/MFD/pages/FMS/F-PLN/MfdFmsFplnArr.tsx
@@ -58,9 +58,9 @@ export class MfdFmsFplnArr extends FmsPage<MfdFmsFplnArrProps> {
 
   private readonly approachName = Subject.create<string>('');
 
-  private readonly approachLsFrequencyChannel = Subject.create<string>('');
+  private readonly approachLsFrequencyChannel = Subject.create<string>('---.--');
 
-  private readonly approachLsIdent = Subject.create('');
+  private readonly approachLsIdent = Subject.create('----');
 
   private readonly via = Subject.create<string>('');
 
@@ -175,8 +175,8 @@ export class MfdFmsFplnArr extends FmsPage<MfdFmsFplnArrProps> {
         this.approachName.set(getApproachName(flightPlan.approach, false));
         const ls = flightPlan.approach ? LandingSystemUtils.getLsFromApproach(flightPlan.approach) : undefined;
         // FIXME handle non-localizer types
-        this.approachLsFrequencyChannel.set(ls?.frequency.toFixed(2) ?? '');
-        this.approachLsIdent.set(ls?.ident ?? '');
+        this.approachLsFrequencyChannel.set(ls?.frequency.toFixed(2) ?? '---.--');
+        this.approachLsIdent.set(ls?.ident ?? '----');
         const isRnp = !!flightPlan.approach.authorisationRequired;
 
         if (flightPlan.availableApproachVias.length > 0) {
@@ -224,12 +224,12 @@ export class MfdFmsFplnArr extends FmsPage<MfdFmsFplnArrProps> {
       } else if (flightPlan.availableApproaches?.length > 0) {
         this.approachName.set('------');
         this.approachLsFrequencyChannel.set('---.--');
-        this.approachLsIdent.set('');
+        this.approachLsIdent.set('----');
         this.viaDisabled.set(true);
       } else {
         this.approachName.set('NONE');
         this.approachLsFrequencyChannel.set('---.--');
-        this.approachLsIdent.set('');
+        this.approachLsIdent.set('----');
         this.viaDisabled.set(true);
       }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #10815 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
LS and FREQ/CHAN are now dashed when a runway does not contain a landing system on the arrival page.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): matze2346

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Open the arrival page with no runway selected and verify that LS and FREQ/CHAN are dashed.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
