### PR TITLE
fix(a380x): landing weight not present gross weight during approach phase

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -61,6 +61,7 @@
 1. [A380X/LIGHTS] Implement storm light switch function - @heclak (Heclak)
 1. [A380X/LIGHTS] Add side console lights - @heclak (Heclak)
 1. [A380X/RMP] Fixed a bug where the PILOT_TRANSMITTER_SET key event would toggle transmission rather than only setting it on - @tracernz (Mike)
+1. [A380X/FMS] Fix landing weight not updating to present gross weight during approach phase - @smchuk (smchuco)
 
 ## 2024.1.0
 

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FlightManagementComputer.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FlightManagementComputer.ts
@@ -498,28 +498,36 @@ export class FlightManagementComputer implements FmcInterface {
   }
 
   /** in kg */
-  public getLandingWeight(forPlan = FlightPlanIndex.Active): number | null {
-    const tow = this.getTakeoffWeight(forPlan);
-    const gw = this.fmgc.getGrossWeightKg();
-    const tf = this.getTripFuel(forPlan);
+ public getLandingWeight(forPlan = FlightPlanIndex.Active): number | null {
+  const plan = this.flightPlanInterface.get(forPlan);
+  const isActiveOrCopyOfActive = plan.isActiveOrCopiedFromActive();
+  const useLiveAircraftState = isActiveOrCopyOfActive && this.enginesWereStarted.get();
 
-    if (!this.enginesWereStarted.get()) {
-      // On ground, engines off
-      // LW = TOW - TRIP
-      return tow && tf ? tow - tf : null;
-    }
-    if (gw && tf && this.fmgc.getFlightPhase() >= FmgcFlightPhase.Takeoff) {
-      // In flight
-      // LW = GW - TRIP
-      return gw - tf;
-    }
-    if (gw) {
-      // Preflight, engines on
-      // LW = GW - TRIP - TAXI
-      return gw - (tf ?? 0) - (this.flightPlanInterface.get(forPlan).performanceData.taxiFuel.get() ?? 0) * 1000;
-    }
-    return null;
+  const tow = this.getTakeoffWeight(forPlan);
+  const tf = this.getTripFuel(forPlan);
+  const phase = this.fmgc.getFlightPhase();
+
+  if (!useLiveAircraftState) {
+    // LW = TOW - TRIP
+    return tow !== null && tf !== null ? tow - tf : null;
   }
+
+  const gw = this.fmgc.getGrossWeightKg(forPlan);
+
+  if (gw !== null && isActiveOrCopyOfActive && phase === FmgcFlightPhase.Approach) {
+    // APPR active: LW is the present gross weight
+    return gw;
+  }
+  if (gw !== null && tf !== null && phase >= FmgcFlightPhase.Takeoff) {
+    // LW = GW - TRIP
+    return gw - tf;
+  }
+  if (gw !== null) {
+    // LW = GW - TRIP - TAXI
+    return gw - (tf ?? 0) - (plan.performanceData.taxiFuel.get() ?? 0) * 1000;
+  }
+  return null;
+}
 
   public getTakeoffWeight(forPlan = FlightPlanIndex.Active): number | null {
     return this.flightPlanInterface.get(forPlan).performanceData.takeoffWeight?.get() ?? null;

--- a/fbw-a380x/src/systems/instruments/src/MFD/FMC/FlightManagementComputer.ts
+++ b/fbw-a380x/src/systems/instruments/src/MFD/FMC/FlightManagementComputer.ts
@@ -514,19 +514,22 @@ export class FlightManagementComputer implements FmcInterface {
 
   const gw = this.fmgc.getGrossWeightKg(forPlan);
 
-  if (gw !== null && isActiveOrCopyOfActive && phase === FmgcFlightPhase.Approach) {
-    // APPR active: LW is the present gross weight
-    return gw;
+  if (gw === null) {
+    return null;
   }
-  if (gw !== null && tf !== null && phase >= FmgcFlightPhase.Takeoff) {
-    // LW = GW - TRIP
-    return gw - tf;
-  }
-  if (gw !== null) {
-    // LW = GW - TRIP - TAXI
+  
+  if (phase < FmgcFlightPhase.Takeoff || !isActiveOrCopyOfActive) {
+    // Predicted LW = GW - TRIP - TAXI
     return gw - (tf ?? 0) - (plan.performanceData.taxiFuel.get() ?? 0) * 1000;
   }
-  return null;
+  
+  if (phase < FmgcFlightPhase.Approach) {
+    // Predicted LW = GW - TRIP
+    return gw - tf;
+  }
+  
+  // APPR active: LW is the present gross weight
+  return gw;
 }
 
   public getTakeoffWeight(forPlan = FlightPlanIndex.Active): number | null {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

Fixes #10823

## Summary of Changes

`getLandingWeight()` in `FlightManagementComputer.ts` treated the Approach
phase the same as any other in-flight phase (`phase >= FmgcFlightPhase.Takeoff`),
so it kept computing `LW = GW - TRIP` after APPR was activated instead of
showing the present gross weight, per the expected behavior in the issue.

Changes:
- LW now snaps to present gross weight specifically on `FmgcFlightPhase.Approach`
  (not `>=`, since that range also includes GoAround, where the previous
  GW-minus-trip logic still applies)
- `forPlan` is now correctly passed through to `fmgc.getGrossWeightKg(forPlan)`,
  which was previously silently defaulting to the active flight plan
- Manually created secondary flight plans (not a copy of active) now use the
  static TOW − TRIP calculation regardless of live engine state, using the
  existing `isActiveOrCopiedFromActive()` check already used elsewhere in this
  file, consistent with the "assume engines off/preflight logic" behavior
  requested in the issue

Out of scope / follow-up needed: full trip-fuel prediction for secondary
flight plans is not implemented, `getTripFuel()` still returns `null` for any
non-active plan, since VNAV doesn't compute profiles for secondary plans yet.
This is a larger feature and will be tracked as a separate issue rather than
bundled here.

## Screenshots (if necessary)

## References

## Additional context

Discord username (if different from GitHub):
smchuco

## Testing instructions

1. Load the A380X, fly to cruise/descent phase.
2. Open MFD PERF APPR page, note the LW value.
3. Activate the APPR phase (either automatically at DECEL or via ACTIVATE
   APPR).
4. Confirm LW updates to match the current GW figure (cross-check against SD
   GW readout) rather than continuing to decrease with predicted trip fuel.
5. Trigger a go-around from APPR and confirm LW reverts to predicting
   GW − TRIP rather than staying frozen at the GW snapshot.
6. Repeat with a secondary flight plan that is a copy of active, and
   separately with a manually-created secondary, to confirm the
   engines-off/preflight-style calculation applies to the latter.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
