### PR TITLE
fix(a380x/flight model): A380X flight model fixes

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -97,6 +97,7 @@ Always start an item with "1."; GitHub will number the rendered list automatical
 1. [A380X/FCTL] Add pitch up compensation in flare law - @lukecologne (luke)
 1. [A32NX/EFB] Update A32NX takeoff perf calcs - @donstim (donbikes)
 1. [A380X/FLIGHT MODEL] Fix outer fuel tank transfer rate - @donstim (donbikes)
+1. [A380X/FLIGHT MODEL] Flight model fixes - @donstim (donbikes)
 
 ## 2024.1.0
 

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380X/common/config/flight_model.cfg
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380X/common/config/flight_model.cfg
@@ -611,7 +611,7 @@ elevator_area = 500 ; Elevator area (SQUARE FEET)
 aileron_area = 258 ; Aileron area (SQUARE FEET)
 rudder_area = 416.6 ; Rudder area (SQUARE FEET)
 elevator_up_limit = 30 ; Elevator max deflection up angle (DEGREES)
-elevator_down_limit = 30 ; Elevator max deflection down angle (absolute value) (DEGREES)
+elevator_down_limit = 20 ; Elevator max deflection down angle (absolute value) (DEGREES)
 aileron_up_limit = 30; Aileron max deflection  angle (DEGREES)
 aileron_down_limit = 30; Aileron max deflection down angle (absolute value) (DEGREES)
 rudder_limit = 30; Rudder max deflection angle (absolute value) (DEGREES)
@@ -641,7 +641,7 @@ fly_by_wire = 0 ; Fly-by-wire available true/false
 elevator_elasticity_table = 0:1, 400:1
 aileron_elasticity_table = 0:1, 400:1
 rudder_elasticity_table = 0:1, 400:1
-elevator_trim_elasticity_table = 0:0.80, 40:0.92, 80:0.94, 100:1.0, 400:1.5
+elevator_trim_elasticity_table = 0:0.82, 40:0.82, 80:0.82, 110:1.0, 400:1.5
 
 [AERODYNAMICS]
 lift_coef_flaps = 1.2694 ; Change in lift due to flaps
@@ -749,7 +749,7 @@ cruise_lift_scalar = 1
 parasite_drag_scalar = 1
 induced_drag_scalar = 0.876
 flap_induced_drag_scalar = 0.35
-elevator_effectiveness = 0.70
+elevator_effectiveness = 0.78
 elevator_maxangle_scalar = 0.85
 aileron_effectiveness = 1.8
 rudder_effectiveness = 0.2
@@ -892,11 +892,11 @@ pitch_scalar = 1 ; Scalar coefficient to ponderate global flap pitch coef (non d
 max_on_ground_position = 5 ; Dynamically set in-tool to last flap-position index by defaut when -1 is found
 ;Flap section index number, flap position in degrees, airspeed limit, drag scalar, lift scalar, area scalar, add camber (radians), add aft feet (pos value moves center of lift forward), add incidence - scalar setting proportion of additional lift added at 0 degrees AOA (with 100% at stall AOA)
 flaps-position.0 =  0.00,  -1, 0.00, 0.00,   1.00, 0.00,  0.00, 1.00 ; CONF 0
-flaps-position.1 =  5.00,  -1, 0.05, 0.01,   1.00, 0.00,  0.00, 1.00 ; CONF 1
-flaps-position.2 = 10.00, 222, 0.75, 0.32,   1.00, 0.00,  2.00, 1.00 ; CONF 1+F
-flaps-position.3 = 15.00, 220, 0.82, 0.473,  1.00, 0.005, 3.00, 1.00 ; CONF 2
-flaps-position.4 = 20.00, 196, 0.76, 1.17,   1.02, 0.01,  6.50, 1.00 ; CONF 3
-flaps-position.5 = 32.00, 182, 0.98, 0.9915, 1.02, 0.015, 7.50, 1.00 ; CONF FULL
+flaps-position.1 =  5.00,  -1, 0.050, 0.01,   1.00, 0.00,  0.00, 1.00 ; CONF 1
+flaps-position.2 = 10.00, 222, 0.750, 0.32,   1.00, 0.00,  2.00, 1.00 ; CONF 1+F
+flaps-position.3 = 15.00, 220, 0.820, 0.473,  1.00, 0.005, 2.00, 1.00 ; CONF 2
+flaps-position.4 = 20.00, 196, 1.441, 1.230,  1.02, 0.007, 2.20, 1.00 ; CONF 3
+flaps-position.5 = 32.00, 182, 0.973, 0.9946, 1.02, 0.010, 2.50, 1.00 ; CONF FULL
 
 [FLAPS.2]
 type = 2 ; Flap type 0 = None, 1 = trailing edge, 2 = leading edge
@@ -911,9 +911,9 @@ drag_scalar = 0.5 ; Scalar coefficient to ponderate global flap drag coef (non d
 pitch_scalar = 1 ; Scalar coefficient to ponderate global flap pitch coef (non dimensioned)
 max_on_ground_position = 5 ; Dynamically set in-tool to last flap-position index by defaut when -1 is found.
 ;Flap section index number, flap position in degrees, airspeed limit, drag scalar, lift scalar, area scalar, add camber (radians), add aft feet (pos value moves center of lift forward), add incidence - scalar setting proportion of additional lift added at 0 degrees AOA (with 100% at stall AOA)
-flaps-position.0 =  0.00,  -1, 1.00, 1.00,  1.00, 0.00,  0.00, 0.00 ; CONF 0
-flaps-position.1 = 20.00, 263, 0.10, 0.10,  1.00, 0.006, 0.00, 0.00 ; CONF 1
-flaps-position.2 = 20.01, 222, 0.72, 0.26,  1.00, 0.006, 0.00, 0.00 ; CONF 1+F
-flaps-position.3 = 20.02, 220, 0.76, 0.41,  1.00, 0.006, 0.00, 0.00 ; CONF 2
-flaps-position.4 = 23.00, 196, 0.78, 1.275, 1.00, 0.01,  0.00, 0.00 ; CONF 3
-flaps-position.5 = 23.01, 182, 1.00, 1.005, 1.00, 0.01,  0.00, 0.00 ; CONF FULL
+flaps-position.0 =  0.00,  -1, 1.00, 1.00,  1.00, 0.00 ; CONF 0
+flaps-position.1 = 20.00, 263, 0.10, 0.10,  1.00, 0.006 ; CONF 1
+flaps-position.2 = 20.01, 222, 0.72, 0.29,  1.00, 0.006 ; CONF 1+F
+flaps-position.3 = 20.02, 220, 0.76, 0.43,  1.00, 0.006 ; CONF 2
+flaps-position.4 = 23.00, 196, 1.36, 1.317, 1.00, 0.008 ; CONF 3
+flaps-position.5 = 23.01, 182, 1.00, 1.005, 1.00, 0.008 ; CONF FULL

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380X/common/config/flight_model.cfg
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380X/common/config/flight_model.cfg
@@ -641,7 +641,7 @@ fly_by_wire = 0 ; Fly-by-wire available true/false
 elevator_elasticity_table = 0:1, 400:1
 aileron_elasticity_table = 0:1, 400:1
 rudder_elasticity_table = 0:1, 400:1
-elevator_trim_elasticity_table = 0:0.82, 40:0.82, 80:0.82, 110:1.0, 400:1.5
+elevator_trim_elasticity_table = 0:0.67, 90:0.67, 110:1.0, 130:1.10, 400:1.5
 
 [AERODYNAMICS]
 lift_coef_flaps = 1.2694 ; Change in lift due to flaps
@@ -891,11 +891,11 @@ drag_scalar = 1 ; Scalar coefficient to ponderate global flap drag coef (non dim
 pitch_scalar = 1 ; Scalar coefficient to ponderate global flap pitch coef (non dimensioned)
 max_on_ground_position = 5 ; Dynamically set in-tool to last flap-position index by defaut when -1 is found
 ;Flap section index number, flap position in degrees, airspeed limit, drag scalar, lift scalar, area scalar, add camber (radians), add aft feet (pos value moves center of lift forward), add incidence - scalar setting proportion of additional lift added at 0 degrees AOA (with 100% at stall AOA)
-flaps-position.0 =  0.00,  -1, 0.00, 0.00,   1.00, 0.00,  0.00, 1.00 ; CONF 0
+flaps-position.0 =  0.00,  -1, 0.00,  0.00,   1.00, 0.00,  0.00, 1.00 ; CONF 0
 flaps-position.1 =  5.00,  -1, 0.050, 0.01,   1.00, 0.00,  0.00, 1.00 ; CONF 1
 flaps-position.2 = 10.00, 222, 0.750, 0.32,   1.00, 0.00,  2.00, 1.00 ; CONF 1+F
 flaps-position.3 = 15.00, 220, 0.820, 0.473,  1.00, 0.005, 2.00, 1.00 ; CONF 2
-flaps-position.4 = 20.00, 196, 1.441, 1.230,  1.02, 0.007, 2.20, 1.00 ; CONF 3
+flaps-position.4 = 20.00, 196, 1.394, 1.229,  1.02, 0.007, 0.00, 1.00 ; CONF 3
 flaps-position.5 = 32.00, 182, 0.973, 0.9946, 1.02, 0.010, 2.50, 1.00 ; CONF FULL
 
 [FLAPS.2]
@@ -916,4 +916,4 @@ flaps-position.1 = 20.00, 263, 0.10, 0.10,  1.00, 0.006 ; CONF 1
 flaps-position.2 = 20.01, 222, 0.72, 0.29,  1.00, 0.006 ; CONF 1+F
 flaps-position.3 = 20.02, 220, 0.76, 0.43,  1.00, 0.006 ; CONF 2
 flaps-position.4 = 23.00, 196, 1.36, 1.317, 1.00, 0.008 ; CONF 3
-flaps-position.5 = 23.01, 182, 1.00, 1.005, 1.00, 0.008 ; CONF FULL
+flaps-position.5 = 23.01, 182, 1.00, 1.00,  1.00, 0.008 ; CONF FULL

--- a/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380X/common/config/flight_model.cfg
+++ b/fbw-a380x/src/base/flybywire-aircraft-a380-842/SimObjects/AirPlanes/FlyByWire_A380X/common/config/flight_model.cfg
@@ -17,8 +17,8 @@ minor = 4
 max_gross_weight = 1124355 ; Max takeoff weight, (LBS)
 empty_weight = 661403; Empty weight, (LBS)
 reference_datum_position = 0, 0, 0 ; Position of reference datum relative to FS(0,0,0) (FEET), z, x, y
-empty_weight_CG_position = 16, 0, 2.8 ; Position of airplane empty weight CG relative to reference datum (FEET), z, x, y
-CG_forward_limit = 0.10 ; Gravity center forward limit (longitudinal offset) for longitudinal stability (this value used just to prevent beyond cg limit messages)
+empty_weight_CG_position = 21, 0, 2.8 ; Position of airplane empty weight CG relative to reference datum (FEET), z, x, y
+CG_forward_limit = 0.0 ; Gravity center forward limit (longitudinal offset) for longitudinal stability (this value used just to prevent beyond cg limit messages)
 CG_aft_limit = 0.44 ; Gravity center after limit (longitudinal offset z) w.r.t reference datum for longitudinal stability (FEET)
 empty_weight_pitch_MOI = 60518042 ; Empty pitch moment of inertia, Jxx (SLUG SQ FEET)
 empty_weight_roll_MOI = 53559900 ; Empty roll moment of inertia, Jzz (SLUG SQ FEET)
@@ -641,13 +641,13 @@ fly_by_wire = 0 ; Fly-by-wire available true/false
 elevator_elasticity_table = 0:1, 400:1
 aileron_elasticity_table = 0:1, 400:1
 rudder_elasticity_table = 0:1, 400:1
-elevator_trim_elasticity_table = 0:0.67, 90:0.67, 110:1.0, 130:1.10, 400:1.5
+elevator_trim_elasticity_table = 0:2.5, 70:1.8, 90:0.50, 200:1.1, 400: 1.5
 
 [AERODYNAMICS]
-lift_coef_flaps = 1.2694 ; Change in lift due to flaps
+lift_coef_flaps = 0.607 ; Change in lift due to flaps
 lift_coef_spoilers = -0.546875 ; Change in lift due to spoilers
-drag_coef_zero_lift = 0.0193 ; The zero lift drag coefficient
-drag_coef_flaps = 0.270 ; Change in drag due to flaps
+drag_coef_zero_lift = 0.01988 ; The zero lift drag coefficient
+drag_coef_flaps = 0.154 ; Change in drag due to flaps
 drag_coef_gear = 0.019 ; Change in drag due to landing gear
 drag_coef_spoilers = 0.025;  ; Change in drag due to spoilers
 compute_aero_center = 0
@@ -745,11 +745,11 @@ aileron_load_factor_effectiveness_table = 0:1 ; scaling of roll_moment_delta_ail
 
 modern_fm_only = 1; 1 (true) forces use of modern flight model regardless of what user selected in MSFS options menu. 0 (false) allows use of user-selected flight model
 icing_scalar = 1 ; Scales effect of icing on lift and weight
-cruise_lift_scalar = 1
+cruise_lift_scalar = 1.02
 parasite_drag_scalar = 1
-induced_drag_scalar = 0.876
+induced_drag_scalar = 0.849
 flap_induced_drag_scalar = 0.35
-elevator_effectiveness = 0.78
+elevator_effectiveness = 0.70
 elevator_maxangle_scalar = 0.85
 aileron_effectiveness = 1.8
 rudder_effectiveness = 0.2
@@ -760,7 +760,7 @@ yaw_stability = 1
 pitch_gyro_stability = 4.5
 roll_gyro_stability = 2.5
 yaw_gyro_stability = 1
-elevator_trim_effectiveness = 1.1
+elevator_trim_effectiveness = 1
 aileron_trim_effectiveness = 1
 rudder_trim_effectiveness = 1
 p_factor_on_yaw = 0
@@ -891,12 +891,12 @@ drag_scalar = 1 ; Scalar coefficient to ponderate global flap drag coef (non dim
 pitch_scalar = 1 ; Scalar coefficient to ponderate global flap pitch coef (non dimensioned)
 max_on_ground_position = 5 ; Dynamically set in-tool to last flap-position index by defaut when -1 is found
 ;Flap section index number, flap position in degrees, airspeed limit, drag scalar, lift scalar, area scalar, add camber (radians), add aft feet (pos value moves center of lift forward), add incidence - scalar setting proportion of additional lift added at 0 degrees AOA (with 100% at stall AOA)
-flaps-position.0 =  0.00,  -1, 0.00,  0.00,   1.00, 0.00,  0.00, 1.00 ; CONF 0
-flaps-position.1 =  5.00,  -1, 0.050, 0.01,   1.00, 0.00,  0.00, 1.00 ; CONF 1
-flaps-position.2 = 10.00, 222, 0.750, 0.32,   1.00, 0.00,  2.00, 1.00 ; CONF 1+F
-flaps-position.3 = 15.00, 220, 0.820, 0.473,  1.00, 0.005, 2.00, 1.00 ; CONF 2
-flaps-position.4 = 20.00, 196, 1.394, 1.229,  1.02, 0.007, 0.00, 1.00 ; CONF 3
-flaps-position.5 = 32.00, 182, 0.973, 0.9946, 1.02, 0.010, 2.50, 1.00 ; CONF FULL
+flaps-position.0 =  0.00,  -1, 0.00,  0.00, 1.00, 0.00,  0.00, 1.00 ; CONF 0
+flaps-position.1 =  5.00,  -1, 0.050, 0.01, 1.00, 0.00,  0.00, 1.00 ; CONF 1
+flaps-position.2 = 10.00, 222, 1.30,  0.65, 1.00, 0.00,  2.00, 1.00 ; CONF 1+F
+flaps-position.3 = 15.00, 220, 1.40,  0.99, 1.00, 0.005, 2.00, 1.00 ; CONF 2
+flaps-position.4 = 20.00, 196, 1.17,  1.31, 1.02, 0.00, -1.00, 1.00 ; CONF 3
+flaps-position.5 = 32.00, 182, 1.00,  1.00, 1.02, 0.010, 2.50, 1.00 ; CONF FULL
 
 [FLAPS.2]
 type = 2 ; Flap type 0 = None, 1 = trailing edge, 2 = leading edge
@@ -911,9 +911,9 @@ drag_scalar = 0.5 ; Scalar coefficient to ponderate global flap drag coef (non d
 pitch_scalar = 1 ; Scalar coefficient to ponderate global flap pitch coef (non dimensioned)
 max_on_ground_position = 5 ; Dynamically set in-tool to last flap-position index by defaut when -1 is found.
 ;Flap section index number, flap position in degrees, airspeed limit, drag scalar, lift scalar, area scalar, add camber (radians), add aft feet (pos value moves center of lift forward), add incidence - scalar setting proportion of additional lift added at 0 degrees AOA (with 100% at stall AOA)
-flaps-position.0 =  0.00,  -1, 1.00, 1.00,  1.00, 0.00 ; CONF 0
-flaps-position.1 = 20.00, 263, 0.10, 0.10,  1.00, 0.006 ; CONF 1
-flaps-position.2 = 20.01, 222, 0.72, 0.29,  1.00, 0.006 ; CONF 1+F
-flaps-position.3 = 20.02, 220, 0.76, 0.43,  1.00, 0.006 ; CONF 2
-flaps-position.4 = 23.00, 196, 1.36, 1.317, 1.00, 0.008 ; CONF 3
-flaps-position.5 = 23.01, 182, 1.00, 1.00,  1.00, 0.008 ; CONF FULL
+flaps-position.0 =  0.00,  -1, 1.00, 1.00, 1.00, 0.00 ;  CONF 0
+flaps-position.1 = 20.00, 263, 0.10, 0.10, 1.00, 0.006 ; CONF 1
+flaps-position.2 = 20.01, 222, 1.30, 0.66, 1.00, 0.006 ; CONF 1+F
+flaps-position.3 = 20.02, 220, 1.40, 1.00, 1.00, 0.006 ; CONF 2
+flaps-position.4 = 23.00, 196, 1.17, 1.24, 1.00, 0.00 ;  CONF 3
+flaps-position.5 = 23.01, 182, 1.00, 1.00, 1.00, 0.008 ; CONF FULL


### PR DESCRIPTION
This PR is intended to fix:
1) Inability to reduce pitch angle in a high pitch attitude A.Floor situation in CONF FULL
2) Premature auto nose wheel liftoff (autorotation) in CONF 3
3) Incorrect drag (N1) on approach in CONF 3

This PR supersedes and adds to #10851 

## Summary of Changes
See above.
Changes:
1) MSFS empty weight position was moved farther forward
2) Trim effectiveness was tailored to prevent premature autorotation
3) Re-tuning of lift/drag of the entire flight model as a result of changing the MSFS CGposition

## Cockpit API Changes
<!-- If applicable, list any Var added, removed, renamed, or otherwise changed by this PR. -->
<!-- Ensure the corresponding documentation in `fbw-a32nx/docs` or `fbw-a380x/docs` is updated. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
Moving the MSFS flight model CG further forward provides more down pitch authority to fix issue 1 above and to assist in preventing premature autorotation.  However, pitch effectiveness on the ground is still too high, so the trim effectiveness needed to be reduced to prevent premature autorotation for the conditions that were considered. It may still be possible to get premature autorotation in some conditions that are beyond those considered (light weight with corresponding more forward cg calling for higher takeoff trim settings and heavy weights with correspondingly high VR speeds.

(Note:  The early autorotation is caused in part by the airplane's reaction to the waviness of MSFS 2024 runways. The nosewheel will sometimes leave the surface when the runway surface rises and falls, but the nosewheel will then come back into contact with the runway.)

Although there is an attempt to tailor the trim effectiveness reductions to takeoff speeds, because these speeds are also close to the landing speeds, the trim required at approach speeds from green dot flaps up to VAPP with full flaps are a bithigher than they should be.
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): donbikes

## Testing instructions
Extensive testing needed throughout the flight envelope to: 1) confirm that recovery from high pitch attitudes is possible, including during A.FLOOR events; 2) premature autorotation (defined as autorotation before VR) does not occur; and 3) the airplane has good manual handling from takeoff through landing, including the takeoff rotation and landing flare. (Note: that the takeoff rotation law and other portions of the pitch control laws to allow pitch to be held constant with no stick input are still TBD.)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause new A32NX and A380X artifacts to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, find and click on the **PR Build** tab
1. Click on either **flybywire-aircraft-a320-neo** or **flybywire-aircraft-a380-842** download link at the bottom of the page
