### PR TITLE
fix(a32nx/mcdu): schedule a single remote mcdu update for all mutations

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -64,6 +64,7 @@
 1. [MISC] Refactor handling of unknown enum values to fix issues with GSX "complete now" feature and potential other wasm crashes - @Saschl
 1. [FMS] Fix a bug where the flight number was not retained when entering a new FROM/TO - @tracernz (Mike)
 1. [Sounds] Fixed boarding complete and welcome onboard announcements playing simultaneously by adding a delay between them - @Ditoo29 (dito29 on Discord) & Saschl
+1. [A32NX/MCDU] Fix navigation arrows missing from remote MCDU pages - @tracernz (Mike)
 
 ## 2024.1.0
 

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A320_Neo_CDU_MainDisplay.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A320_Neo_CDU_MainDisplay.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-// Copyright (c) 2021-2023, 2025 FlyByWire Simulations
+// Copyright (c) 2021-2023, 2025-2026 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
 import { NXDataStore, UpdateThrottler } from '@flybywiresim/fbw-sdk';
@@ -15,7 +15,7 @@ import { CDUFuelPredPage } from '../legacy_pages/A320_Neo_CDU_FuelPredPage';
 import { FmgcFlightPhase } from '@shared/flightphase';
 import { CDU_Field } from './A320_Neo_CDU_Field';
 import { AtsuStatusCodes } from '@datalink/common';
-import { EventBus, GameStateProvider, HEvent } from '@microsoft/msfs-sdk';
+import { DebounceTimer, EventBus, GameStateProvider, HEvent } from '@microsoft/msfs-sdk';
 import { LegacyFmsPageInterface, LskCallback, LskDelayFunction } from './LegacyFmsPageInterface';
 import { LegacyAtsuPageInterface } from './LegacyAtsuPageInterface';
 import { EngineOutTargetPage } from '@fmgc/events/EngineOutEvents';
@@ -34,6 +34,8 @@ export class A320_Neo_CDU_MainDisplay
   private readonly minPageUpdateThrottler = new UpdateThrottler(100);
   private readonly mcduServerConnectUpdateThrottler = new UpdateThrottler(1000);
   private readonly powerCheckUpdateThrottler = new UpdateThrottler(500);
+
+  private readonly mcduServerUpdateDebounceTimer = new DebounceTimer();
 
   public readonly fmgcMesssagesListener = RegisterViewListener('JS_LISTENER_SIMVARS', null, true);
 
@@ -334,7 +336,7 @@ export class A320_Neo_CDU_MainDisplay
           timeout: 5000,
         });
         this.sendToMcduServerClient('mcduConnected');
-        this.sendUpdate();
+        this.requestServerUpdate();
         break;
       }
       case 'close': {
@@ -356,7 +358,7 @@ export class A320_Neo_CDU_MainDisplay
           SimVar.SetSimVarValue(`L:A32NX_MCDU_PUSH_ANIM_${mcduIndex}_${button}`, 'Number', 1);
         }
         if (messageType === 'requestUpdate') {
-          this.sendUpdate();
+          this.requestServerUpdate();
         }
         break;
       }
@@ -486,7 +488,7 @@ export class A320_Neo_CDU_MainDisplay
         this.onFmPowerStateChanged(isPoweredL);
 
         if (this.mcduServerClient && this.mcduServerClient.isConnected()) {
-          this.sendUpdate();
+          this.requestServerUpdate();
         }
       }
     }
@@ -565,7 +567,7 @@ export class A320_Neo_CDU_MainDisplay
     }
 
     if (updateNeeded) {
-      this.sendUpdate();
+      this.requestServerUpdate();
     }
   }
 
@@ -611,7 +613,7 @@ export class A320_Neo_CDU_MainDisplay
     }
 
     if (updateNeeded) {
-      this.sendUpdate();
+      this.requestServerUpdate();
     }
   }
 
@@ -689,6 +691,7 @@ export class A320_Neo_CDU_MainDisplay
     this._title = content.split('[color]')[0];
     this._title = `{${color}}${this._title}{end}`;
     this._titleElement.textContent = this._title;
+    this.requestServerUpdate();
   }
 
   private setPageCurrent(value: string | number) {
@@ -698,6 +701,7 @@ export class A320_Neo_CDU_MainDisplay
       this._pageCurrent = parseInt(value);
     }
     this._pageCurrentElement.textContent = (this._pageCurrent > 0 ? this._pageCurrent : '') + '';
+    this.requestServerUpdate();
   }
 
   private setPageCount(value: string | number) {
@@ -712,9 +716,10 @@ export class A320_Neo_CDU_MainDisplay
     } else {
       this.getChildById('page-slash').textContent = '/';
     }
+    this.requestServerUpdate();
   }
 
-  private setLabel(label: string, row: number, col = -1, websocketDraw = true) {
+  private setLabel(label: string, row: number, col = -1) {
     if (col >= this._labelElements[row].length) {
       return;
     }
@@ -752,13 +757,10 @@ export class A320_Neo_CDU_MainDisplay
     }
     this._labels[row][col] = label;
     this._labelElements[row][col].textContent = label;
-
-    if (websocketDraw) {
-      this.sendUpdate();
-    }
+    this.requestServerUpdate();
   }
 
-  private setLine(content: string | CDU_Field, row: number, col = -1, websocketDraw = true) {
+  private setLine(content: string | CDU_Field, row: number, col = -1) {
     if (content instanceof CDU_Field) {
       const field = content;
       (col === 0 || col === -1 ? this.onLeftInput : this.onRightInput)[row] = (value) => {
@@ -800,10 +802,7 @@ export class A320_Neo_CDU_MainDisplay
     }
     this._lines[row][col] = content;
     this._lineElements[row][col].textContent = this._lines[row][col];
-
-    if (websocketDraw) {
-      this.sendUpdate();
-    }
+    this.requestServerUpdate();
   }
 
   public setTemplate(template: any[][], large = false) {
@@ -817,33 +816,33 @@ export class A320_Neo_CDU_MainDisplay
       if (template[tIndex]) {
         if (large) {
           if (template[tIndex][1] !== undefined) {
-            this.setLine(template[tIndex][0], i, 0, false);
-            this.setLine(template[tIndex][1], i, 1, false);
-            this.setLine(template[tIndex][2], i, 2, false);
-            this.setLine(template[tIndex][3], i, 3, false);
+            this.setLine(template[tIndex][0], i, 0);
+            this.setLine(template[tIndex][1], i, 1);
+            this.setLine(template[tIndex][2], i, 2);
+            this.setLine(template[tIndex][3], i, 3);
           } else {
-            this.setLine(template[tIndex][0], i, -1, false);
+            this.setLine(template[tIndex][0], i, -1);
           }
         } else {
           if (template[tIndex][1] !== undefined) {
-            this.setLabel(template[tIndex][0], i, 0, false);
-            this.setLabel(template[tIndex][1], i, 1, false);
-            this.setLabel(template[tIndex][2], i, 2, false);
-            this.setLabel(template[tIndex][3], i, 3, false);
+            this.setLabel(template[tIndex][0], i, 0);
+            this.setLabel(template[tIndex][1], i, 1);
+            this.setLabel(template[tIndex][2], i, 2);
+            this.setLabel(template[tIndex][3], i, 3);
           } else {
-            this.setLabel(template[tIndex][0], i, -1, false);
+            this.setLabel(template[tIndex][0], i, -1);
           }
         }
       }
       tIndex = 2 * i + 2;
       if (template[tIndex]) {
         if (template[tIndex][1] !== undefined) {
-          this.setLine(template[tIndex][0], i, 0, false);
-          this.setLine(template[tIndex][1], i, 1, false);
-          this.setLine(template[tIndex][2], i, 2, false);
-          this.setLine(template[tIndex][3], i, 3, false);
+          this.setLine(template[tIndex][0], i, 0);
+          this.setLine(template[tIndex][1], i, 1);
+          this.setLine(template[tIndex][2], i, 2);
+          this.setLine(template[tIndex][3], i, 3);
         } else {
-          this.setLine(template[tIndex][0], i, -1, false);
+          this.setLine(template[tIndex][0], i, -1);
         }
       }
     }
@@ -869,7 +868,6 @@ export class A320_Neo_CDU_MainDisplay
         }
       });
     });
-    this.sendUpdate();
   }
 
   /**
@@ -897,19 +895,20 @@ export class A320_Neo_CDU_MainDisplay
     } else {
       this.arrowHorizontal.innerHTML = '←\xa0\xa0';
     }
+    this.requestServerUpdate();
   }
 
-  public clearDisplay(webSocketDraw = false) {
+  public clearDisplay() {
     this.onUnload();
     this.onUnload = () => {};
     this.setTitle('');
     this.setPageCurrent(0);
     this.setPageCount(0);
     for (let i = 0; i < 6; i++) {
-      this.setLabel('', i, -1, webSocketDraw);
+      this.setLabel('', i, -1);
     }
     for (let i = 0; i < 6; i++) {
-      this.setLine('', i, -1, webSocketDraw);
+      this.setLine('', i, -1);
     }
     this.onLeftInput = [];
     this.onRightInput = [];
@@ -1568,13 +1567,27 @@ export class A320_Neo_CDU_MainDisplay
   }
 
   /**
-   * Sends an update to the websocket server (if connected) with the current state of the MCDU
+   * Schedules an update to the websocket server with the current state of the MCDU.
+   * Multiple synchronous state changes are combined into one update.
    */
-  public sendUpdate() {
-    // only calculate update when mcduServerClient is established.
-    if (this.mcduServerClient && !this.mcduServerClient.isConnected()) {
+  public requestServerUpdate() {
+    if (
+      this.mcduServerUpdateDebounceTimer.isPending() ||
+      !this.mcduServerClient ||
+      !this.mcduServerClient.isConnected()
+    ) {
       return;
     }
+
+    this.mcduServerUpdateDebounceTimer.schedule(() => this.sendUpdateToMcduServer(), 0);
+  }
+
+  private sendUpdateToMcduServer() {
+    // Only calculate the update when mcduServerClient is established.
+    if (!this.mcduServerClient?.isConnected()) {
+      return;
+    }
+
     let left = this.emptyLines;
     let right = this.emptyLines;
 

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A320_Neo_CDU_MainDisplay.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A320_Neo_CDU_MainDisplay.ts
@@ -1579,10 +1579,10 @@ export class A320_Neo_CDU_MainDisplay
       return;
     }
 
-    this.mcduServerUpdateDebounceTimer.schedule(() => this.sendUpdateToMcduServer(), 0);
+    this.mcduServerUpdateDebounceTimer.schedule(this.sendUpdateToMcduServer, 0);
   }
 
-  private sendUpdateToMcduServer() {
+  private sendUpdateToMcduServer = (): void => {
     // Only calculate the update when mcduServerClient is established.
     if (!this.mcduServerClient?.isConnected()) {
       return;
@@ -1637,7 +1637,7 @@ export class A320_Neo_CDU_MainDisplay
 
     const content = { right, left };
     this.sendToMcduServerClient(`update:${JSON.stringify(content)}`);
-  }
+  };
 
   /**
    * Clears the remote MCDU clients' screens

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A320_Neo_CDU_Scratchpad.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/A320_Neo_CDU_Scratchpad.ts
@@ -8,7 +8,7 @@ import { Keypad } from './A320_Neo_CDU_Keypad';
 export class ScratchpadDisplay {
   public readonly guid = `SP-${Utils.generateGUID()}`;
   constructor(
-    private mcdu: { sendUpdate: () => void },
+    private mcdu: { requestServerUpdate: () => void },
     private scratchpadElement: HTMLElement,
   ) {
     this.mcdu = mcdu;
@@ -19,7 +19,7 @@ export class ScratchpadDisplay {
   write(value = '', color = 'white') {
     this.scratchpadElement.textContent = value;
     this.scratchpadElement.className = color;
-    this.mcdu.sendUpdate();
+    this.mcdu.requestServerUpdate();
   }
 
   setStyle(style: string) {

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/LegacyAidsPageInterface.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/LegacyAidsPageInterface.ts
@@ -1,11 +1,11 @@
-// Copyright (c) 2025 FlyByWire Simulations
+// Copyright (c) 2025-2026 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
 import { LskCallback, LskDelayFunction } from './LegacyFmsPageInterface';
 import { McduMessage } from '../messages/NXSystemMessages';
 
 interface LegacyAidsPageDrawingInterface {
-  clearDisplay(webSocketDraw?: boolean): void;
+  clearDisplay(): void;
   setTemplate(template: any[][], large?: boolean): void;
   getDelaySwitchPage(): number;
   onRightInput: LskCallback[];

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/LegacyAtsuPageInterface.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/LegacyAtsuPageInterface.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 FlyByWire Simulations
+// Copyright (c) 2025-2026 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
 import { FmsClient } from '@atsu/fmsclient';
@@ -11,7 +11,7 @@ import { FlightPlanIndex } from '@fmgc/flightplanning/FlightPlanManager';
 import { ISimbriefData } from '@flybywiresim/fbw-sdk';
 
 interface LegacyAtsuPageDrawingInterface {
-  clearDisplay(webSocketDraw?: boolean): void;
+  clearDisplay(): void;
   setTemplate(template: any[][], large?: boolean): void;
   setTitle(title: string): void;
   setArrows(up: boolean, down: boolean, left: boolean, right: boolean): void;

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/LegacyCfdiuPageInterface.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/LegacyCfdiuPageInterface.ts
@@ -1,10 +1,10 @@
-// Copyright (c) 2025 FlyByWire Simulations
+// Copyright (c) 2025-2026 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
 import { LskCallback, LskDelayFunction } from './LegacyFmsPageInterface';
 
 interface LegacyCfdiuPageDrawingInterface {
-  clearDisplay(webSocketDraw?: boolean): void;
+  clearDisplay(): void;
   setTemplate(template: any[][], large?: boolean): void;
   getDelaySwitchPage(): number;
   onPrevPage: () => void;

--- a/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/LegacyFmsPageInterface.ts
+++ b/fbw-a32nx/src/systems/instruments/src/MCDU/legacy/LegacyFmsPageInterface.ts
@@ -48,7 +48,7 @@ export enum SimbriefOfpState {
 }
 
 interface LegacyFmsPageDrawingInterface {
-  clearDisplay(webSocketDraw?: boolean): void;
+  clearDisplay(): void;
   setTemplate(template: any[][], large?: boolean): void;
   setTitle(title: string): void;
   setArrows(up: boolean, down: boolean, left: boolean, right: boolean): void;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #10881 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Previously, only some CDU mutation operations actually sent an update to the remote server. This meant the order of mcdu.set* calls was critical for the remote server to get the full state. Several pages called setArrows after setTemplate, and the remote server therefore never got the arrows.

Now we schedule a remote server update after the end of the current Update frame whenever any method that mutates the display is called, so the remote server will always get a single complete update any time the screen is mutated during an Update frame.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Load a flight in the A32NX on the runway, with simbridge running. Navigate your web browser to the MCDU interface (http://simbridge.local:8380/interfaces/mcdu/), press FUEL PRED and ensure the left/right scroll arrows are displayed at the top right of the screen. Scroll left/right to INIT A then back to FUEL PRED and ensure the arrows remain displayed.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
