### PR TITLE
fix(a380x/rmp): Fix RMP auto brightness init

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -66,6 +66,7 @@
 1. [Sounds] Fixed boarding complete and welcome onboard announcements playing simultaneously by adding a delay between them - @Ditoo29 (dito29 on Discord) & Saschl
 1. [EFB] Fix rendering issues in pushback page causing display to turn black - @heclak (Heclak)
 1. [EFB] Improve pushback line to be drawn as a constant length - @heclak (Heclak)
+1. [A380X/RMP] Fix RMP brightness initialisation - @CameronCarlyon (YouBaconMeCrazy)
 
 ## 2024.1.0
 

--- a/fbw-a380x/src/systems/extras-host/modules/light_sync/LightSync.ts
+++ b/fbw-a380x/src/systems/extras-host/modules/light_sync/LightSync.ts
@@ -187,10 +187,9 @@ export class LightSync implements Instrument {
 
   /**
    * Gets the automatic brightness level from the sim.
-   * @returns Brightness in the range [0, 1].
+   * @returns Brightness in the range [15, 85], clamped from raw [0, 100] ambient-light reading.
    */
   private getAutoBrightness(): number {
-    /** automatic brightness based on ambient light, [0, 1] scale */
     return Math.max(15, Math.min(85, SimVar.GetSimVarValue('GLASSCOCKPIT AUTOMATIC BRIGHTNESS', 'percent')));
   }
 }

--- a/fbw-a380x/src/systems/extras-host/modules/light_sync/LightSync.ts
+++ b/fbw-a380x/src/systems/extras-host/modules/light_sync/LightSync.ts
@@ -96,9 +96,9 @@ export class LightSync implements Instrument {
 
     // Pedestal
 
-    this.setRmpBrightness(1, autoBrightness * 100); // rmpCptLightLevel
-    this.setRmpBrightness(2, autoBrightness * 100); // rmpFoLightLevel
-    this.setRmpBrightness(3, autoBrightness * 100); // rmpOvhdLightLevel
+    this.setRmpBrightness(1, autoBrightness); // rmpCptLightLevel
+    this.setRmpBrightness(2, autoBrightness); // rmpFoLightLevel
+    this.setRmpBrightness(3, autoBrightness); // rmpOvhdLightLevel
     this.setPotentiometer(92, autoBrightness); // ecamUpperLightLevel
     this.setPotentiometer(93, autoBrightness); // ecamLowerLightLevel
     this.setPotentiometer(76, autoBrightness); // pedFloodLightLevel
@@ -182,7 +182,7 @@ export class LightSync implements Instrument {
    */
   private setRmpBrightness(rmp: 1 | 2 | 3, brightness: number): void {
     // FIXME should use the B events, but not supported in FS2020.
-    SimVar.SetSimVarValue(`L:A380X_RMP_#RMP_ID#_BRIGHTNESS_KNOB`, SimVarValueType.Number, brightness);
+    SimVar.SetSimVarValue(`L:A380X_RMP_${rmp}_BRIGHTNESS_KNOB`, SimVarValueType.Number, brightness);
   }
 
   /**


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #10886

## Summary of Changes
Fixes two bugs in A380X RMP auto-brightness initialisation in `LightSync.ts`:

1. `setRmpBrightness()` wrote to the SimVar name `L:A380X_RMP_#RMP_ID#_BRIGHTNESS_KNOB`. `#RMP_ID#` was a literal, never-substituted placeholder in a JS template string, so the `rmp` parameter was unused and all three RMPs wrote to the same non-existent LVar instead of their real per-unit vars (`L:A380X_RMP_1/2/3_BRIGHTNESS_KNOB`).
2. The brightness value passed was `autoBrightness * 100`. Since `autoBrightness` is already clamped to `[15, 85]` (the same scale every other display uses), this pushed the value to `1500`–`8500`, far outside the valid range.

RMP screen brightness was not following auto-brightness at all, and even if it had reached the correct LVar, the value would have been wildly out of range.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): YouBaconMeCrazy

## Testing instructions
QA testers can check this PR by spawning the A380X at night and observe the RMP follow auto-brightness logic upon lighting initialisation and is within valid range.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
