### PR TITLE
fix(oanc): prevent race conditions on load/unload

### DIFF
--- a/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
+++ b/fbw-common/src/systems/instruments/src/OANC/Oanc.tsx
@@ -25,6 +25,7 @@ import {
   AmdbFeatureTypeStrings,
   AmdbProjection,
   AmdbProperties,
+  AmdbResponse,
   Arinc429LocalVarConsumerSubject,
   EfisNdMode,
   EfisSide,
@@ -215,6 +216,8 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
   private readonly labelManager = new OancLabelManager<T>(this);
 
   private readonly positionComputer = new OancPositionComputer<T>(this);
+
+  private opId = 0;
 
   public dataLoading = false;
 
@@ -612,6 +615,8 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
   }
 
   public unloadAirportMap(performanceModeUnload: boolean = false) {
+    this.opId++;
+
     if (!performanceModeUnload) {
       this.btvUtils.clearSelection();
     }
@@ -637,6 +642,8 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
     this.airportLoading.set(true);
 
     this.unloadAirportMap(performanceModeUnload);
+
+    const opId = this.opId;
 
     if (!icao) {
       this.dataLoading = false;
@@ -670,13 +677,29 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
     includeLayers.push(FeatureTypeString.PaintedCenterline);
     includeLayers.push(FeatureTypeString.RunwayThreshold);
 
-    const data = await this.amdbClient.getAirportData(icao, includeLayers, undefined);
-    const wgs84ArpDat = await this.amdbClient.getAirportData(
-      icao,
-      [FeatureTypeString.AerodromeReferencePoint],
-      undefined,
-      AmdbProjection.Epsg4326,
-    );
+    let data!: AmdbResponse;
+    let wgs84ArpDat!: AmdbResponse;
+    try {
+      data = await this.amdbClient.getAirportData(icao, includeLayers, undefined);
+      wgs84ArpDat = await this.amdbClient.getAirportData(
+        icao,
+        [FeatureTypeString.AerodromeReferencePoint],
+        undefined,
+        AmdbProjection.Epsg4326,
+      );
+    } catch (e) {
+      console.error(`[OANC](loadAirportMap) Failed to fetch airport data for ${icao}: ${e}`);
+      if (opId === this.opId) {
+        this.dataLoading = false;
+        this.airportLoading.set(false);
+      }
+      return;
+    }
+
+    if (opId !== this.opId) {
+      // A newer load or unload superseded this one, discard the result
+      return;
+    }
 
     const features = Object.values(data).reduce((acc, it) => {
       const features = it.features.map((f) => {
@@ -707,6 +730,8 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
 
     if (!wgs84ReferencePoint) {
       console.error('[OANC](loadAirportMap) Invalid airport data - aerodrome reference point not found');
+      this.dataLoading = false;
+      this.airportLoading.set(false);
       return;
     }
 
@@ -718,6 +743,8 @@ export class Oanc<T extends number> extends DisplayComponent<OancProps<T>> {
       console.error(
         '[OANC](loadAirportMap) Invalid airport data - aerodrome reference point does not contain lat/long/scale custom properties',
       );
+      this.dataLoading = false;
+      this.airportLoading.set(false);
       return;
     }
     this.arpCoordinates.set({ lat: refPointLat, long: refPointLong });


### PR DESCRIPTION
Also adds improved error handling to prevent "Please wait" staying forever

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Adds an opId to the oanc load/unload airport functionality to discard older requests in case mutliple are fired in quick succession. Might be a fix for overlayed airports being shown.

I could reproduce the issue by adding an additional delay inside the code, but not reliably with the dev version

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

A bit hard to test as the issue cannot be reproduced reliably. But you can make sure the OANS works as before and allows seleciton of multiple airports (but only one should be shown at once)


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
