### PR TITLE
refactor: log unknown enum values instead of panicking (2020)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -22,6 +22,25 @@
 1. [A380X/MFD] Fixed TMPY being generated upon accessing  vertical revision pages - @BravoMike99 (bruno_pt99)
 1. [A380X/MFD] Alternate flightplan or go around legs can be loaded on the vertical revision pages - @BravoMike99 (bruno_pt99)
 1. [EFB] Added a cold temperature correction calculator - @tracernz (Mike)
+1. [A380X/MFD] Show approach QNH and TEMP as mandatory only when closer than 180 NM to destination or when predictions are unavailable - @matze-tech (matze2346)
+1. [A380X/FWS] Improve ROW/ROP callouts, changed autobrake off master caution light to 3 seconds - @BravoMike99 (bruno_pt99)
+1. [A380X/OIT] Restart FLT OPS startup sequence after laptop power loss - @HendersonTyler (Tyler Henderson)
+1. [A380X/MFD] Fix LS field remaining blank on F-PLN arrival page when no landing system is available or selected - @matze-tech (matze2346)
+1. [A380X/PRIM] Move FE to PRIM and add SPD LIM flag - @lukecologne (luke)
+1. [A380X/PRIM] Improve speed trend behaviour - @lukecologne (luke)
+1. [A380X/FWS] Add NAV UNRELIABLE AIRSPEED INDICATION procedure - @matze-tech (matze2346)
+1. [A380X/FLIGHT MODEL] Bounced landings fix plus added pitch inertia - @donstim (donbikes)
+1. [A380X] Fix character spawning under the ground in walkaround mode - @heclak (Heclak)
+1. [A380X] Add pilot avatar to cockpit in external views - @heclak (Heclak)
+1. [A380X/FLIGHT MODEL] Fix for tires sinking into runway - @donstim (donbikes)
+1. [A380X/MFD] Accept inches in QNH as 4 digits and change placeholder based on FCU setting - @BravoMike99 (bruno_pt99)
+1. [A380X/FMS] Disable destination QNH, temperature and wind fields on the PERF APPR page if no destination airport exists - @HendersonTyler
+1. [A380X/MFD] Show dashed placeholders for unset APPR and airport idents on PERF APPR page - @zain-asif-dev
+1. [A380X/MFD] Fix F speed showing CONF3 value instead of F2 on PERF APPR page - @smchuk
+1. [A380X/LIGHTS] Implement storm light switch function - @heclak (Heclak)
+1. [A380X/LIGHTS] Add side console lights - @heclak (Heclak)
+1. [A380X/RMP] Fixed a bug where the PILOT_TRANSMITTER_SET key event would toggle transmission rather than only setting it on - @tracernz (Mike)
+1. [MISC] Refactor handling of unknown enum values to fix issues with GSX "complete now" feature and potential other wasm crashes - @Saschl
 
 ## 2020.15.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -22,24 +22,6 @@
 1. [A380X/MFD] Fixed TMPY being generated upon accessing  vertical revision pages - @BravoMike99 (bruno_pt99)
 1. [A380X/MFD] Alternate flightplan or go around legs can be loaded on the vertical revision pages - @BravoMike99 (bruno_pt99)
 1. [EFB] Added a cold temperature correction calculator - @tracernz (Mike)
-1. [A380X/MFD] Show approach QNH and TEMP as mandatory only when closer than 180 NM to destination or when predictions are unavailable - @matze-tech (matze2346)
-1. [A380X/FWS] Improve ROW/ROP callouts, changed autobrake off master caution light to 3 seconds - @BravoMike99 (bruno_pt99)
-1. [A380X/OIT] Restart FLT OPS startup sequence after laptop power loss - @HendersonTyler (Tyler Henderson)
-1. [A380X/MFD] Fix LS field remaining blank on F-PLN arrival page when no landing system is available or selected - @matze-tech (matze2346)
-1. [A380X/PRIM] Move FE to PRIM and add SPD LIM flag - @lukecologne (luke)
-1. [A380X/PRIM] Improve speed trend behaviour - @lukecologne (luke)
-1. [A380X/FWS] Add NAV UNRELIABLE AIRSPEED INDICATION procedure - @matze-tech (matze2346)
-1. [A380X/FLIGHT MODEL] Bounced landings fix plus added pitch inertia - @donstim (donbikes)
-1. [A380X] Fix character spawning under the ground in walkaround mode - @heclak (Heclak)
-1. [A380X] Add pilot avatar to cockpit in external views - @heclak (Heclak)
-1. [A380X/FLIGHT MODEL] Fix for tires sinking into runway - @donstim (donbikes)
-1. [A380X/MFD] Accept inches in QNH as 4 digits and change placeholder based on FCU setting - @BravoMike99 (bruno_pt99)
-1. [A380X/FMS] Disable destination QNH, temperature and wind fields on the PERF APPR page if no destination airport exists - @HendersonTyler
-1. [A380X/MFD] Show dashed placeholders for unset APPR and airport idents on PERF APPR page - @zain-asif-dev
-1. [A380X/MFD] Fix F speed showing CONF3 value instead of F2 on PERF APPR page - @smchuk
-1. [A380X/LIGHTS] Implement storm light switch function - @heclak (Heclak)
-1. [A380X/LIGHTS] Add side console lights - @heclak (Heclak)
-1. [A380X/RMP] Fixed a bug where the PILOT_TRANSMITTER_SET key event would toggle transmission rather than only setting it on - @tracernz (Mike)
 1. [MISC] Refactor handling of unknown enum values to fix issues with GSX "complete now" feature and potential other wasm crashes - @Saschl
 
 ## 2020.15.0

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/air_conditioning.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/air_conditioning.rs
@@ -1107,7 +1107,7 @@ mod tests {
         },
         simulation::{
             test::{ReadByName, SimulationTestBed, TestBed, WriteByName},
-            Aircraft, Read, SimulationElement, SimulationElementVisitor, SimulatorReader,
+            Aircraft, Reader, SimulationElement, SimulationElementVisitor, SimulatorReader,
             UpdateContext,
         },
     };
@@ -1241,9 +1241,21 @@ mod tests {
     }
     impl SimulationElement for TestFadec {
         fn read(&mut self, reader: &mut SimulatorReader) {
-            self.engine_1_state = reader.read(&self.engine_1_state_id);
-            self.engine_2_state = reader.read(&self.engine_2_state_id);
-            self.engine_mode_selector_position = reader.read(&self.engine_mode_selector_id);
+            self.engine_1_state = reader.read_discrete_or_fallback(
+                &self.engine_1_state_id,
+                "EngineState1",
+                EngineState::Off,
+            );
+            self.engine_2_state = reader.read_discrete_or_fallback(
+                &self.engine_2_state_id,
+                "EngineState2",
+                EngineState::Off,
+            );
+            self.engine_mode_selector_position = reader.read_discrete_or_fallback(
+                &self.engine_mode_selector_id,
+                "EngineModeSelector",
+                EngineModeSelector::Norm,
+            );
         }
     }
 

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/pneumatic.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/pneumatic.rs
@@ -32,7 +32,7 @@ use systems::{
         ReservoirAirPressure,
     },
     simulation::{
-        InitContext, Read, SimulationElement, SimulationElementVisitor, SimulatorReader,
+        InitContext, Read, Reader, SimulationElement, SimulationElementVisitor, SimulatorReader,
         SimulatorWriter, UpdateContext, VariableIdentifier, Write,
     },
     valve_signal_implementation,
@@ -1641,9 +1641,21 @@ impl FullAuthorityDigitalEngineControl {
 }
 impl SimulationElement for FullAuthorityDigitalEngineControl {
     fn read(&mut self, reader: &mut SimulatorReader) {
-        self.engine_1_state = reader.read(&self.engine_1_state_id);
-        self.engine_2_state = reader.read(&self.engine_2_state_id);
-        self.engine_mode_selector1_position = reader.read(&self.engine_mode_selector1_id);
+        self.engine_1_state = reader.read_discrete_or_fallback(
+            &self.engine_1_state_id,
+            "EngineState1",
+            EngineState::Off,
+        );
+        self.engine_2_state = reader.read_discrete_or_fallback(
+            &self.engine_2_state_id,
+            "EngineState2",
+            EngineState::Off,
+        );
+        self.engine_mode_selector1_position = reader.read_discrete_or_fallback(
+            &self.engine_mode_selector1_id,
+            "EngineModeSelector",
+            EngineModeSelector::Norm,
+        );
         self.engine_1_n2_percent = Ratio::new::<percent>(reader.read(&self.engine_1_n2_percent_id));
         self.engine_2_n2_percent = Ratio::new::<percent>(reader.read(&self.engine_2_n2_percent_id));
     }

--- a/fbw-a32nx/src/wasm/systems/a320_systems_wasm/src/lib.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems_wasm/src/lib.rs
@@ -29,8 +29,8 @@ use systems::air_conditioning::{
 };
 use systems::failures::FailureType;
 use systems::shared::{
-    AirbusElectricPumpId, AirbusEngineDrivenPumpId, ElectricalBusType, GearActuatorId,
-    HydraulicColor, LgciuId, ProximityDetectorId,
+    report_diagnostic, AirbusElectricPumpId, AirbusEngineDrivenPumpId, ElectricalBusType,
+    GearActuatorId, HydraulicColor, LgciuId, ProximityDetectorId,
 };
 use systems_wasm::aspects::ExecuteOn;
 use systems_wasm::{MsfsSimulationBuilder, Variable};
@@ -38,6 +38,13 @@ use trimmable_horizontal_stabilizer::trimmable_horizontal_stabilizer;
 
 #[msfs::gauge(name=systems)]
 async fn systems(mut gauge: msfs::Gauge) -> Result<(), Box<dyn Error>> {
+    // The default panic output is lost when the WASM instance aborts, so print the
+    // panic message and location to the MSFS console before the trap happens.
+    std::panic::set_hook(Box::new(|panic_info| {
+        println!("A32NX_SYSTEMS PANIC: {panic_info}");
+        report_diagnostic(&format!("A32NX_SYSTEMS PANIC: {panic_info}"));
+    }));
+
     let mut sim_connect = gauge.open_simconnect("systems")?;
 
     let key_prefix = "A32NX_";

--- a/fbw-a380x/src/systems/instruments/src/OITlegacy/OitLegacy.tsx
+++ b/fbw-a380x/src/systems/instruments/src/OITlegacy/OitLegacy.tsx
@@ -18,7 +18,6 @@ import {
   setCabinInfo,
   setFlypadInfo,
   store,
-  TroubleshootingContextProvider,
   useAppDispatch,
   useEventBus,
   useNavigraphAuthInfo,
@@ -137,24 +136,22 @@ export const OitEfbWrapper: React.FC<OitEfbWrapperProps> = ({ eventBus }) => {
       }}
     >
       <Provider store={store}>
-        <TroubleshootingContextProvider eventBus={eventBus}>
-          <FailuresOrchestratorProvider failures={[]}>
-            <ErrorBoundary FallbackComponent={ErrorFallback} onReset={() => setErr(false)} resetKeys={[err]}>
-              <Router>
-                <ModalProvider>
-                  <EventBusContextProvider eventBus={eventBus}>
-                    <NavigraphAuthProvider>
-                      <PowerContext.Provider value={{ powerState, setPowerState }}>
-                        <ToastContainer position="top-center" draggableDirection="y" limit={2} />
-                        <OitEfbPageWrapper eventBus={eventBus} />
-                      </PowerContext.Provider>
-                    </NavigraphAuthProvider>
-                  </EventBusContextProvider>
-                </ModalProvider>
-              </Router>
-            </ErrorBoundary>
-          </FailuresOrchestratorProvider>
-        </TroubleshootingContextProvider>
+        <FailuresOrchestratorProvider failures={[]}>
+          <ErrorBoundary FallbackComponent={ErrorFallback} onReset={() => setErr(false)} resetKeys={[err]}>
+            <Router>
+              <ModalProvider>
+                <EventBusContextProvider eventBus={eventBus}>
+                  <NavigraphAuthProvider>
+                    <PowerContext.Provider value={{ powerState, setPowerState }}>
+                      <ToastContainer position="top-center" draggableDirection="y" limit={2} />
+                      <OitEfbPageWrapper eventBus={eventBus} />
+                    </PowerContext.Provider>
+                  </NavigraphAuthProvider>
+                </EventBusContextProvider>
+              </ModalProvider>
+            </Router>
+          </ErrorBoundary>
+        </FailuresOrchestratorProvider>
       </Provider>
     </AircraftContext.Provider>
   );

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/air_conditioning/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/air_conditioning/mod.rs
@@ -1215,7 +1215,7 @@ mod tests {
         },
         simulation::{
             test::{ReadByName, SimulationTestBed, TestBed, WriteByName},
-            Aircraft, Read, SimulationElement, SimulationElementVisitor, SimulatorReader,
+            Aircraft, Reader, SimulationElement, SimulationElementVisitor, SimulatorReader,
             UpdateContext,
         },
     };
@@ -1455,11 +1455,31 @@ mod tests {
     }
     impl SimulationElement for TestFadec {
         fn read(&mut self, reader: &mut SimulatorReader) {
-            self.engine_1_state = reader.read(&self.engine_1_state_id);
-            self.engine_2_state = reader.read(&self.engine_2_state_id);
-            self.engine_3_state = reader.read(&self.engine_3_state_id);
-            self.engine_4_state = reader.read(&self.engine_4_state_id);
-            self.engine_mode_selector_position = reader.read(&self.engine_mode_selector_id);
+            self.engine_1_state = reader.read_discrete_or_fallback(
+                &self.engine_1_state_id,
+                "EngineState",
+                EngineState::Off,
+            );
+            self.engine_2_state = reader.read_discrete_or_fallback(
+                &self.engine_2_state_id,
+                "EngineState",
+                EngineState::Off,
+            );
+            self.engine_3_state = reader.read_discrete_or_fallback(
+                &self.engine_3_state_id,
+                "EngineState",
+                EngineState::Off,
+            );
+            self.engine_4_state = reader.read_discrete_or_fallback(
+                &self.engine_4_state_id,
+                "EngineState",
+                EngineState::Off,
+            );
+            self.engine_mode_selector_position = reader.read_discrete_or_fallback(
+                &self.engine_mode_selector_id,
+                "EngineModeSelector",
+                EngineModeSelector::Norm,
+            );
         }
     }
 

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/fuel/cpiom_f/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/fuel/cpiom_f/mod.rs
@@ -20,7 +20,7 @@ use systems::{
         ConsumePower, DelayedTrueLogicGate, ElectricalBusType, ElectricalBuses, Resolution,
     },
     simulation::{
-        InitContext, Read, SimulationElementVisitor, SimulatorReader, SimulatorWriter,
+        InitContext, Read, Reader, SimulationElementVisitor, SimulatorReader, SimulatorWriter,
         UpdateContext, VariableIdentifier, Write, Writer,
     },
 };
@@ -162,14 +162,18 @@ impl SimulationElement for RefuelPanelInput {
         self.total_desired_fuel_input =
             Mass::new::<kilogram>(reader.read(&self.total_desired_fuel_id));
         self.refuel_status = reader.read(&self.refuel_status_id);
-        self.refuel_rate_setting = reader.read(&self.refuel_rate_setting_id);
+        self.refuel_rate_setting = reader.read_discrete_or_fallback(
+            &self.refuel_rate_setting_id,
+            "RefuelRate",
+            RefuelRate::Real,
+        );
 
         for (id, state) in self
             .engine_state_ids
             .iter()
             .zip(self.engine_states.iter_mut())
         {
-            *state = reader.read(id);
+            *state = reader.read_discrete_or_fallback(id, "EngineState", EngineState::Off);
         }
         self.target_zero_fuel_weight =
             Mass::new::<kilogram>(reader.read(&self.target_zero_fuel_weight_id));

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/pneumatic.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/pneumatic.rs
@@ -28,7 +28,7 @@ use systems::{
         PneumaticBleed, PneumaticValve, ReservoirAirPressure,
     },
     simulation::{
-        InitContext, Read, SimulationElement, SimulationElementVisitor, SimulatorReader,
+        InitContext, Reader, SimulationElement, SimulationElementVisitor, SimulatorReader,
         SimulatorWriter, UpdateContext, VariableIdentifier, Write,
     },
 };
@@ -1177,11 +1177,31 @@ impl FullAuthorityDigitalEngineControl {
 }
 impl SimulationElement for FullAuthorityDigitalEngineControl {
     fn read(&mut self, reader: &mut SimulatorReader) {
-        self.engine_1_state = reader.read(&self.engine_1_state_id);
-        self.engine_2_state = reader.read(&self.engine_2_state_id);
-        self.engine_3_state = reader.read(&self.engine_3_state_id);
-        self.engine_4_state = reader.read(&self.engine_4_state_id);
-        self.engine_mode_selector1_position = reader.read(&self.engine_mode_selector1_id);
+        self.engine_1_state = reader.read_discrete_or_fallback(
+            &self.engine_1_state_id,
+            "EngineState1",
+            EngineState::Off,
+        );
+        self.engine_2_state = reader.read_discrete_or_fallback(
+            &self.engine_2_state_id,
+            "EngineState2",
+            EngineState::Off,
+        );
+        self.engine_3_state = reader.read_discrete_or_fallback(
+            &self.engine_3_state_id,
+            "EngineState3",
+            EngineState::Off,
+        );
+        self.engine_4_state = reader.read_discrete_or_fallback(
+            &self.engine_4_state_id,
+            "EngineState4",
+            EngineState::Off,
+        );
+        self.engine_mode_selector1_position = reader.read_discrete_or_fallback(
+            &self.engine_mode_selector1_id,
+            "EngineModeSelector",
+            EngineModeSelector::Norm,
+        );
     }
 }
 

--- a/fbw-a380x/src/wasm/systems/a380_systems_wasm/src/lib.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems_wasm/src/lib.rs
@@ -36,8 +36,9 @@ use systems::air_conditioning::{Channel, FdacId, OcsmId, VcmId};
 use systems::failures::FailureType;
 use systems::integrated_modular_avionics::core_processing_input_output_module::CpiomId;
 use systems::shared::{
-    AirbusElectricPumpId, AirbusEngineDrivenPumpId, ElectricalBusType, FireDetectionLoopID,
-    FireDetectionZone, GearActuatorId, HydraulicColor, LgciuId, ProximityDetectorId,
+    report_diagnostic, AirbusElectricPumpId, AirbusEngineDrivenPumpId, ElectricalBusType,
+    FireDetectionLoopID, FireDetectionZone, GearActuatorId, HydraulicColor, LgciuId,
+    ProximityDetectorId,
 };
 
 use systems_wasm::{MsfsSimulationBuilder, Variable};
@@ -45,6 +46,13 @@ use trimmable_horizontal_stabilizer::trimmable_horizontal_stabilizer;
 
 #[msfs::gauge(name=systems)]
 async fn systems(mut gauge: msfs::Gauge) -> Result<(), Box<dyn Error>> {
+    // The default panic output is lost when the WASM instance aborts, so print the
+    // panic message and location to the MSFS console before the trap happens.
+    std::panic::set_hook(Box::new(|panic_info| {
+        println!("A380X_SYSTEMS PANIC: {panic_info}");
+        report_diagnostic(&format!("A380X_SYSTEMS PANIC: {panic_info}"));
+    }));
+
     let mut sim_connect = gauge.open_simconnect("systems")?;
 
     let key_prefix = "A32NX_";

--- a/fbw-common/src/systems/instruments/src/EFB/TroubleshootingContext.tsx
+++ b/fbw-common/src/systems/instruments/src/EFB/TroubleshootingContext.tsx
@@ -4,7 +4,8 @@
 
 import { EventBus } from '@microsoft/msfs-sdk';
 import React, { useContext, useEffect, useState } from 'react';
-import { TroubleshootingEvents } from '../../../shared/src/Troubleshooting';
+import { logTroubleshootingError, TroubleshootingEvents } from '../../../shared/src/Troubleshooting';
+import { useViewListenerEvent } from './Utils/listener';
 
 const TroubleshootingContext = React.createContext<string[]>(undefined as any);
 
@@ -28,6 +29,10 @@ export const TroubleshootingContextProvider: React.FC<TroubleshootingContextProp
       sub.destroy();
     };
   }, []);
+
+  useViewListenerEvent('JS_LISTENER_COMM_BUS', 'FBW_SYSTEMS_TROUBLESHOOTING_LOG', (message: string) =>
+    logTroubleshootingError(eventBus, message),
+  );
 
   return <TroubleshootingContext.Provider value={errorLog}>{children}</TroubleshootingContext.Provider>;
 };

--- a/fbw-common/src/wasm/systems/systems/src/air_conditioning/acs_controller.rs
+++ b/fbw-common/src/wasm/systems/systems/src/air_conditioning/acs_controller.rs
@@ -1439,7 +1439,7 @@ mod acs_controller_tests {
         },
         simulation::{
             test::{ReadByName, SimulationTestBed, TestBed, WriteByName},
-            Aircraft, Read, SimulationElement, SimulationElementVisitor, SimulatorReader,
+            Aircraft, Reader, SimulationElement, SimulationElementVisitor, SimulatorReader,
             UpdateContext,
         },
     };
@@ -1749,9 +1749,21 @@ mod acs_controller_tests {
     }
     impl SimulationElement for TestFadec {
         fn read(&mut self, reader: &mut SimulatorReader) {
-            self.engine_1_state = reader.read(&self.engine_1_state_id);
-            self.engine_2_state = reader.read(&self.engine_2_state_id);
-            self.engine_mode_selector_position = reader.read(&self.engine_mode_selector_id);
+            self.engine_1_state = reader.read_discrete_or_fallback(
+                &self.engine_1_state_id,
+                "EngineState",
+                EngineState::Off,
+            );
+            self.engine_2_state = reader.read_discrete_or_fallback(
+                &self.engine_2_state_id,
+                "EngineState",
+                EngineState::Off,
+            );
+            self.engine_mode_selector_position = reader.read_discrete_or_fallback(
+                &self.engine_mode_selector_id,
+                "EngineModeSelector",
+                EngineModeSelector::Norm,
+            );
         }
     }
 

--- a/fbw-common/src/wasm/systems/systems/src/fuel/mod.rs
+++ b/fbw-common/src/wasm/systems/systems/src/fuel/mod.rs
@@ -17,14 +17,16 @@ pub enum RefuelRate {
     Fast,
     Instant,
 }
-read_write_enum!(RefuelRate);
-impl From<f64> for RefuelRate {
-    fn from(value: f64) -> Self {
+try_read_write_enum!(RefuelRate);
+impl TryFrom<f64> for RefuelRate {
+    type Error = u8;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
         match value as u8 {
-            0 => RefuelRate::Real,
-            1 => RefuelRate::Fast,
-            2 => RefuelRate::Instant,
-            i => panic!("Cannot convert from {} to RefuelRate.", i),
+            0 => Ok(RefuelRate::Real),
+            1 => Ok(RefuelRate::Fast),
+            2 => Ok(RefuelRate::Instant),
+            i => Err(i),
         }
     }
 }

--- a/fbw-common/src/wasm/systems/systems/src/macros/mod.rs
+++ b/fbw-common/src/wasm/systems/systems/src/macros/mod.rs
@@ -45,11 +45,11 @@ macro_rules! provide_potential {
     };
 }
 
-macro_rules! read_write_enum {
+macro_rules! try_read_write_enum {
     ($t: ty) => {
-        impl<T: Reader> Read<$t> for T {
-            fn convert(&mut self, value: f64) -> $t {
-                value.into()
+        impl<T: Reader> Read<Result<$t, <$t as TryFrom<f64>>::Error>> for T {
+            fn convert(&mut self, value: f64) -> Result<$t, <$t as TryFrom<f64>>::Error> {
+                value.try_into()
             }
         }
 

--- a/fbw-common/src/wasm/systems/systems/src/navigation/adirs.rs
+++ b/fbw-common/src/wasm/systems/systems/src/navigation/adirs.rs
@@ -205,14 +205,17 @@ enum InertialReferenceMode {
     Attitude = 2,
 }
 
-read_write_enum!(InertialReferenceMode);
+try_read_write_enum!(InertialReferenceMode);
 
-impl From<f64> for InertialReferenceMode {
-    fn from(value: f64) -> Self {
+impl TryFrom<f64> for InertialReferenceMode {
+    type Error = u8;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
         match value as u8 {
-            1 => InertialReferenceMode::Navigation,
-            2 => InertialReferenceMode::Attitude,
-            _ => InertialReferenceMode::Off,
+            0 => Ok(InertialReferenceMode::Off),
+            1 => Ok(InertialReferenceMode::Navigation),
+            2 => Ok(InertialReferenceMode::Attitude),
+            i => Err(i),
         }
     }
 }
@@ -255,25 +258,31 @@ impl InertialReferenceModeSelector {
 }
 impl SimulationElement for InertialReferenceModeSelector {
     fn read(&mut self, reader: &mut SimulatorReader) {
-        self.mode = reader.read(&self.mode_id)
+        self.mode = reader.read_discrete_or_fallback(
+            &self.mode_id,
+            "InertialReferenceModeSelector",
+            InertialReferenceMode::Off,
+        );
     }
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 enum AlignState {
     Off = 0,
     Aligning = 1,
     Aligned = 2,
 }
 
-read_write_enum!(AlignState);
+try_read_write_enum!(AlignState);
 
-impl From<f64> for AlignState {
-    fn from(value: f64) -> Self {
+impl TryFrom<f64> for AlignState {
+    type Error = u8;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
         match value as u8 {
-            1 => AlignState::Aligning,
-            2 => AlignState::Aligned,
-            _ => AlignState::Off,
+            1 => Ok(AlignState::Aligning),
+            2 => Ok(AlignState::Aligned),
+            i => Err(i),
         }
     }
 }
@@ -464,7 +473,11 @@ impl SimulationElement for AdirsSimulatorData {
         self.baro_correction_1 = reader.read_arinc429(&self.baro_correction_1_id);
         self.baro_correction_2 = reader.read_arinc429(&self.baro_correction_2_id);
         self.is_boarding_started_by_user = reader.read(&self.is_boarding_started_by_user_id);
-        self.boarding_rate = reader.read(&self.boarding_rate_id);
+        self.boarding_rate = reader.read_discrete_or_fallback(
+            &self.boarding_rate_id,
+            "BoardingRate",
+            BoardingRate::Instant,
+        );
     }
 }
 
@@ -602,7 +615,11 @@ impl SimulationElement for AirDataInertialReferenceSystem {
     }
 
     fn read(&mut self, reader: &mut SimulatorReader) {
-        self.configured_align_time = reader.read(&self.configured_align_time_id);
+        self.configured_align_time = reader.read_discrete_or_fallback(
+            &self.configured_align_time_id,
+            "AlignTime",
+            AlignTime::Realistic,
+        );
         self.aircraft_preset_quick_mode = reader.read(&self.aircraft_preset_quick_mode_id);
     }
 
@@ -1584,21 +1601,24 @@ impl SimulationElement for AirDataReference {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum AlignTime {
     Realistic = 0,
     Instant = 1,
     Fast = 2,
 }
 
-read_write_enum!(AlignTime);
+try_read_write_enum!(AlignTime);
 
-impl From<f64> for AlignTime {
-    fn from(value: f64) -> Self {
+impl TryFrom<f64> for AlignTime {
+    type Error = u8;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
         match value as u8 {
-            1 => AlignTime::Instant,
-            2 => AlignTime::Fast,
-            _ => AlignTime::Realistic,
+            0 => Ok(AlignTime::Realistic),
+            1 => Ok(AlignTime::Instant),
+            2 => Ok(AlignTime::Fast),
+            i => Err(i),
         }
     }
 }
@@ -2928,7 +2948,9 @@ mod tests {
         }
 
         fn align_state(&mut self, adiru_number: usize) -> AlignState {
-            self.read_by_name(&AirDataInertialReferenceUnit::state_id(adiru_number))
+            let state: Result<AlignState, _> =
+                self.read_by_name(&AirDataInertialReferenceUnit::state_id(adiru_number));
+            state.unwrap_or(AlignState::Off)
         }
 
         fn remaining_alignment_time(&mut self) -> Duration {

--- a/fbw-common/src/wasm/systems/systems/src/payload/mod.rs
+++ b/fbw-common/src/wasm/systems/systems/src/payload/mod.rs
@@ -647,14 +647,16 @@ pub enum BoardingRate {
     Fast,
     Real,
 }
-read_write_enum!(BoardingRate);
-impl From<f64> for BoardingRate {
-    fn from(value: f64) -> Self {
+try_read_write_enum!(BoardingRate);
+impl TryFrom<f64> for BoardingRate {
+    type Error = u8;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
         match value as u8 {
-            2 => BoardingRate::Real,
-            1 => BoardingRate::Fast,
-            0 => BoardingRate::Instant,
-            _ => panic!("{} cannot be converted into BoardingRate", value),
+            0 => Ok(BoardingRate::Instant),
+            1 => Ok(BoardingRate::Fast),
+            2 => Ok(BoardingRate::Real),
+            i => Err(i),
         }
     }
 }
@@ -1060,7 +1062,11 @@ impl SimulationElement for BoardingInputs {
         self.developer_state
             .set(reader.read(&self.developer_state_id));
         self.is_boarding = reader.read(&self.is_boarding_id);
-        self.board_rate = reader.read(&self.board_rate_id);
+        self.board_rate = reader.read_discrete_or_fallback(
+            &self.board_rate_id,
+            "boarding_rate",
+            BoardingRate::Instant,
+        );
         self.per_pax_weight
             .set(Mass::new::<kilogram>(reader.read(&self.per_pax_weight_id)));
     }
@@ -1088,22 +1094,26 @@ pub enum GsxState {
     Performing,
     Completed,
 }
-impl From<f64> for GsxState {
-    fn from(value: f64) -> Self {
+
+impl TryFrom<f64> for GsxState {
+    type Error = u8;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
         match value as u8 {
-            0 => GsxState::None,
-            1 => GsxState::Available,
-            2 => GsxState::NotAvailable,
-            3 => GsxState::Bypassed,
-            4 => GsxState::Requested,
-            5 => GsxState::Performing,
-            6 => GsxState::Completed,
-            i => panic!("Cannot convert from {} to GsxState.", i),
+            0 => Ok(GsxState::None),
+            1 => Ok(GsxState::Available),
+            2 => Ok(GsxState::NotAvailable),
+            3 => Ok(GsxState::Bypassed),
+            4 => Ok(GsxState::Requested),
+            5 => Ok(GsxState::Performing),
+            6 => Ok(GsxState::Completed),
+            7 => Ok(GsxState::Completed),
+            unexpected => Err(unexpected),
         }
     }
 }
 
-read_write_enum!(GsxState);
+try_read_write_enum!(GsxState);
 
 pub struct GsxInput {
     is_enabled_id: VariableIdentifier,
@@ -1173,8 +1183,16 @@ impl SimulationElement for GsxInput {
         self.pax_deboarding = reader.read(&self.pax_deboarding_id);
         self.cargo_boarding_percent = reader.read(&self.cargo_boarding_percent_id);
         self.cargo_deboarding_percent = reader.read(&self.cargo_deboarding_percent_id);
-        self.boarding_state = reader.read(&self.boarding_state_id);
-        self.deboarding_state = reader.read(&self.deboarding_state_id);
+        self.boarding_state = reader.read_discrete_or_fallback(
+            &self.boarding_state_id,
+            "boarding_state",
+            GsxState::Completed,
+        );
+        self.deboarding_state = reader.read_discrete_or_fallback(
+            &self.deboarding_state_id,
+            "deboarding_state",
+            GsxState::Completed,
+        );
     }
 }
 

--- a/fbw-common/src/wasm/systems/systems/src/pneumatic/mod.rs
+++ b/fbw-common/src/wasm/systems/systems/src/pneumatic/mod.rs
@@ -436,7 +436,11 @@ impl SimulationElement for WingAntiIcePushButton {
     }
 
     fn read(&mut self, reader: &mut SimulatorReader) {
-        self.mode = reader.read(&self.mode_id)
+        self.mode = reader.read_discrete_or_fallback(
+            &self.mode_id,
+            "WingAntiIcePushButtonMode",
+            WingAntiIcePushButtonMode::On,
+        )
     }
 }
 
@@ -446,13 +450,16 @@ pub enum WingAntiIcePushButtonMode {
     On = 1,
 }
 
-read_write_enum!(WingAntiIcePushButtonMode);
+try_read_write_enum!(WingAntiIcePushButtonMode);
 
-impl From<f64> for WingAntiIcePushButtonMode {
-    fn from(value: f64) -> Self {
+impl TryFrom<f64> for WingAntiIcePushButtonMode {
+    type Error = u8;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
         match value as u8 {
-            0 => WingAntiIcePushButtonMode::Off,
-            _ => WingAntiIcePushButtonMode::On,
+            0 => Ok(WingAntiIcePushButtonMode::Off),
+            1 => Ok(WingAntiIcePushButtonMode::On),
+            i => Err(i),
         }
     }
 }
@@ -479,7 +486,11 @@ impl SimulationElement for CrossBleedValveSelectorKnob {
     }
 
     fn read(&mut self, reader: &mut SimulatorReader) {
-        self.mode = reader.read(&self.mode_id)
+        self.mode = reader.read_discrete_or_fallback(
+            &self.mode_id,
+            "CrossBleedValveSelectorMode",
+            CrossBleedValveSelectorMode::Auto,
+        )
     }
 }
 
@@ -490,15 +501,17 @@ pub enum CrossBleedValveSelectorMode {
     Open = 2,
 }
 
-read_write_enum!(CrossBleedValveSelectorMode);
+try_read_write_enum!(CrossBleedValveSelectorMode);
 
-impl From<f64> for CrossBleedValveSelectorMode {
-    fn from(value: f64) -> Self {
+impl TryFrom<f64> for CrossBleedValveSelectorMode {
+    type Error = u8;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
         match value as u8 {
-            0 => CrossBleedValveSelectorMode::Shut,
-            1 => CrossBleedValveSelectorMode::Auto,
-            2 => CrossBleedValveSelectorMode::Open,
-            _ => panic!("CrossBleedValveSelectorMode value does not correspond to any enum member"),
+            0 => Ok(CrossBleedValveSelectorMode::Shut),
+            1 => Ok(CrossBleedValveSelectorMode::Auto),
+            2 => Ok(CrossBleedValveSelectorMode::Open),
+            i => Err(i),
         }
     }
 }
@@ -512,17 +525,19 @@ pub enum EngineState {
     Shutting = 4,
 }
 
-read_write_enum!(EngineState);
+try_read_write_enum!(EngineState);
 
-impl From<f64> for EngineState {
-    fn from(value: f64) -> Self {
+impl TryFrom<f64> for EngineState {
+    type Error = u8;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
         match value as u8 {
-            0 | 10 => EngineState::Off,
-            1 | 11 => EngineState::On,
-            2 | 12 => EngineState::Starting,
-            3 | 13 => EngineState::Restarting,
-            4 | 14 => EngineState::Shutting,
-            _ => panic!("EngineState value does not correspond to any enum member"),
+            0 | 10 => Ok(EngineState::Off),
+            1 | 11 => Ok(EngineState::On),
+            2 | 12 => Ok(EngineState::Starting),
+            3 | 13 => Ok(EngineState::Restarting),
+            4 | 14 => Ok(EngineState::Shutting),
+            i => Err(i),
         }
     }
 }
@@ -768,15 +783,17 @@ pub enum EngineModeSelector {
     Ignition = 2,
 }
 
-read_write_enum!(EngineModeSelector);
+try_read_write_enum!(EngineModeSelector);
 
-impl From<f64> for EngineModeSelector {
-    fn from(value: f64) -> Self {
+impl TryFrom<f64> for EngineModeSelector {
+    type Error = u8;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
         match value as u8 {
-            0 => EngineModeSelector::Crank,
-            1 => EngineModeSelector::Norm,
-            2 => EngineModeSelector::Ignition,
-            _ => panic!("Engine mode selector position not recognized."),
+            0 => Ok(EngineModeSelector::Crank),
+            1 => Ok(EngineModeSelector::Norm),
+            2 => Ok(EngineModeSelector::Ignition),
+            i => Err(i),
         }
     }
 }

--- a/fbw-common/src/wasm/systems/systems/src/shared/diagnostics.rs
+++ b/fbw-common/src/wasm/systems/systems/src/shared/diagnostics.rs
@@ -1,0 +1,40 @@
+use std::{cell::RefCell, sync::OnceLock};
+
+use rustc_hash::FxHashSet;
+
+type DiagnosisReporter = fn(&str);
+
+static DIAGNOSTICS_REPORTER: OnceLock<DiagnosisReporter> = OnceLock::new();
+
+pub fn set_diagnostics_reporter(reporter: DiagnosisReporter) {
+    if DIAGNOSTICS_REPORTER.set(reporter).is_err() {
+        println!("WARNING: diagnostics reporter already set, ignoring");
+    }
+}
+
+pub fn report_diagnostic(message: &str) {
+    match DIAGNOSTICS_REPORTER.get() {
+        Some(reporter) => reporter(message),
+        None => println!("{message}"),
+    }
+}
+
+pub fn fallback_on_unexpected_discrete<T: std::fmt::Debug>(
+    context: &'static str,
+    value: u64,
+    fallback: T,
+) -> T {
+    thread_local! {
+        // log context and value pairs of unexpected values to avoid flooding the log
+        static LOGGED_UNEXPECTED_DISCRETES: RefCell<FxHashSet<(&'static str, u64)>> =
+            RefCell::new(FxHashSet::default());
+    }
+    let first_report =
+        LOGGED_UNEXPECTED_DISCRETES.with(|logged| logged.borrow_mut().insert((context, value)));
+    if first_report {
+        report_diagnostic(&format!(
+            "unexpected {context} discrete value {value}; falling back to {fallback:?}."
+        ));
+    }
+    fallback
+}

--- a/fbw-common/src/wasm/systems/systems/src/shared/mod.rs
+++ b/fbw-common/src/wasm/systems/systems/src/shared/mod.rs
@@ -30,6 +30,9 @@ pub mod update_iterator;
 mod random;
 pub use random::*;
 
+mod diagnostics;
+pub use diagnostics::*;
+
 pub mod arinc429;
 pub mod arinc825;
 pub mod can_bus;

--- a/fbw-common/src/wasm/systems/systems/src/simulation/mod.rs
+++ b/fbw-common/src/wasm/systems/systems/src/simulation/mod.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 mod update_context;
 use crate::electrical::{ElectricalElementIdentifier, ElectricalElementIdentifierProvider};
-use crate::shared::{from_bool, ElectricalBusType};
+use crate::shared::{fallback_on_unexpected_discrete, from_bool, ElectricalBusType};
 use crate::{
     electrical::Electricity,
     failures::FailureType,
@@ -538,6 +538,23 @@ impl SimulationElementVisitor for SimulationToSimulatorVisitor<'_> {
 
 pub trait Reader {
     fn read_f64(&mut self, identifier: &VariableIdentifier) -> f64;
+
+    fn read_discrete_or_fallback<T>(
+        &mut self,
+        identifier: &VariableIdentifier,
+        context: &'static str,
+        fallback: T,
+    ) -> T
+    where
+        Self: Sized + Read<Result<T, <T as TryFrom<f64>>::Error>>,
+        T: Copy + std::fmt::Debug + TryFrom<f64>,
+        <T as TryFrom<f64>>::Error: Copy + Into<u64>,
+    {
+        let value: Result<T, _> = self.read(identifier);
+        value.unwrap_or_else(|unexpected| {
+            fallback_on_unexpected_discrete(context, unexpected.into(), fallback)
+        })
+    }
 }
 
 /// Reads data from the simulator into the aircraft system simulation.

--- a/fbw-common/src/wasm/systems/systems/src/simulation/update_context.rs
+++ b/fbw-common/src/wasm/systems/systems/src/simulation/update_context.rs
@@ -12,10 +12,10 @@ use uom::si::{
     velocity::{foot_per_minute, foot_per_second, meter_per_second},
 };
 
-use super::{Read, SimulatorReader};
+use super::{Read, Reader, SimulatorReader};
 use crate::{
     shared::{low_pass_filter::LowPassFilter, MachNumber},
-    simulation::{InitContext, VariableIdentifier},
+    simulation::{InitContext, VariableIdentifier, Write, Writer},
 };
 use nalgebra::{Rotation3, Vector3};
 
@@ -56,7 +56,7 @@ impl Attitude {
 pub enum SurfaceTypeMsfs {
     Concrete = 0,
     Grass = 1,
-    Water = 2,
+    WaterFsx = 2,
     GrassBumpy = 3,
     Asphalt = 4,
     ShortGrass = 5,
@@ -78,38 +78,60 @@ pub enum SurfaceTypeMsfs {
     Sand = 21,
     Shale = 22,
     Tarmac = 23,
+    WrightFlyerTrack = 24,
+    Ocean = 26,
+    Water = 27,
+    Pond = 28,
+    Lake = 29,
+    River = 30,
+    WasteWater = 31,
+    Paint = 32,
+    Unknown = 255,
 }
-impl From<f64> for SurfaceTypeMsfs {
-    fn from(value: f64) -> Self {
+impl TryFrom<f64> for SurfaceTypeMsfs {
+    type Error = u32;
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
         match value.floor() as u32 {
-            0 => SurfaceTypeMsfs::Concrete,
-            1 => SurfaceTypeMsfs::Grass,
-            2 => SurfaceTypeMsfs::Water,
-            3 => SurfaceTypeMsfs::GrassBumpy,
-            4 => SurfaceTypeMsfs::Asphalt,
-            5 => SurfaceTypeMsfs::ShortGrass,
-            6 => SurfaceTypeMsfs::LongGrass,
-            7 => SurfaceTypeMsfs::HardTurf,
-            8 => SurfaceTypeMsfs::Snow,
-            9 => SurfaceTypeMsfs::Ice,
-            10 => SurfaceTypeMsfs::Urban,
-            11 => SurfaceTypeMsfs::Forest,
-            12 => SurfaceTypeMsfs::Dirt,
-            13 => SurfaceTypeMsfs::Coral,
-            14 => SurfaceTypeMsfs::Gravel,
-            15 => SurfaceTypeMsfs::OilTreated,
-            16 => SurfaceTypeMsfs::SteelMats,
-            17 => SurfaceTypeMsfs::Bituminus,
-            18 => SurfaceTypeMsfs::Brick,
-            19 => SurfaceTypeMsfs::Macadam,
-            20 => SurfaceTypeMsfs::Planks,
-            21 => SurfaceTypeMsfs::Sand,
-            22 => SurfaceTypeMsfs::Shale,
-            23 => SurfaceTypeMsfs::Tarmac,
-            _ => SurfaceTypeMsfs::Macadam,
+            0 => Ok(SurfaceTypeMsfs::Concrete),
+            1 => Ok(SurfaceTypeMsfs::Grass),
+            2 => Ok(SurfaceTypeMsfs::WaterFsx),
+            3 => Ok(SurfaceTypeMsfs::GrassBumpy),
+            4 => Ok(SurfaceTypeMsfs::Asphalt),
+            5 => Ok(SurfaceTypeMsfs::ShortGrass),
+            6 => Ok(SurfaceTypeMsfs::LongGrass),
+            7 => Ok(SurfaceTypeMsfs::HardTurf),
+            8 => Ok(SurfaceTypeMsfs::Snow),
+            9 => Ok(SurfaceTypeMsfs::Ice),
+            10 => Ok(SurfaceTypeMsfs::Urban),
+            11 => Ok(SurfaceTypeMsfs::Forest),
+            12 => Ok(SurfaceTypeMsfs::Dirt),
+            13 => Ok(SurfaceTypeMsfs::Coral),
+            14 => Ok(SurfaceTypeMsfs::Gravel),
+            15 => Ok(SurfaceTypeMsfs::OilTreated),
+            16 => Ok(SurfaceTypeMsfs::SteelMats),
+            17 => Ok(SurfaceTypeMsfs::Bituminus),
+            18 => Ok(SurfaceTypeMsfs::Brick),
+            19 => Ok(SurfaceTypeMsfs::Macadam),
+            20 => Ok(SurfaceTypeMsfs::Planks),
+            21 => Ok(SurfaceTypeMsfs::Sand),
+            22 => Ok(SurfaceTypeMsfs::Shale),
+            23 => Ok(SurfaceTypeMsfs::Tarmac),
+            24 => Ok(SurfaceTypeMsfs::WrightFlyerTrack),
+            26 => Ok(SurfaceTypeMsfs::Ocean),
+            27 => Ok(SurfaceTypeMsfs::Water),
+            28 => Ok(SurfaceTypeMsfs::Pond),
+            29 => Ok(SurfaceTypeMsfs::Lake),
+            30 => Ok(SurfaceTypeMsfs::River),
+            31 => Ok(SurfaceTypeMsfs::WasteWater),
+            32 => Ok(SurfaceTypeMsfs::Paint),
+            // Undocumented, but MSFS reports this occasionally
+            255 => Ok(SurfaceTypeMsfs::Unknown),
+            unexpected => Err(unexpected),
         }
     }
 }
+
+try_read_write_enum!(SurfaceTypeMsfs);
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct LocalAcceleration {
@@ -627,8 +649,11 @@ impl UpdateContext {
 
         self.in_cloud = reader.read(&self.in_cloud_id);
 
-        let surface_read: f64 = reader.read(&self.surface_id);
-        self.surface = surface_read.into();
+        self.surface = reader.read_discrete_or_fallback(
+            &self.surface_id,
+            "SurfaceTypeMsfs",
+            SurfaceTypeMsfs::Macadam,
+        );
 
         self.rotation_accel = Vector3::new(
             AngularAcceleration::new::<radian_per_second_squared>(

--- a/fbw-common/src/wasm/systems/systems_wasm/src/lib.rs
+++ b/fbw-common/src/wasm/systems/systems_wasm/src/lib.rs
@@ -30,7 +30,7 @@ use std::cell::RefCell;
 use std::fmt::{Display, Formatter};
 use std::rc::Rc;
 use std::{error::Error, time::Duration};
-use systems::shared::ElectricalBusType;
+use systems::shared::{set_diagnostics_reporter, ElectricalBusType};
 use systems::simulation::{InitContext, StartState};
 use systems::{
     failures::FailureType,
@@ -199,6 +199,15 @@ impl MsfsHandler {
         sim_connect: &mut SimConnect,
     ) -> Result<Self, Box<dyn Error>> {
         let failures = Rc::new(RefCell::new(failures));
+
+        set_diagnostics_reporter(|message| {
+            CommBus::call(
+                "FBW_SYSTEMS_TROUBLESHOOTING_LOG",
+                message,
+                CommBusBroadcastFlags::JS,
+            );
+        });
+
         let mut commbus = CommBus::default();
         {
             let failures = failures.clone();


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Port of #10831 for msfs 2020

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Make sure the plane starts up fine (systems + engines)
1. Enable Developer mode in the Sim, open the behaviours menu from the "Tools" Section. Select the variables tab, uncheck "only show variables get/set by this behaviour" and search for A32NX_ENGINE_STATE:1
1. Change the value to 42 and observe the EFB. The red status bar should appear and show an error log about Engine State like in the screenshot

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
