### PR TITLE
fix(atsu): uppercase weather message sources

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -64,6 +64,7 @@
 1. [MISC] Refactor handling of unknown enum values to fix issues with GSX "complete now" feature and potential other wasm crashes - @Saschl
 1. [FMS] Fix a bug where the flight number was not retained when entering a new FROM/TO - @tracernz (Mike)
 1. [Sounds] Fixed boarding complete and welcome onboard announcements playing simultaneously by adding a delay between them - @Ditoo29 (dito29 on Discord) & Saschl
+1. [ATSU] Fix lowercase weather source names and MSFS METAR reports - @tracernz (Mike)
 
 ## 2024.1.0
 

--- a/fbw-common/src/systems/datalink/common/src/messages/AtisMessage.ts
+++ b/fbw-common/src/systems/datalink/common/src/messages/AtisMessage.ts
@@ -20,7 +20,7 @@ export class AtisMessage extends WeatherMessage {
   constructor() {
     super();
     this.Type = AtsuMessageType.ATIS;
-    this.Station = NXDataStore.getSetting('CONFIG_ATIS_SRC').get();
+    this.Station = NXDataStore.getSetting('CONFIG_ATIS_SRC').get().toUpperCase();
   }
 
   public parseInformation(): void {

--- a/fbw-common/src/systems/datalink/common/src/messages/MetarMessage.ts
+++ b/fbw-common/src/systems/datalink/common/src/messages/MetarMessage.ts
@@ -12,7 +12,7 @@ export class MetarMessage extends WeatherMessage {
   constructor() {
     super();
     this.Type = AtsuMessageType.METAR;
-    this.Station = NXDataStore.getSetting('CONFIG_METAR_SRC').get();
+    this.Station = NXDataStore.getSetting('CONFIG_METAR_SRC').get().toUpperCase();
   }
 
   public static deserialize(jsonData: MetarMessage | Record<string, unknown>): MetarMessage {

--- a/fbw-common/src/systems/datalink/router/src/msfs/MsfsConnector.ts
+++ b/fbw-common/src/systems/datalink/router/src/msfs/MsfsConnector.ts
@@ -8,7 +8,7 @@ export class MsfsConnector {
   public static async receiveMsfsMetar(icao: string, message: WeatherMessage): Promise<AtsuStatusCodes> {
     try {
       const metar: Metar = await Coherent.call('GET_METAR_BY_IDENT', icao);
-      let report = metar.metarString;
+      let report = metar.metarString.toUpperCase();
       if (!report || metar.icao !== icao) {
         report = 'NO METAR AVAILABLE';
       }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #10841 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Converts METAR and ATIS source identifiers to uppercase before assigning them as the message station.
- Converts METAR reports returned by the MSFS weather source to uppercase, just in case.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Select **MSFS** as the METAR source in the ATSU/AOC settings.
1. In the A32NX MCDU, open the AOC weather request page.
1. Request a METAR for a valid airport and wait for the response.
1. Verify that the received-message list displays `FROM MS` instead of two unsupported-glyph boxes.
1. Open the received message and verify that the METAR report is uppercase and contains no lowercase missing-glyph boxes.
1. Select another METAR provider and verify that its source identifier is displayed in uppercase.
1. Request an ATIS and verify that the existing ATIS request and display behavior is unaffected.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
