### PR TITLE
fix(fms): retain flight number on new city pair

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -62,6 +62,7 @@
 1. [A380X/LIGHTS] Add side console lights - @heclak (Heclak)
 1. [A380X/RMP] Fixed a bug where the PILOT_TRANSMITTER_SET key event would toggle transmission rather than only setting it on - @tracernz (Mike)
 1. [MISC] Refactor handling of unknown enum values to fix issues with GSX "complete now" feature and potential other wasm crashes - @Saschl
+1. [FMS] Fix a bug where the flight number was not retained when entering a new FROM/TO - @tracernz (Mike)
 
 ## 2024.1.0
 

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/FlightPlanService.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/FlightPlanService.ts
@@ -336,6 +336,10 @@ export class FlightPlanService<P extends FlightPlanPerformanceData = FlightPlanP
       throw new Error('[FMS/FPM] Cannot enter new city pair on temporary flight plan');
     }
 
+    const flightNumber = this.flightPlanManager.has(planIndex)
+      ? this.flightPlanManager.get(planIndex).flightNumber.get()
+      : null;
+
     if (planIndex === FlightPlanIndex.Active && this.flightPlanManager.has(FlightPlanIndex.Temporary)) {
       this.flightPlanManager.delete(FlightPlanIndex.Temporary);
     }
@@ -346,6 +350,10 @@ export class FlightPlanService<P extends FlightPlanPerformanceData = FlightPlanP
     this.flightPlanManager.create(planIndex, true, FlightPlanFlags.ManualCreation);
 
     const plan = this.flightPlanManager.get(planIndex);
+
+    if (flightNumber !== null) {
+      plan.setFlightNumber(flightNumber);
+    }
 
     await plan.setOriginAirport(fromIcao);
     await plan.setDestinationAirport(toIcao);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Do not erase the flight number when entering a new FROM/TO.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
This was tested and confirmed on a real Honeywell H4 FMS. A380 pilots are confident it is the same.

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
In the A32NX:
- Enter a flight number on the INIT A page.
- Enter FROM/TO.
- Ensure the flight number is not erased.

The same flow should be possible in the A380X if using it.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
