### PR TITLE
fix(fms): fix vnav crash with far-away speed constraint

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/climb/ClimbPathBuilder.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/climb/ClimbPathBuilder.ts
@@ -105,6 +105,7 @@ export class ClimbPathBuilder {
             profile,
             climbStrategy,
             currentSpeedConstraint.distanceFromStart - profile.lastCheckpoint.distanceFromStart,
+            finalAltitude,
             VerticalCheckpointReason.SpeedConstraint,
           );
 
@@ -173,6 +174,7 @@ export class ClimbPathBuilder {
           profile,
           climbStrategy,
           speedConstraint.distanceFromStart - profile.lastCheckpoint.distanceFromStart,
+          finalAltitude,
           VerticalCheckpointReason.SpeedConstraint,
         );
 
@@ -262,22 +264,38 @@ export class ClimbPathBuilder {
     profile: BaseGeometryProfile,
     climbStrategy: ClimbStrategy,
     distance: NauticalMiles,
+    finalAltitude: NauticalMiles,
     reason: VerticalCheckpointReason,
   ) {
-    let distanceCrossed = 0;
-    for (; distanceCrossed + 3 < distance; distanceCrossed += 3) {
+    const stepDistance = 3; // NM
+    const numSteps = Math.ceil(distance / stepDistance);
+
+    for (let i = 0; i < numSteps; i++) {
       // The reason we don't check the actual distance travelled is because we don't want to have an infinite loop if the distance step travels no distance for some reason.
       // With this loop, it terminates at some point at least
-      this.distanceStepFromLastCheckpoint(profile, climbStrategy, 3, VerticalCheckpointReason.AtmosphericConditions);
+      this.distanceStepFromLastCheckpoint(
+        profile,
+        climbStrategy,
+        Math.min(stepDistance, distance - i * stepDistance),
+        finalAltitude,
+        VerticalCheckpointReason.AtmosphericConditions,
+      );
+
+      if (profile.lastCheckpoint.altitude >= finalAltitude) {
+        break;
+      }
     }
 
-    this.distanceStepFromLastCheckpoint(profile, climbStrategy, distance - distanceCrossed, reason);
+    if (numSteps > 0) {
+      profile.lastCheckpoint.reason = reason;
+    }
   }
 
   private distanceStepFromLastCheckpoint(
     profile: BaseGeometryProfile,
     climbStrategy: ClimbStrategy,
     distance: NauticalMiles,
+    finalAltitude: NauticalMiles,
     reason: VerticalCheckpointReason,
   ) {
     const { managedClimbSpeedMach } = this.computationParametersObserver.get();
@@ -291,6 +309,11 @@ export class ClimbPathBuilder {
       remainingFuelOnBoard,
       -profile.winds.getClimbTailwind(distanceFromStart, altitude),
     );
+
+    if (step.finalAltitude > finalAltitude) {
+      const scaling = (finalAltitude - altitude) / (step.finalAltitude - altitude);
+      this.scaleStepBasedOnLastCheckpoint(profile.lastCheckpoint, step, scaling);
+    }
 
     this.addCheckpointFromStep(profile, step, reason);
   }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes an issue where a speed constraint that was far away from the departure would cause a crash in the computation of predictions. This happened because VNAV tried to build a really long climb segment to the speed constraint, reaching altitudes above performance envelope. To fix it, we stop the segment when we reach the cruise altitude.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
Before:
<img width="474" height="303" alt="image" src="https://github.com/user-attachments/assets/b96b9fa8-4611-4273-a8e7-5089f8969f35" />
<img width="687" height="137" alt="image" src="https://github.com/user-attachments/assets/4dc3bd4b-5b65-498c-be86-045850346c20" />


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Setup a flight plan, enter an SID, a cruise altitude and your weights such that predictions are computed. Then, enter a speed constraint on a waypoint downroute. Alternatively, you can enter a random waypoint after the SID and set a climb speed constraint on that waypoint, make sure predictions are computed as you would expect them to.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
